### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-videos.yml
+++ b/.github/workflows/docs-videos.yml
@@ -18,6 +18,9 @@ on:
       - '.claude/scripts/**'
   workflow_dispatch: # Permet de lancer manuellement
 
+permissions:
+  contents: read
+
 env:
   RUST_VERSION: 1.83.0
   NODE_VERSION: 20


### PR DESCRIPTION
Potential fix for [https://github.com/gilmry/koprogo/security/code-scanning/17](https://github.com/gilmry/koprogo/security/code-scanning/17)

To fix the issue, we need to add an explicit `permissions` block that restricts the default permissions for the workflow or for each job that does not currently specify its own permissions. The single best way is to add the following at the top level of the workflow (between `name:` and `env:` or just after `on:`), so that all jobs default to restricted permissions unless they specify otherwise. The minimum safe permissions are usually `contents: read`, which allows the workflow to access repo contents for most tasks but does not allow write access. Jobs that need more (like `deploy-docs`) should set it themselves, which they already do.  
Edit `.github/workflows/docs-videos.yml`, adding:

```yaml
permissions:
  contents: read
```

after the `on:` block and before `env:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
