### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-videos.yml
+++ b/.github/workflows/docs-videos.yml
@@ -26,6 +26,8 @@ jobs:
   build-docs-with-videos:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     services:
       postgres:


### PR DESCRIPTION
Potential fix for [https://github.com/gilmry/koprogo/security/code-scanning/16](https://github.com/gilmry/koprogo/security/code-scanning/16)

To fix the problem, you should add a `permissions` block specifying the minimal required access for the `build-docs-with-videos` job. Since the steps in this job do not appear to require any write permissions to repository contents, but need to allow for artifact upload (which does not require write access to contents), the minimal recommended block is `permissions: contents: read`. This restricts the token to the minimal rights. Place this block under jobs > build-docs-with-videos, before the `steps` block (analogous to how it's set for the `deploy-docs` job). No other code or dependency changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
