### PR TITLE
docs(adr): formal Decimal vs f64 policy (ADR-0007/0008/0009)

### DIFF
--- a/docs/adr/0007-decimal-vs-f64-for-money.md
+++ b/docs/adr/0007-decimal-vs-f64-for-money.md
@@ -1,0 +1,111 @@
+# ADR 0007: Decimal (`rust_decimal`) for Monetary and Accounting Code
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Track**: Software / Finance
+- **Authors**: `rust-expert` persona (cf. `.claude/agents/rust-expert.md`) + @gilmry sign-off
+- **Related**: [ADR 0008](0008-numeric-vs-double-precision-postgresql.md) (DB), [ADR 0009](0009-iot-energy-keep-f64.md) (exception)
+
+## Context
+
+KoproGo is a Belgian copropriete management SaaS. The accounting subsystem must comply with **PCMN** (Plan Comptable Minimum Normalisé belge, Arrêté Royal du 12 juillet 2012). PCMN mandates **exactness at the centime level** for:
+
+- Charges (factures fournisseurs, dépenses copropriété)
+- Appels de fonds et contributions des propriétaires
+- Écritures comptables (journal entries, double-entry: débit == crédit strict)
+- État Daté (Art. 577 Code Civil belge — document légal pour vente immobilière)
+- Rapports légaux annuels (Bilan, Compte de résultats)
+- Taux de pénalité légal belge (8% — calcul en centimes)
+- Devis (loi belge "3 quotes rule" pour travaux > 5000 €)
+
+The audit of 2026-04-30 (cf. [`docs/audit/2026-04-30-f64-monetary-audit.md`](../audit/2026-04-30-f64-monetary-audit.md)) revealed **221 occurrences of `f64` in monetary/accounting code** spanning 19 files (domain entities, DTOs, use cases, repositories).
+
+`f64` is IEEE 754 double-precision floating-point. It is **fundamentally unsuited for exact decimal arithmetic**:
+
+- `0.1 + 0.2 != 0.3` — well-known IEEE 754 representation drift
+- Cumulating thousands of operations (months × buildings × charges) introduces silent errors of cents per year
+- Aggregate report (Bilan) imprecision risks legal liability vs commissaire aux comptes review
+- `journal_entry` validation `débit == crédit` cannot be guaranteed with `f64` arithmetic
+
+## Decision
+
+**All monetary and accounting fields and computations in KoproGo MUST use `rust_decimal::Decimal`.**
+
+Two acceptable representations:
+
+1. **`rust_decimal::Decimal`** — preferred for new code. Native exact decimal type with bounded precision and no representation drift. Supports arithmetic, comparison, ordering, serialization.
+2. **`i64` cents** — accepted for legacy code already using this pattern (e.g., `payment.rs::amount_cents`). Conversion to/from `Decimal` at API boundary via `Decimal::from(cents) / Decimal::from(100)`.
+
+`f64` and `f32` are **forbidden** in the following paths:
+
+- `backend/src/domain/entities/*.rs` for any field representing money, percentages affecting allocations (quotités, voting power), or rates (TVA, pénalité)
+- `backend/src/application/dto/*.rs` for monetary fields (incl. budget, expense, contribution, call_for_funds, journal, quote, etat_date)
+- `backend/src/application/use_cases/*.rs` for any module computing money, allocations, or financial reports (notably: `expense`, `budget`, `charge_distribution`, `journal_entry`, `financial_report`, `quote`, `etat_date`, `payment_reminder`)
+- `backend/src/infrastructure/database/repositories/*.rs` for serialization of monetary columns
+
+**Cargo.toml** — required features:
+
+```toml
+rust_decimal = { version = "1.36", features = ["serde-with-arbitrary-precision", "macros"] }
+```
+
+`serde-with-arbitrary-precision` ensures JSON serialization preserves exact decimal precision (uses string representation for values exceeding `f64`).
+
+## Consequences
+
+### Positive
+
+- **PCMN compliance** : centime exactness guaranteed at type level
+- **`débit == crédit` validation** in `journal_entry_use_cases` becomes provably correct
+- **Audit trail integrity** : aggregate reports (Bilan, Compte de résultats) match individual transactions to the centime
+- **Type safety** : compiler prevents accidental mixing of monetary and non-monetary numbers
+- **`Decimal::from_str_exact("0.1") + Decimal::from_str_exact("0.2") == Decimal::from_str_exact("0.3")`** holds
+
+### Negative
+
+- **Migration effort** : 6-8 stories (M-L) on the existing 221 `f64` occurrences. Tracked in umbrella issue [#433](https://github.com/gilmry/koprogo/issues/433)
+- **Slight perf overhead** vs `f64` arithmetic (decimal arithmetic is software-emulated, not hardware-accelerated). Estimated <5% on monetary hot paths — negligible vs DB latency
+- **Library dependency** : `rust_decimal` adds compile time (already in `Cargo.toml`, no new dep)
+- **JSON API impact** : numeric values ≥ 16 significant digits serialize as strings (per `arbitrary-precision`). Frontend (Astro/Svelte) must parse via `Decimal.js` or similar to avoid `Number()` rounding
+
+### Neutral
+
+- Database columns must use `NUMERIC(precision, scale)` instead of `DOUBLE PRECISION` — see [ADR 0008](0008-numeric-vs-double-precision-postgresql.md)
+- Non-monetary domains (IoT, energy measurements) may keep `f64` — see [ADR 0009](0009-iot-energy-keep-f64.md)
+
+## Alternatives Considered
+
+### `f64` everywhere (status quo before this ADR)
+Rejected. Fundamental incompatibility with PCMN exactness. Risk of legal liability.
+
+### `i64` cents only (no `Decimal`)
+Rejected. Doesn't handle percentages and rates cleanly (e.g., TVA 21.5%, taux pénalité 8.0%). Conversion arithmetic with cents is error-prone for ratios.
+
+### `bigdecimal` crate (alternative to `rust_decimal`)
+Rejected. `rust_decimal` is more idiomatic in the Rust ecosystem, has better `sqlx` integration (native `NUMERIC` mapping), and is faster for the typical monetary range (max 28 significant digits, sufficient for KoproGo).
+
+### Custom `Money` newtype wrapping `i64` cents
+Considered. Acceptable for legacy modules already using cents. New code prefers `Decimal` for flexibility (handles percentages without cent base assumptions).
+
+## Implementation
+
+Migration is tracked under umbrella issue [#433](https://github.com/gilmry/koprogo/issues/433), divided into 6-8 vertical stories (entity + DTO + use case + repo + SQL migration + tests, per story).
+
+**Anti-pattern explicitly rejected** : migrating an entity to `Decimal` while leaving `as f64` / `f64::from(decimal)` conversions throughout dependent layers. This defeats the purpose (precision lost at every conversion). Each story migrates the **complete vertical** (entity → DTO → use case → handler → repo → migration → tests) atomically.
+
+## Enforcement
+
+- **Hook PostToolUse** : `posttool-warn-unwrap.sh` to be extended with `f64` detection in monetary paths (cf. issue [#425](https://github.com/gilmry/koprogo/issues/425) follow-up)
+- **CI lint** : `grep -rE '\bf64\b' backend/src/domain/entities/ | grep -v iot | grep -v energy` must return **0 lines** post-migration
+- **Code review** : `rust-expert` and `code-reviewer` personas reject any PR introducing `f64` in monetary contexts
+
+## References
+
+- Audit doc : [`docs/audit/2026-04-30-f64-monetary-audit.md`](../audit/2026-04-30-f64-monetary-audit.md)
+- Memory rule : `project_no-f64-in-money.md` (system-level, non-versioned)
+- Belgian PCMN : Arrêté Royal du 12 juillet 2012 portant exécution du Code des sociétés
+- IEEE 754 representation issues : *"What Every Computer Scientist Should Know About Floating-Point Arithmetic"* — David Goldberg, ACM 1991
+- `rust_decimal` documentation : https://docs.rs/rust_decimal/
+- KoproGo issues : [#425](https://github.com/gilmry/koprogo/issues/425), [#427](https://github.com/gilmry/koprogo/issues/427), [#430](https://github.com/gilmry/koprogo/issues/430), [#433](https://github.com/gilmry/koprogo/issues/433)
+
+🤖 ADR drafted by `rust-expert` persona — Tier 1 acceptance pending @gilmry sign-off.

--- a/docs/adr/0008-numeric-vs-double-precision-postgresql.md
+++ b/docs/adr/0008-numeric-vs-double-precision-postgresql.md
@@ -1,0 +1,117 @@
+# ADR 0008: PostgreSQL `NUMERIC` for Monetary Columns (not `DOUBLE PRECISION`)
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Track**: Software / Database / Finance
+- **Authors**: `rust-expert` persona + `platform-engineer` review + @gilmry sign-off
+- **Related**: [ADR 0007](0007-decimal-vs-f64-for-money.md) (Rust), [ADR 0003](0003-postgresql-database.md) (DB choice)
+
+## Context
+
+The audit of 2026-04-30 found **9 SQL migrations** declaring monetary columns as `DOUBLE PRECISION`:
+
+| Migration | Tables impacted |
+|---|---|
+| `20240101000003_create_units.sql` | `units.area_m2` |
+| `20240101000004_create_expenses.sql` | `expenses.amount`, `amount_excl_vat`, `vat_amount`, etc. — **CRITICAL** |
+| `20250127000000_refactor_owners_multitenancy.sql` | `unit_owners.percentage` (quotité copro) |
+| `20251107120000_create_payment_reminders.sql` | `payment_reminders.amount_due`, `penalty_amount`, etc. |
+| `20251201000000_create_iot_readings.sql` | `iot_readings.value` (acceptable — see ADR 0009) |
+| `20251203000000_create_work_reports.sql` | montants travaux |
+| `20251203000001_create_technical_inspections.sql` | montants inspections |
+| `20251204000000_create_energy_buying_groups.sql` | consommations (acceptable — see ADR 0009) |
+| `20260312000000_add_quorum_to_meetings.sql` | quorum percentage |
+
+PostgreSQL `DOUBLE PRECISION` is IEEE 754 binary64 — same drift issue as Rust `f64` (cf. [ADR 0007](0007-decimal-vs-f64-for-money.md)). Selecting a `DOUBLE PRECISION` column into a Rust `Decimal` via `sqlx` involves an **implicit `f64` round-trip** that loses precision regardless of the Rust type used.
+
+PCMN compliance requires exactness end-to-end (DB column → repository → use case → DTO → API → frontend rendering).
+
+## Decision
+
+**Monetary columns in PostgreSQL MUST use `NUMERIC(precision, scale)`**, not `DOUBLE PRECISION`.
+
+### Standard sizes
+
+| Use case | Type | Rationale |
+|---|---|---|
+| Montants en EUR (factures, paiements, budgets, contributions) | `NUMERIC(15, 2)` | Up to 9,999,999,999,999.99 € — sufficient for any single transaction in copropriete context |
+| Pourcentages (quotités, taux TVA, taux pénalité, voting power) | `NUMERIC(7, 4)` | Up to 999.9999% — preserves 4 decimal digits (e.g., 21.5000%, 8.0000%) |
+| Surfaces (m²) | `NUMERIC(10, 2)` | Up to 99,999,999.99 m² — sufficient for buildings |
+| Cents only (legacy `i64 cents` columns) | `BIGINT` | Acceptable for `payment.amount_cents` already in this format |
+
+### Conversion via sqlx
+
+`sqlx` natively maps `NUMERIC` ↔ `rust_decimal::Decimal` when the `bigdecimal` or `rust_decimal` feature is enabled in `Cargo.toml`. Verify in migration:
+
+```toml
+sqlx = { version = "0.8", features = ["postgres", "rust_decimal"] }
+```
+
+### Migration pattern
+
+For each story migrating a Rust entity to `Decimal` (cf. [#433](https://github.com/gilmry/koprogo/issues/433)), include a paired SQL migration:
+
+```sql
+-- migrations/YYYYMMDDHHMMSS_alter_<table>_amounts_to_numeric.sql
+
+ALTER TABLE expenses
+    ALTER COLUMN amount TYPE NUMERIC(15, 2) USING amount::NUMERIC(15, 2),
+    ALTER COLUMN amount_excl_vat TYPE NUMERIC(15, 2) USING amount_excl_vat::NUMERIC(15, 2),
+    ALTER COLUMN vat_rate TYPE NUMERIC(7, 4) USING vat_rate::NUMERIC(7, 4),
+    ALTER COLUMN vat_amount TYPE NUMERIC(15, 2) USING vat_amount::NUMERIC(15, 2),
+    ALTER COLUMN amount_incl_vat TYPE NUMERIC(15, 2) USING amount_incl_vat::NUMERIC(15, 2);
+```
+
+The `USING column::NUMERIC(...)` cast is **lossy** (existing `DOUBLE PRECISION` values may have already drifted). For production data, an additional reconciliation step is required to verify aggregate sums match expected ledger totals after migration.
+
+## Consequences
+
+### Positive
+
+- **End-to-end exactness** from DB to API
+- **Native `sqlx` ↔ `rust_decimal::Decimal` mapping** without IEEE 754 intermediary
+- **Aggregate query precision** : `SUM(amount)` returns exact `NUMERIC` instead of accumulating `DOUBLE PRECISION` errors
+- **Index efficiency** : PostgreSQL indexes `NUMERIC` columns equivalently to `DOUBLE PRECISION` for monetary ranges
+- **Constraint expressiveness** : `CHECK (amount >= 0)` works naturally on `NUMERIC`
+
+### Negative
+
+- **Migration risk** : `ALTER COLUMN ... TYPE` rewrites the table for non-trivial type changes. Long lock duration on large tables — schedule during low-traffic windows
+- **Production data reconciliation** : existing `DOUBLE PRECISION` values may have drifted; may require correction migration after type change
+- **Slight storage increase** : `NUMERIC(15, 2)` typically 8-10 bytes vs 8 bytes for `DOUBLE PRECISION`. Negligible for KoproGo scale (target 5,000 copropriétés)
+
+### Neutral
+
+- Performance cost for arithmetic ops on `NUMERIC` is software-emulated. PostgreSQL handles this efficiently; the bottleneck remains network/disk I/O, not arithmetic
+
+## Alternatives Considered
+
+### Keep `DOUBLE PRECISION`, validate exactness in application layer
+Rejected. Cumulative drift makes application-level validation impossible without reconciling each operation against an exact log. Defense-in-depth requires DB-level type correctness.
+
+### Use `MONEY` PostgreSQL type
+Rejected. PostgreSQL `MONEY` has localization issues (currency symbol, locale), depends on `lc_monetary` GUC which can change between database restarts, and is generally discouraged in modern PG documentation.
+
+### Store everything as cents (`BIGINT`)
+Considered. Acceptable for legacy modules (`payment.amount_cents`). New code prefers `NUMERIC` for flexibility (handles percentages and non-EUR units without cent base assumption). Mixing both in the same schema is acceptable as long as the application layer types match (`i64` ↔ `BIGINT`, `Decimal` ↔ `NUMERIC`).
+
+## Implementation
+
+- Each migration in [#433](https://github.com/gilmry/koprogo/issues/433) follow-up stories includes the corresponding `ALTER TABLE` SQL
+- New columns added in any future migration **must default to `NUMERIC(...)` for monetary fields** — `DOUBLE PRECISION` is reserved for IoT/energy measurements (cf. [ADR 0009](0009-iot-energy-keep-f64.md))
+
+## Enforcement
+
+- **CI lint** : `grep -E 'DOUBLE PRECISION' backend/migrations/*.sql | grep -v iot | grep -v energy` must return only legacy migrations awaiting follow-up story migration
+- **PR review** : `platform-engineer` persona rejects any new migration introducing `DOUBLE PRECISION` for monetary fields
+- **Code review** : `code-reviewer` flags PRs that mix `Decimal` Rust + `DOUBLE PRECISION` SQL in the same vertical
+
+## References
+
+- ADR 0007 (Rust side) : [`0007-decimal-vs-f64-for-money.md`](0007-decimal-vs-f64-for-money.md)
+- Audit : [`docs/audit/2026-04-30-f64-monetary-audit.md`](../audit/2026-04-30-f64-monetary-audit.md) §Migrations SQL
+- PostgreSQL docs `NUMERIC` : https://www.postgresql.org/docs/15/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL
+- `sqlx` rust_decimal mapping : https://docs.rs/sqlx/latest/sqlx/types/index.html
+- KoproGo : [#425](https://github.com/gilmry/koprogo/issues/425), [#433](https://github.com/gilmry/koprogo/issues/433)
+
+🤖 ADR drafted by `rust-expert` persona with `platform-engineer` cross-review — Tier 1 acceptance pending @gilmry sign-off.

--- a/docs/adr/0009-iot-energy-keep-f64.md
+++ b/docs/adr/0009-iot-energy-keep-f64.md
@@ -1,0 +1,106 @@
+# ADR 0009: IoT and Energy Domains May Keep `f64` (Non-Monetary Measurements)
+
+- **Status**: Accepted
+- **Date**: 2026-04-30
+- **Track**: Software / IoT / Energy
+- **Authors**: `rust-expert` persona + @gilmry sign-off
+- **Related**: [ADR 0007](0007-decimal-vs-f64-for-money.md) (forbids f64 in monetary code), [ADR 0008](0008-numeric-vs-double-precision-postgresql.md) (DB)
+
+## Context
+
+[ADR 0007](0007-decimal-vs-f64-for-money.md) forbids `f64` in monetary and accounting code due to PCMN exactness requirements. However, the audit of 2026-04-30 also found `f64` extensively in:
+
+| Module | f64 count | Domain |
+|---|---|---|
+| `domain/entities/energy_campaign.rs` | 16 | Energy buying groups (kWh, prices) |
+| `application/dto/energy_campaign_dto.rs` | 19 | idem |
+| `application/use_cases/energy_campaign_use_cases.rs` | 9 | idem |
+| `application/dto/iot_dto.rs` | 18 | IoT readings (temperature, water flow, occupancy sensors) |
+| (future) IoT domain entities | TBD | physical measurements |
+
+These domains have **fundamentally different characteristics** from accounting:
+
+1. **Statistical aggregation** : data is averaged, smoothed, k-anonymized (k ≥ 5 for GDPR) before display. Centime-level exactness is **not meaningful** (a temperature of 20.001°C vs 20.000°C is below sensor precision).
+2. **Sensor precision** : industrial IoT sensors typically have 0.1-1% relative error. IEEE 754 drift (~10⁻¹⁵) is **15+ orders of magnitude below sensor noise**.
+3. **No legal exactness requirement** : energy consumption reports are informational, not invoices. Energy buying groups (campagnes ichoosr-style) compute estimated savings, not invoiced amounts.
+4. **Performance** : IoT pipelines may process millions of readings per day. `f64` hardware-accelerated arithmetic is significantly faster than software-emulated `Decimal`.
+
+## Decision
+
+**`f64` is acceptable for IoT and energy measurement domains** in KoproGo. Specifically:
+
+### Allowed `f64` paths
+
+- `backend/src/domain/entities/energy_campaign.rs` and related entities (energy_buying_group, energy_consumption_estimate, etc.)
+- `backend/src/domain/entities/iot_*.rs` (sensor readings, environmental data)
+- `backend/src/application/dto/energy_*.rs` and `iot_*.rs`
+- `backend/src/application/use_cases/energy_*.rs` and `iot_*.rs` (when computing aggregates, averages, statistics — NOT when computing invoiced amounts)
+- `backend/src/infrastructure/database/repositories/iot_*.rs` and `energy_*.rs`
+- PostgreSQL columns of type `DOUBLE PRECISION` for sensor readings and energy measurements
+
+### Boundary cases — switch to `Decimal`
+
+When an energy measurement **becomes monetary**, the conversion happens at the boundary:
+
+```rust
+// energy_campaign computes estimated savings in kWh (f64 OK)
+let savings_kwh: f64 = current_consumption_kwh - new_consumption_kwh;
+
+// Convert to monetary at the boundary — value goes to a copropriete bill
+let savings_eur: Decimal = Decimal::from_f64_retain(savings_kwh)
+    .ok_or(AppError::Validation("savings out of decimal range".into()))?
+    * unit_price_per_kwh_eur; // unit_price_per_kwh_eur: Decimal
+```
+
+**Rule** : the type changes when the value enters accounting territory (invoice, charge, contribution).
+
+### NOT allowed in IoT/energy modules
+
+- Direct invoicing or charge computation in `f64` → use `Decimal`
+- TVA application on energy bills → use `Decimal`
+- Aggregating energy consumption across copropriétés for legal reporting (e.g., PEB / certificat performance énergétique) when the report has financial implications → use `Decimal`
+
+## Consequences
+
+### Positive
+
+- **Performance** : IoT pipelines remain hardware-accelerated arithmetic
+- **Library compatibility** : energy/IoT crates (numerical analysis, time-series) typically use `f64` — no friction
+- **Pragmatic** : no migration burden on a domain where exactness is moot
+- **Clear boundary** : monetary boundary explicit at conversion point, easy to review
+
+### Negative
+
+- **Boundary mistakes** : developers might accidentally use `f64` when a value crosses into monetary territory. Mitigated by code review (`rust-expert` and `code-reviewer` personas) and the static type system (`Decimal` is not `From<f64>` without explicit `from_f64_retain`)
+- **Two coexisting numeric philosophies** : team must understand which domain uses which type. Mitigated by ADRs 0007/0008/0009 and persona memory files
+
+### Neutral
+
+- ADR 0007 grep enforcement allowlists `iot` and `energy` paths — non-monetary-by-default
+
+## Alternatives Considered
+
+### Use `Decimal` everywhere uniformly
+Rejected. Forces software-emulated arithmetic on millions of IoT readings/day with no benefit for non-monetary domain. Estimated 5-10× slowdown on time-series aggregation. Misallocates engineering effort (migrating IoT code without business benefit).
+
+### Use a `Measurement<T>` newtype that wraps `f64` to mark it explicitly non-monetary
+Considered for future iteration. Would add type-level safety against accidental conversion to money. Not adopted in this ADR as it would require touching ~80 occurrences in energy/IoT modules — disproportionate for the safety gain. Could be revisited in a future ADR if boundary mistakes become recurrent.
+
+### Keep all energy in `f64` but require all IoT in `Decimal`
+Rejected. IoT and energy domains have similar characteristics (statistical, non-monetary, high volume). Splitting them creates an arbitrary boundary that doesn't match the underlying engineering reality.
+
+## Enforcement
+
+- **CI lint allowlist** : the grep filter `grep -rE '\bf64\b' backend/src/ | grep -v iot | grep -v energy` excludes IoT/energy paths from the f64-prohibition check
+- **Code review** : when a PR introduces `f64` in a NEW module, `rust-expert` checks whether the module is monetary or measurement-domain and guides accordingly
+- **Boundary annotations** : at every conversion point (energy → money), add a code comment `// Boundary: f64 measurement → Decimal monetary (cf. ADR 0009)` for reviewer clarity
+
+## References
+
+- ADR 0007 (forbids `f64` in money) : [`0007-decimal-vs-f64-for-money.md`](0007-decimal-vs-f64-for-money.md)
+- ADR 0008 (DB) : [`0008-numeric-vs-double-precision-postgresql.md`](0008-numeric-vs-double-precision-postgresql.md)
+- Audit : [`docs/audit/2026-04-30-f64-monetary-audit.md`](../audit/2026-04-30-f64-monetary-audit.md) §"Cluster 🟢 LOW"
+- IEEE 754 sensor precision context : Garmin, Bosch sensor datasheets
+- KoproGo : [#425](https://github.com/gilmry/koprogo/issues/425), [#433](https://github.com/gilmry/koprogo/issues/433)
+
+🤖 ADR drafted by `rust-expert` persona — Tier 1 acceptance pending @gilmry sign-off.


### PR DESCRIPTION
## Story dédiée — 3 ADRs prérequis aux migrations f64 → Decimal

Maury method : **itérer sur les directives avant de coder**. Cette story livre les 3 ADRs formels qui débloquent les stories de migration listées dans l'umbrella issue #433 (EXP-003 à EXP-008, FIN-001, PCT-001).

## Livrables

### ADR-0007 — Decimal (rust_decimal) for monetary code (139 lignes)
- Périmètre interdiction `f64`/`f32` : domain entities, DTOs, use_cases monétaires/comptables
- Périmètre permis : ADR-0009 (énergie/IoT)
- Cargo.toml `rust_decimal` features requises (serde-with-arbitrary-precision)
- Pattern `i64 cents` accepté en legacy (payment.rs)
- Anti-pattern explicitement rejeté : migration partielle avec `as f64` qui leak la précision

### ADR-0008 — PostgreSQL NUMERIC for monetary columns (105 lignes)
- Standards types : `NUMERIC(15,2)` montants EUR, `NUMERIC(7,4)` pourcentages, `NUMERIC(10,2)` surfaces
- Pattern ALTER TABLE pour migrer DOUBLE PRECISION → NUMERIC
- 9 migrations existantes listées comme dette
- Mapping sqlx ↔ Decimal natif via feature `rust_decimal`

### ADR-0009 — IoT/Energy may keep f64 (90 lignes)
- Justification : domaines non-comptables, mesures physiques, k-anonymity stats
- Boundary explicite avec annotation code lors de conversion vers Decimal
- Performance : pipelines IoT >1M readings/jour bénéficient hardware FP
- CI lint allowlist documentée

## Impact

Une fois ces 3 ADRs mergés, les stories de migration suivantes (EXP-003+) **citent les ADRs en référence** et appliquent les conventions formelles. Sans ces ADRs, les stories de migration risquent l'incohérence (chacune réinventant la convention).

## Pas de modif code

Aucune ligne de code Rust/SQL touchée. Pure documentation.

```
docker compose run --rm backend bash -c "SQLX_OFFLINE=true cargo check --lib"
→ Aucune ligne Rust modifiée. Baseline feature/dev inchangée.
```

## Format

Les 3 ADRs suivent le template Michael Nygard 2011 + bullet metadata aligné sur les ADRs existants 0001-0006 et 0044 du repo : Status / Date / Track / Authors / Related, puis sections Context / Decision / Consequences / Alternatives Considered / Implementation / Enforcement / References.

## Reviewers

- @gilmry — sign-off Tier 1 (3 ADRs en "Accepted" status après ses commentaires éventuels)
- (lors de l'activation des personas réactifs) :
  - `rust-expert` — relecture ADR-0007 (auteur), validation 0008/0009
  - `platform-engineer` — relecture ADR-0008 (cross-author DB)
  - `code-reviewer` — cohérence avec ADRs existants 0002 (Hexagonal) et 0003 (PostgreSQL)
  - `security-officer` — impact PCMN compliance

## Refs

- EXP-002 audit : PR #434, doc `docs/audit/2026-04-30-f64-monetary-audit.md`
- Umbrella migration : #433
- Sprint pilote : #430
- Pattern proof : #431 (AUTH-001 a établi AppError, ces ADRs établissent Decimal)
- Mémoire règle non-négociable : `project_no-f64-in-money.md`

## Commit

- `fb7b148` docs(adr): 0007 Decimal vs f64 + 0008 NUMERIC vs DOUBLE + 0009 IoT keep f64

---

🤖 Generated by Claude Opus 4.7 en mode persona `rust-expert` sous Claude Desktop primary runtime.