### PR TITLE
WIP feat(expense): partial Decimal migration (EXP-003) — cascade detected

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 # Database
 sqlx = { version = "0.8.6", features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono", "migrate", "rust_decimal"] }
 rust_decimal = "1.36"
+rust_decimal_macros = "1.36"
 
 # Configuration
 dotenvy = "0.15"

--- a/backend/src/application/dto/expense_dto.rs
+++ b/backend/src/application/dto/expense_dto.rs
@@ -1,4 +1,12 @@
+//! Expense DTOs — monetary fields use `rust_decimal::Decimal` (cf. ADR-0007).
+//!
+//! Note : `validator` crate `#[validate(range(...))]` ne support pas Decimal
+//! avec literals de type f64. Les invariants montants (> 0, taux VAT 0-100)
+//! sont enforced dans `Expense::new` / `Expense::new_with_vat` côté domaine
+//! (cf. `domain/entities/expense.rs`).
+
 use crate::domain::entities::{ApprovalStatus, ExpenseCategory, PaymentStatus};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -14,8 +22,8 @@ pub struct CreateExpenseDto {
     #[validate(length(min = 1))]
     pub description: String,
 
-    #[validate(range(min = 0.01))]
-    pub amount: f64,
+    /// Montant TTC (validé > 0 dans Expense::new). Decimal exact (cf. ADR-0007).
+    pub amount: Decimal,
 
     pub expense_date: String,
     pub supplier: Option<String>,
@@ -33,7 +41,7 @@ pub struct ExpenseResponseDto {
     pub building_id: String,
     pub category: ExpenseCategory,
     pub description: String,
-    pub amount: f64,
+    pub amount: Decimal,
     pub expense_date: String,
     pub payment_status: PaymentStatus,
     pub approval_status: ApprovalStatus,
@@ -47,7 +55,8 @@ pub struct ExpenseResponseDto {
 
 // ========== New Invoice DTOs (with VAT & Workflow) ==========
 
-/// Créer une facture brouillon avec gestion TVA
+/// Créer une facture brouillon avec gestion TVA.
+/// Validation des montants > 0 et taux 0-100 effectuée dans `Expense::new_with_vat`.
 #[derive(Debug, Deserialize, Validate, Clone)]
 pub struct CreateInvoiceDraftDto {
     #[serde(default)]
@@ -58,11 +67,11 @@ pub struct CreateInvoiceDraftDto {
     #[validate(length(min = 1))]
     pub description: String,
 
-    #[validate(range(min = 0.01))]
-    pub amount_excl_vat: f64, // Montant HT
+    /// Montant HT (validé > 0 dans `Expense::new_with_vat`).
+    pub amount_excl_vat: Decimal,
 
-    #[validate(range(min = 0.0, max = 100.0))]
-    pub vat_rate: f64, // Taux TVA (21.0 pour 21%)
+    /// Taux TVA en % (validé 0..=100 dans `Expense::new_with_vat`).
+    pub vat_rate: Decimal,
 
     pub invoice_date: String,     // ISO 8601
     pub due_date: Option<String>, // ISO 8601
@@ -70,7 +79,7 @@ pub struct CreateInvoiceDraftDto {
     pub invoice_number: Option<String>,
 }
 
-/// Modifier une facture brouillon ou rejetée
+/// Modifier une facture brouillon ou rejetée.
 #[derive(Debug, Deserialize, Validate, Clone)]
 pub struct UpdateInvoiceDraftDto {
     #[validate(length(min = 1))]
@@ -78,11 +87,8 @@ pub struct UpdateInvoiceDraftDto {
 
     pub category: Option<ExpenseCategory>,
 
-    #[validate(range(min = 0.01))]
-    pub amount_excl_vat: Option<f64>,
-
-    #[validate(range(min = 0.0, max = 100.0))]
-    pub vat_rate: Option<f64>,
+    pub amount_excl_vat: Option<Decimal>,
+    pub vat_rate: Option<Decimal>,
 
     pub invoice_date: Option<String>,
     pub due_date: Option<String>,
@@ -90,19 +96,19 @@ pub struct UpdateInvoiceDraftDto {
     pub invoice_number: Option<String>,
 }
 
-/// Soumettre une facture pour validation (Draft → PendingApproval)
+/// Soumettre une facture pour validation (Draft → PendingApproval).
 #[derive(Debug, Deserialize, Clone)]
 pub struct SubmitForApprovalDto {
     // Empty body, action via PUT /invoices/:id/submit
 }
 
-/// Approuver une facture (PendingApproval → Approved)
+/// Approuver une facture (PendingApproval → Approved).
 #[derive(Debug, Deserialize, Clone)]
 pub struct ApproveInvoiceDto {
     pub approved_by_user_id: String, // User ID du syndic/admin
 }
 
-/// Rejeter une facture avec raison (PendingApproval → Rejected)
+/// Rejeter une facture avec raison (PendingApproval → Rejected).
 #[derive(Debug, Deserialize, Validate, Clone)]
 pub struct RejectInvoiceDto {
     pub rejected_by_user_id: String,
@@ -111,7 +117,8 @@ pub struct RejectInvoiceDto {
     pub rejection_reason: String,
 }
 
-/// Créer une ligne de facture
+/// Créer une ligne de facture.
+/// Validations (quantity > 0, unit_price ≥ 0, vat_rate 0..=100) dans `InvoiceLineItem::new`.
 #[derive(Debug, Deserialize, Validate, Clone)]
 pub struct CreateInvoiceLineItemDto {
     pub expense_id: String,
@@ -119,19 +126,14 @@ pub struct CreateInvoiceLineItemDto {
     #[validate(length(min = 1))]
     pub description: String,
 
-    #[validate(range(min = 0.01))]
-    pub quantity: f64,
-
-    #[validate(range(min = 0.0))]
-    pub unit_price: f64,
-
-    #[validate(range(min = 0.0, max = 100.0))]
-    pub vat_rate: f64,
+    pub quantity: Decimal,
+    pub unit_price: Decimal,
+    pub vat_rate: Decimal,
 }
 
 // ========== Response DTOs ==========
 
-/// Response enrichie avec tous les champs invoice/workflow
+/// Response enrichie avec tous les champs invoice/workflow.
 #[derive(Debug, Serialize, Clone)]
 pub struct InvoiceResponseDto {
     pub id: String,
@@ -140,12 +142,12 @@ pub struct InvoiceResponseDto {
     pub category: ExpenseCategory,
     pub description: String,
 
-    // Montants
-    pub amount: f64, // TTC (backward compatibility)
-    pub amount_excl_vat: Option<f64>,
-    pub vat_rate: Option<f64>,
-    pub vat_amount: Option<f64>,
-    pub amount_incl_vat: Option<f64>,
+    // Montants — exact decimal (cf. ADR-0007)
+    pub amount: Decimal, // TTC (backward compatibility)
+    pub amount_excl_vat: Option<Decimal>,
+    pub vat_rate: Option<Decimal>,
+    pub vat_amount: Option<Decimal>,
+    pub amount_incl_vat: Option<Decimal>,
 
     // Dates
     pub expense_date: String,
@@ -172,34 +174,35 @@ pub struct InvoiceResponseDto {
     pub updated_at: String,
 }
 
-/// Response pour une ligne de facture
+/// Response pour une ligne de facture.
 #[derive(Debug, Serialize)]
 pub struct InvoiceLineItemResponseDto {
     pub id: String,
     pub expense_id: String,
     pub description: String,
-    pub quantity: f64,
-    pub unit_price: f64,
-    pub amount_excl_vat: f64,
-    pub vat_rate: f64,
-    pub vat_amount: f64,
-    pub amount_incl_vat: f64,
+    pub quantity: Decimal,
+    pub unit_price: Decimal,
+    pub amount_excl_vat: Decimal,
+    pub vat_rate: Decimal,
+    pub vat_amount: Decimal,
+    pub amount_incl_vat: Decimal,
     pub created_at: String,
 }
 
-/// Response pour une répartition de charge
+/// Response pour une répartition de charge.
 #[derive(Debug, Serialize)]
 pub struct ChargeDistributionResponseDto {
     pub id: String,
     pub expense_id: String,
     pub unit_id: String,
     pub owner_id: String,
-    pub quota_percentage: f64, // Sera converti en pourcentage côté client (0.25 → 25%)
-    pub amount_due: f64,
+    /// Quote-part (e.g., dec!(0.25) pour 25%). Decimal exact (cf. ADR-0007).
+    pub quota_percentage: Decimal,
+    pub amount_due: Decimal,
     pub created_at: String,
 }
 
-/// Liste des factures en attente d'approbation (pour syndics)
+/// Liste des factures en attente d'approbation (pour syndics).
 #[derive(Debug, Serialize)]
 pub struct PendingInvoicesListDto {
     pub invoices: Vec<InvoiceResponseDto>,

--- a/backend/src/domain/entities/expense.rs
+++ b/backend/src/domain/entities/expense.rs
@@ -1,4 +1,10 @@
+//! Expense entity — monetary fields use `rust_decimal::Decimal` (cf. ADR-0007).
+//!
+//! Migration story EXP-003. PCMN belge exactness (Arrêté Royal du 12 juillet 2012).
+
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -47,12 +53,12 @@ pub struct Expense {
     pub category: ExpenseCategory,
     pub description: String,
 
-    // Montants et TVA
-    pub amount: f64,                  // Montant TTC (backward compatibility)
-    pub amount_excl_vat: Option<f64>, // Montant HT
-    pub vat_rate: Option<f64>,        // Taux TVA (ex: 21.0 pour 21%)
-    pub vat_amount: Option<f64>,      // Montant TVA
-    pub amount_incl_vat: Option<f64>, // Montant TTC (explicite)
+    // Montants et TVA — exact decimal arithmetic (no IEEE 754 drift)
+    pub amount: Decimal,                  // Montant TTC (backward compatibility)
+    pub amount_excl_vat: Option<Decimal>, // Montant HT
+    pub vat_rate: Option<Decimal>,        // Taux TVA (ex: 21.0 pour 21%)
+    pub vat_amount: Option<Decimal>,      // Montant TVA
+    pub amount_incl_vat: Option<Decimal>, // Montant TTC (explicite)
 
     // Dates multiples
     pub expense_date: DateTime<Utc>, // Date originale (backward compatibility)
@@ -88,7 +94,7 @@ impl Expense {
         building_id: Uuid,
         category: ExpenseCategory,
         description: String,
-        amount: f64,
+        amount: Decimal,
         expense_date: DateTime<Utc>,
         supplier: Option<String>,
         invoice_number: Option<String>,
@@ -97,7 +103,7 @@ impl Expense {
         if description.is_empty() {
             return Err("Description cannot be empty".to_string());
         }
-        if amount <= 0.0 {
+        if amount <= Decimal::ZERO {
             return Err("Amount must be greater than 0".to_string());
         }
 
@@ -143,15 +149,15 @@ impl Expense {
         })
     }
 
-    /// Crée une facture avec gestion complète de la TVA
+    /// Crée une facture avec gestion complète de la TVA (exact decimal arithmetic).
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_vat(
         organization_id: Uuid,
         building_id: Uuid,
         category: ExpenseCategory,
         description: String,
-        amount_excl_vat: f64,
-        vat_rate: f64,
+        amount_excl_vat: Decimal,
+        vat_rate: Decimal,
         invoice_date: DateTime<Utc>,
         due_date: Option<DateTime<Utc>>,
         supplier: Option<String>,
@@ -161,15 +167,15 @@ impl Expense {
         if description.is_empty() {
             return Err("Description cannot be empty".to_string());
         }
-        if amount_excl_vat <= 0.0 {
+        if amount_excl_vat <= Decimal::ZERO {
             return Err("Amount (excl. VAT) must be greater than 0".to_string());
         }
-        if !(0.0..=100.0).contains(&vat_rate) {
+        if vat_rate < Decimal::ZERO || vat_rate > dec!(100) {
             return Err("VAT rate must be between 0 and 100".to_string());
         }
 
-        // Calcul automatique de la TVA
-        let vat_amount = (amount_excl_vat * vat_rate) / 100.0;
+        // Calcul automatique de la TVA — exact decimal arithmetic
+        let vat_amount = (amount_excl_vat * vat_rate) / dec!(100);
         let amount_incl_vat = amount_excl_vat + vat_amount;
 
         let now = Utc::now();
@@ -203,17 +209,17 @@ impl Expense {
         })
     }
 
-    /// Recalcule la TVA si le montant HT ou le taux change
+    /// Recalcule la TVA si le montant HT ou le taux change (exact decimal).
     pub fn recalculate_vat(&mut self) -> Result<(), String> {
         if let (Some(amount_excl_vat), Some(vat_rate)) = (self.amount_excl_vat, self.vat_rate) {
-            if amount_excl_vat <= 0.0 {
+            if amount_excl_vat <= Decimal::ZERO {
                 return Err("Amount (excl. VAT) must be greater than 0".to_string());
             }
-            if !(0.0..=100.0).contains(&vat_rate) {
+            if vat_rate < Decimal::ZERO || vat_rate > dec!(100) {
                 return Err("VAT rate must be between 0 and 100".to_string());
             }
 
-            let vat_amount = (amount_excl_vat * vat_rate) / 100.0;
+            let vat_amount = (amount_excl_vat * vat_rate) / dec!(100);
             let amount_incl_vat = amount_excl_vat + vat_amount;
 
             self.vat_amount = Some(vat_amount);
@@ -414,7 +420,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Entretien ascenseur".to_string(),
-            500.0,
+            dec!(500),
             Utc::now(),
             Some("ACME Elevators".to_string()),
             Some("INV-2024-001".to_string()),
@@ -424,7 +430,7 @@ mod tests {
         assert!(expense.is_ok());
         let expense = expense.unwrap();
         assert_eq!(expense.organization_id, org_id);
-        assert_eq!(expense.amount, 500.0);
+        assert_eq!(expense.amount, dec!(500));
         assert_eq!(expense.payment_status, PaymentStatus::Pending);
         assert_eq!(expense.account_code, Some("611002".to_string()));
     }
@@ -438,7 +444,7 @@ mod tests {
             building_id,
             ExpenseCategory::Other,
             "Miscellaneous expense".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -459,7 +465,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -482,7 +488,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -504,7 +510,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            -100.0,
+            dec!(-100),
             Utc::now(),
             None,
             None,
@@ -524,7 +530,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -552,7 +558,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -578,7 +584,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -600,7 +606,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -628,8 +634,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Réparation toiture".to_string(),
-            1000.0, // HT
-            21.0,   // TVA 21%
+            dec!(1000), // HT
+            dec!(21),   // TVA 21%
             invoice_date,
             Some(due_date),
             Some("BatiPro SPRL".to_string()),
@@ -639,11 +645,11 @@ mod tests {
 
         assert!(invoice.is_ok());
         let invoice = invoice.unwrap();
-        assert_eq!(invoice.amount_excl_vat, Some(1000.0));
-        assert_eq!(invoice.vat_rate, Some(21.0));
-        assert_eq!(invoice.vat_amount, Some(210.0));
-        assert_eq!(invoice.amount_incl_vat, Some(1210.0));
-        assert_eq!(invoice.amount, 1210.0); // Backward compatibility
+        assert_eq!(invoice.amount_excl_vat, Some(dec!(1000)));
+        assert_eq!(invoice.vat_rate, Some(dec!(21)));
+        assert_eq!(invoice.vat_amount, Some(dec!(210)));
+        assert_eq!(invoice.amount_incl_vat, Some(dec!(1210)));
+        assert_eq!(invoice.amount, dec!(1210)); // Backward compatibility
         assert_eq!(invoice.approval_status, ApprovalStatus::Draft);
     }
 
@@ -657,8 +663,8 @@ mod tests {
             building_id,
             ExpenseCategory::Works,
             "Rénovation énergétique".to_string(),
-            5000.0, // HT
-            6.0,    // TVA réduite 6%
+            dec!(5000), // HT
+            dec!(6),    // TVA réduite 6%
             Utc::now(),
             None,
             None,
@@ -667,8 +673,8 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(invoice.vat_amount, Some(300.0));
-        assert_eq!(invoice.amount_incl_vat, Some(5300.0));
+        assert_eq!(invoice.vat_amount, Some(dec!(300)));
+        assert_eq!(invoice.amount_incl_vat, Some(dec!(5300)));
     }
 
     #[test]
@@ -681,8 +687,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
-            -5.0, // Taux négatif invalide
+            dec!(100),
+            dec!(-5), // Taux négatif invalide
             Utc::now(),
             None,
             None,
@@ -704,8 +710,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
-            150.0, // Taux > 100% invalide
+            dec!(100),
+            dec!(150), // Taux > 100% invalide
             Utc::now(),
             None,
             None,
@@ -726,8 +732,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -737,12 +743,12 @@ mod tests {
         .unwrap();
 
         // Modifier le montant HT
-        invoice.amount_excl_vat = Some(1500.0);
+        invoice.amount_excl_vat = Some(dec!(1500));
         let result = invoice.recalculate_vat();
 
         assert!(result.is_ok());
-        assert_eq!(invoice.vat_amount, Some(315.0)); // 1500 * 21% = 315
-        assert_eq!(invoice.amount_incl_vat, Some(1815.0));
+        assert_eq!(invoice.vat_amount, Some(dec!(315))); // 1500 * 21% = 315
+        assert_eq!(invoice.amount_incl_vat, Some(dec!(1815)));
     }
 
     #[test]
@@ -756,7 +762,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -780,8 +786,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -809,8 +815,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -837,8 +843,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -871,8 +877,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -902,8 +908,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -930,8 +936,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -966,8 +972,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -993,8 +999,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -1017,8 +1023,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -1044,8 +1050,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            1000.0,
-            21.0,
+            dec!(1000),
+            dec!(21),
             Utc::now(),
             None,
             None,
@@ -1071,7 +1077,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Test".to_string(),
-            100.0,
+            dec!(100),
             Utc::now(),
             None,
             None,
@@ -1101,8 +1107,8 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Entretien annuel".to_string(),
-            2000.0,
-            21.0,
+            dec!(2000),
+            dec!(21),
             Utc::now(),
             Some(Utc::now() + chrono::Duration::days(30)),
             Some("MaintenancePro".to_string()),
@@ -1143,7 +1149,7 @@ mod tests {
             building_id,
             ExpenseCategory::Works,
             "Réparation toiture".to_string(),
-            5000.0,
+            dec!(5000),
             Utc::now(),
             Some("Construction SPRL".to_string()),
             Some("DV-2025-001".to_string()),
@@ -1171,7 +1177,7 @@ mod tests {
             building_id,
             ExpenseCategory::Works,
             "Réparation toiture".to_string(),
-            5000.0,
+            dec!(5000),
             Utc::now(),
             Some("Construction SPRL".to_string()),
             Some("DV-2025-001".to_string()),
@@ -1197,7 +1203,7 @@ mod tests {
             building_id,
             ExpenseCategory::Maintenance,
             "Maintenance".to_string(),
-            1000.0,
+            dec!(1000),
             Utc::now(),
             None,
             None,
@@ -1224,7 +1230,7 @@ mod tests {
             building_id,
             ExpenseCategory::Works,
             "Réparation toiture".to_string(),
-            5000.0,
+            dec!(5000),
             Utc::now(),
             Some("Construction SPRL".to_string()),
             Some("DV-2025-001".to_string()),

--- a/backend/src/domain/entities/invoice_line_item.rs
+++ b/backend/src/domain/entities/invoice_line_item.rs
@@ -1,22 +1,35 @@
+//! Invoice line item entity — monetary fields use `rust_decimal::Decimal`
+//!
+//! Migration story EXP-003 (cf. ADR-0007 `docs/adr/0007-decimal-vs-f64-for-money.md`,
+//! ADR-0008 `docs/adr/0008-numeric-vs-double-precision-postgresql.md`).
+//!
+//! All `f64` monetary fields migrated to `Decimal` for PCMN belge exactness
+//! (Arrêté Royal du 12 juillet 2012). VAT computations no longer subject to
+//! IEEE 754 cumulative drift.
+
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 /// Représente une ligne de facture détaillée
-/// Permet de décomposer une facture en plusieurs postes avec quantité et prix unitaire
+/// Permet de décomposer une facture en plusieurs postes avec quantité et prix unitaire.
+///
+/// **Précision** : tous les montants et taux utilisent `Decimal` pour conformité PCMN.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct InvoiceLineItem {
     pub id: Uuid,
     pub expense_id: Uuid, // Référence à la facture parent
     pub description: String,
-    pub quantity: f64,
-    pub unit_price: f64, // Prix unitaire HT
+    pub quantity: Decimal,
+    pub unit_price: Decimal, // Prix unitaire HT
 
-    // Montants calculés
-    pub amount_excl_vat: f64, // quantity * unit_price
-    pub vat_rate: f64,        // Taux TVA (ex: 21.0 pour 21%)
-    pub vat_amount: f64,      // Montant TVA
-    pub amount_incl_vat: f64, // Montant TTC
+    // Montants calculés (exact, conforme PCMN)
+    pub amount_excl_vat: Decimal, // quantity * unit_price
+    pub vat_rate: Decimal,        // Taux TVA (ex: 21.0 pour 21%, ou 6.0)
+    pub vat_amount: Decimal,      // Montant TVA = amount_excl_vat * vat_rate / 100
+    pub amount_incl_vat: Decimal, // Montant TTC = amount_excl_vat + vat_amount
 
     pub created_at: DateTime<Utc>,
 }
@@ -25,27 +38,27 @@ impl InvoiceLineItem {
     pub fn new(
         expense_id: Uuid,
         description: String,
-        quantity: f64,
-        unit_price: f64,
-        vat_rate: f64,
+        quantity: Decimal,
+        unit_price: Decimal,
+        vat_rate: Decimal,
     ) -> Result<Self, String> {
         // Validations
         if description.trim().is_empty() {
             return Err("Description cannot be empty".to_string());
         }
-        if quantity <= 0.0 {
+        if quantity <= Decimal::ZERO {
             return Err("Quantity must be greater than 0".to_string());
         }
-        if unit_price < 0.0 {
+        if unit_price < Decimal::ZERO {
             return Err("Unit price cannot be negative".to_string());
         }
-        if !(0.0..=100.0).contains(&vat_rate) {
+        if vat_rate < Decimal::ZERO || vat_rate > dec!(100) {
             return Err("VAT rate must be between 0 and 100".to_string());
         }
 
-        // Calculs automatiques
+        // Calculs automatiques (exact decimal arithmetic, no IEEE 754 drift)
         let amount_excl_vat = quantity * unit_price;
-        let vat_amount = (amount_excl_vat * vat_rate) / 100.0;
+        let vat_amount = (amount_excl_vat * vat_rate) / dec!(100);
         let amount_incl_vat = amount_excl_vat + vat_amount;
 
         Ok(Self {
@@ -62,36 +75,37 @@ impl InvoiceLineItem {
         })
     }
 
-    /// Recalcule les montants si quantity ou unit_price changent
+    /// Recalcule les montants si quantity, unit_price ou vat_rate changent.
     pub fn recalculate(&mut self) -> Result<(), String> {
-        if self.quantity <= 0.0 {
+        if self.quantity <= Decimal::ZERO {
             return Err("Quantity must be greater than 0".to_string());
         }
-        if self.unit_price < 0.0 {
+        if self.unit_price < Decimal::ZERO {
             return Err("Unit price cannot be negative".to_string());
         }
-        if self.vat_rate < 0.0 || self.vat_rate > 100.0 {
+        if self.vat_rate < Decimal::ZERO || self.vat_rate > dec!(100) {
             return Err("VAT rate must be between 0 and 100".to_string());
         }
 
         self.amount_excl_vat = self.quantity * self.unit_price;
-        self.vat_amount = (self.amount_excl_vat * self.vat_rate) / 100.0;
+        self.vat_amount = (self.amount_excl_vat * self.vat_rate) / dec!(100);
         self.amount_incl_vat = self.amount_excl_vat + self.vat_amount;
         Ok(())
     }
 
-    /// Calcule le total HT pour toutes les lignes
-    pub fn total_excl_vat(items: &[InvoiceLineItem]) -> f64 {
+    /// Calcule le total HT pour toutes les lignes.
+    /// Exact : pas de drift IEEE 754 sur cumul.
+    pub fn total_excl_vat(items: &[InvoiceLineItem]) -> Decimal {
         items.iter().map(|item| item.amount_excl_vat).sum()
     }
 
-    /// Calcule le total TVA pour toutes les lignes
-    pub fn total_vat(items: &[InvoiceLineItem]) -> f64 {
+    /// Calcule le total TVA pour toutes les lignes.
+    pub fn total_vat(items: &[InvoiceLineItem]) -> Decimal {
         items.iter().map(|item| item.vat_amount).sum()
     }
 
-    /// Calcule le total TTC pour toutes les lignes
-    pub fn total_incl_vat(items: &[InvoiceLineItem]) -> f64 {
+    /// Calcule le total TTC pour toutes les lignes.
+    pub fn total_incl_vat(items: &[InvoiceLineItem]) -> Decimal {
         items.iter().map(|item| item.amount_incl_vat).sum()
     }
 }
@@ -100,156 +114,305 @@ impl InvoiceLineItem {
 mod tests {
     use super::*;
 
+    // -------------------------------------------------------------------
+    // @happy — chemin nominal end-to-end
+    // -------------------------------------------------------------------
+
     #[test]
-    fn test_create_line_item_success() {
+    fn happy_create_line_item_success() {
         let expense_id = Uuid::new_v4();
         let line = InvoiceLineItem::new(
             expense_id,
             "Réparation porte principale".to_string(),
-            2.0,   // quantity
-            150.0, // unit_price
-            21.0,  // vat_rate
+            dec!(2),   // quantity
+            dec!(150), // unit_price
+            dec!(21),  // vat_rate
         );
 
         assert!(line.is_ok());
         let line = line.unwrap();
         assert_eq!(line.expense_id, expense_id);
-        assert_eq!(line.quantity, 2.0);
-        assert_eq!(line.unit_price, 150.0);
-        assert_eq!(line.amount_excl_vat, 300.0); // 2 * 150
-        assert_eq!(line.vat_amount, 63.0); // 300 * 21%
-        assert_eq!(line.amount_incl_vat, 363.0); // 300 + 63
+        assert_eq!(line.quantity, dec!(2));
+        assert_eq!(line.unit_price, dec!(150));
+        assert_eq!(line.amount_excl_vat, dec!(300)); // 2 * 150
+        assert_eq!(line.vat_amount, dec!(63)); // 300 * 21%
+        assert_eq!(line.amount_incl_vat, dec!(363)); // 300 + 63
     }
 
     #[test]
-    fn test_create_line_item_with_vat_6_percent() {
+    fn happy_create_line_item_with_vat_6_percent() {
         let expense_id = Uuid::new_v4();
         let line = InvoiceLineItem::new(
             expense_id,
             "Travaux isolation toit".to_string(),
-            1.0,
-            10000.0,
-            6.0, // TVA réduite 6%
+            dec!(1),
+            dec!(10000),
+            dec!(6), // TVA réduite 6%
         )
         .unwrap();
 
-        assert_eq!(line.amount_excl_vat, 10000.0);
-        assert_eq!(line.vat_amount, 600.0); // 10000 * 6%
-        assert_eq!(line.amount_incl_vat, 10600.0);
+        assert_eq!(line.amount_excl_vat, dec!(10000));
+        assert_eq!(line.vat_amount, dec!(600)); // 10000 * 6%
+        assert_eq!(line.amount_incl_vat, dec!(10600));
     }
 
     #[test]
-    fn test_create_line_item_empty_description_fails() {
-        let expense_id = Uuid::new_v4();
-        let line = InvoiceLineItem::new(expense_id, "   ".to_string(), 1.0, 100.0, 21.0);
-
-        assert!(line.is_err());
-        assert_eq!(line.unwrap_err(), "Description cannot be empty");
-    }
-
-    #[test]
-    fn test_create_line_item_zero_quantity_fails() {
-        let expense_id = Uuid::new_v4();
-        let line = InvoiceLineItem::new(expense_id, "Test".to_string(), 0.0, 100.0, 21.0);
-
-        assert!(line.is_err());
-        assert_eq!(line.unwrap_err(), "Quantity must be greater than 0");
-    }
-
-    #[test]
-    fn test_create_line_item_negative_unit_price_fails() {
-        let expense_id = Uuid::new_v4();
-        let line = InvoiceLineItem::new(expense_id, "Test".to_string(), 1.0, -50.0, 21.0);
-
-        assert!(line.is_err());
-        assert_eq!(line.unwrap_err(), "Unit price cannot be negative");
-    }
-
-    #[test]
-    fn test_create_line_item_invalid_vat_rate_fails() {
-        let expense_id = Uuid::new_v4();
-        let line = InvoiceLineItem::new(expense_id, "Test".to_string(), 1.0, 100.0, 150.0);
-
-        assert!(line.is_err());
-    }
-
-    #[test]
-    fn test_recalculate_after_quantity_change() {
-        let expense_id = Uuid::new_v4();
-        let mut line =
-            InvoiceLineItem::new(expense_id, "Test".to_string(), 1.0, 100.0, 21.0).unwrap();
-
-        assert_eq!(line.amount_excl_vat, 100.0);
-
-        // Changer la quantité
-        line.quantity = 3.0;
-        line.recalculate().unwrap();
-
-        assert_eq!(line.amount_excl_vat, 300.0); // 3 * 100
-        assert_eq!(line.vat_amount, 63.0); // 300 * 21%
-        assert_eq!(line.amount_incl_vat, 363.0);
-    }
-
-    #[test]
-    fn test_recalculate_after_unit_price_change() {
-        let expense_id = Uuid::new_v4();
-        let mut line =
-            InvoiceLineItem::new(expense_id, "Test".to_string(), 2.0, 100.0, 21.0).unwrap();
-
-        // Changer le prix unitaire
-        line.unit_price = 200.0;
-        line.recalculate().unwrap();
-
-        assert_eq!(line.amount_excl_vat, 400.0); // 2 * 200
-        assert_eq!(line.vat_amount, 84.0); // 400 * 21%
-        assert_eq!(line.amount_incl_vat, 484.0);
-    }
-
-    #[test]
-    fn test_total_calculations_multiple_lines() {
+    fn happy_total_calculations_multiple_lines() {
         let expense_id = Uuid::new_v4();
 
         let lines = vec![
-            InvoiceLineItem::new(expense_id, "Item 1".to_string(), 2.0, 100.0, 21.0).unwrap(),
-            InvoiceLineItem::new(expense_id, "Item 2".to_string(), 1.0, 300.0, 21.0).unwrap(),
-            InvoiceLineItem::new(expense_id, "Item 3".to_string(), 3.0, 50.0, 6.0).unwrap(),
+            InvoiceLineItem::new(expense_id, "Item 1".to_string(), dec!(2), dec!(100), dec!(21))
+                .unwrap(),
+            InvoiceLineItem::new(expense_id, "Item 2".to_string(), dec!(1), dec!(300), dec!(21))
+                .unwrap(),
+            InvoiceLineItem::new(expense_id, "Item 3".to_string(), dec!(3), dec!(50), dec!(6))
+                .unwrap(),
         ];
 
         // Item 1: 200 HT, 42 TVA, 242 TTC
         // Item 2: 300 HT, 63 TVA, 363 TTC
         // Item 3: 150 HT, 9 TVA, 159 TTC
         // Total: 650 HT, 114 TVA, 764 TTC
-
-        let total_excl_vat = InvoiceLineItem::total_excl_vat(&lines);
-        let total_vat = InvoiceLineItem::total_vat(&lines);
-        let total_incl_vat = InvoiceLineItem::total_incl_vat(&lines);
-
-        assert_eq!(total_excl_vat, 650.0);
-        assert_eq!(total_vat, 114.0);
-        assert_eq!(total_incl_vat, 764.0);
+        assert_eq!(InvoiceLineItem::total_excl_vat(&lines), dec!(650));
+        assert_eq!(InvoiceLineItem::total_vat(&lines), dec!(114));
+        assert_eq!(InvoiceLineItem::total_incl_vat(&lines), dec!(764));
     }
 
+    // -------------------------------------------------------------------
+    // @edge — bornes (max/min/empty/0/1/N, dates limites, precision)
+    // -------------------------------------------------------------------
+
     #[test]
-    fn test_total_calculations_empty_list() {
+    fn edge_total_calculations_empty_list() {
         let lines: Vec<InvoiceLineItem> = vec![];
-
-        assert_eq!(InvoiceLineItem::total_excl_vat(&lines), 0.0);
-        assert_eq!(InvoiceLineItem::total_vat(&lines), 0.0);
-        assert_eq!(InvoiceLineItem::total_incl_vat(&lines), 0.0);
+        assert_eq!(InvoiceLineItem::total_excl_vat(&lines), Decimal::ZERO);
+        assert_eq!(InvoiceLineItem::total_vat(&lines), Decimal::ZERO);
+        assert_eq!(InvoiceLineItem::total_incl_vat(&lines), Decimal::ZERO);
     }
 
     #[test]
-    fn test_description_trimmed() {
+    fn edge_description_trimmed() {
         let expense_id = Uuid::new_v4();
         let line = InvoiceLineItem::new(
             expense_id,
             "  Peinture couloir   ".to_string(),
-            1.0,
-            500.0,
-            21.0,
+            dec!(1),
+            dec!(500),
+            dec!(21),
         )
         .unwrap();
-
         assert_eq!(line.description, "Peinture couloir");
+    }
+
+    #[test]
+    fn edge_recalculate_after_quantity_change() {
+        let expense_id = Uuid::new_v4();
+        let mut line =
+            InvoiceLineItem::new(expense_id, "Test".to_string(), dec!(1), dec!(100), dec!(21))
+                .unwrap();
+
+        assert_eq!(line.amount_excl_vat, dec!(100));
+
+        line.quantity = dec!(3);
+        line.recalculate().unwrap();
+
+        assert_eq!(line.amount_excl_vat, dec!(300));
+        assert_eq!(line.vat_amount, dec!(63));
+        assert_eq!(line.amount_incl_vat, dec!(363));
+    }
+
+    #[test]
+    fn edge_recalculate_after_unit_price_change() {
+        let expense_id = Uuid::new_v4();
+        let mut line =
+            InvoiceLineItem::new(expense_id, "Test".to_string(), dec!(2), dec!(100), dec!(21))
+                .unwrap();
+
+        line.unit_price = dec!(200);
+        line.recalculate().unwrap();
+
+        assert_eq!(line.amount_excl_vat, dec!(400));
+        assert_eq!(line.vat_amount, dec!(84));
+        assert_eq!(line.amount_incl_vat, dec!(484));
+    }
+
+    #[test]
+    fn edge_decimal_exactness_preserved_on_cumul() {
+        // Le test critique du f64 vs Decimal :
+        // 0.1 + 0.2 == 0.3 EXACTEMENT en Decimal (ce qui est faux en f64).
+        let expense_id = Uuid::new_v4();
+        let lines = vec![
+            InvoiceLineItem::new(
+                expense_id,
+                "Item small".to_string(),
+                dec!(1),
+                dec!(0.1),
+                dec!(0),
+            )
+            .unwrap(),
+            InvoiceLineItem::new(
+                expense_id,
+                "Item small 2".to_string(),
+                dec!(1),
+                dec!(0.2),
+                dec!(0),
+            )
+            .unwrap(),
+        ];
+
+        assert_eq!(InvoiceLineItem::total_excl_vat(&lines), dec!(0.3));
+    }
+
+    #[test]
+    fn edge_vat_rate_zero_allowed() {
+        let expense_id = Uuid::new_v4();
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "Exonéré TVA".to_string(),
+            dec!(1),
+            dec!(100),
+            Decimal::ZERO,
+        )
+        .unwrap();
+        assert_eq!(line.vat_amount, Decimal::ZERO);
+        assert_eq!(line.amount_incl_vat, dec!(100));
+    }
+
+    #[test]
+    fn edge_vat_rate_max_100_allowed() {
+        let expense_id = Uuid::new_v4();
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "Border case".to_string(),
+            dec!(1),
+            dec!(100),
+            dec!(100),
+        )
+        .unwrap();
+        assert_eq!(line.vat_amount, dec!(100)); // 100% TVA
+        assert_eq!(line.amount_incl_vat, dec!(200));
+    }
+
+    // -------------------------------------------------------------------
+    // @security — RBAC, auth, injection (n/a entité pure) ; ici on
+    // teste les invariants de saisie qui empêcheraient un client
+    // malveillant de créer une ligne incohérente ou abusive
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn security_create_line_item_empty_description_fails() {
+        let expense_id = Uuid::new_v4();
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "   ".to_string(),
+            dec!(1),
+            dec!(100),
+            dec!(21),
+        );
+        assert!(line.is_err());
+        assert_eq!(line.unwrap_err(), "Description cannot be empty");
+    }
+
+    #[test]
+    fn security_create_line_item_negative_unit_price_fails() {
+        // Empêche un client malveillant de créer une 'remise' déguisée
+        // en prix négatif qui contournerait les workflows d'approbation.
+        let expense_id = Uuid::new_v4();
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "Test".to_string(),
+            dec!(1),
+            dec!(-50),
+            dec!(21),
+        );
+        assert!(line.is_err());
+        assert_eq!(line.unwrap_err(), "Unit price cannot be negative");
+    }
+
+    #[test]
+    fn security_create_line_item_vat_rate_above_100_fails() {
+        // Empêche un taux de TVA aberrant (e.g., 9999%) qui pourrait
+        // gonfler artificiellement le montant TTC.
+        let expense_id = Uuid::new_v4();
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "Test".to_string(),
+            dec!(1),
+            dec!(100),
+            dec!(150),
+        );
+        assert!(line.is_err());
+    }
+
+    #[test]
+    fn security_create_line_item_negative_vat_rate_fails() {
+        let expense_id = Uuid::new_v4();
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "Test".to_string(),
+            dec!(1),
+            dec!(100),
+            dec!(-1),
+        );
+        assert!(line.is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // @negative — défaillance correcte (pas de panic, erreur typée)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn negative_create_line_item_zero_quantity_fails() {
+        let expense_id = Uuid::new_v4();
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "Test".to_string(),
+            Decimal::ZERO,
+            dec!(100),
+            dec!(21),
+        );
+        assert!(line.is_err());
+        assert_eq!(line.unwrap_err(), "Quantity must be greater than 0");
+    }
+
+    #[test]
+    fn negative_recalculate_with_invalid_state_returns_error() {
+        // Si on modifie directement les fields invalides puis on
+        // recalcule, l'erreur est retournée proprement (pas de panic).
+        let expense_id = Uuid::new_v4();
+        let mut line =
+            InvoiceLineItem::new(expense_id, "Test".to_string(), dec!(1), dec!(100), dec!(21))
+                .unwrap();
+
+        line.quantity = dec!(-5); // invalide
+        let result = line.recalculate();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Quantity must be greater than 0");
+    }
+
+    #[test]
+    fn negative_no_panic_on_extreme_values() {
+        // Decimal supports up to ~28 digits. Au-delà, retourne erreur
+        // ou comportement défini (pas de panic IEEE 754 NaN/Inf).
+        let expense_id = Uuid::new_v4();
+        // Valeur grande mais dans la plage Decimal
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "Big".to_string(),
+            dec!(1),
+            dec!(99999999999.99), // proche de la limite NUMERIC(15,2)
+            dec!(21),
+        )
+        .unwrap();
+        // Le calcul doit produire un Decimal valide (pas de NaN)
+        assert!(line.amount_incl_vat > line.amount_excl_vat);
+    }
+
+    #[test]
+    fn negative_description_only_whitespace_fails() {
+        let expense_id = Uuid::new_v4();
+        let line =
+            InvoiceLineItem::new(expense_id, "\t\n  ".to_string(), dec!(1), dec!(100), dec!(21));
+        assert!(line.is_err());
     }
 }


### PR DESCRIPTION
## ⚠️ DRAFT WIP — ne compile pas en l'état

Cette PR documente un **scope dépassé** sur EXP-003. Elle livre la migration des entités + DTO mais **la cascade downstream nécessite 3-4 stories supplémentaires** pour rendre la branche compilable.

## Migré dans cette PR

| Fichier | Avant | Après | Tests |
|---|---|---|---|
| `domain/entities/expense.rs` | 8 f64 | 0 f64 (Decimal) | tests existants migrés via `dec!()` |
| `domain/entities/invoice_line_item.rs` | 12 f64 | 0 f64 (Decimal) | full rewrite + **18 tests 4-cat** (3 happy + 7 edge + 4 security + 4 negative) |
| `application/dto/expense_dto.rs` | 22 f64 | 0 f64 (Decimal) | DTOs (legacy + invoice + line item + charge_distribution) |
| `backend/Cargo.toml` | rust_decimal_macros en `[dev-dependencies]` | promu en `[dependencies]` (dec!() en code prod) | — |

**Stats** : 4 files changed, +400 / -227.

## Test critique ajouté

```rust
#[test]
fn edge_decimal_exactness_preserved_on_cumul() {
    // Le test qui valide 0.1 + 0.2 == 0.3 EXACTEMENT en Decimal
    // (impossible en f64 — c'est le test signature de la migration)
    let lines = vec![
        InvoiceLineItem::new(.., dec!(0.1), ..)?,
        InvoiceLineItem::new(.., dec!(0.2), ..)?,
    ];
    assert_eq!(InvoiceLineItem::total_excl_vat(&lines), dec!(0.3));
}
```

## ❌ Cascade non migrée (36 erreurs cargo check)

```
docker compose run --rm backend bash -c "SQLX_OFFLINE=true cargo check --lib"
→ error: could not compile `koprogo-api` (lib) due to 36 previous errors
```

Modules downstream qui consomment `expense.amount` ou `invoice_line_item` comme `f64` :

| Module | Erreurs | Pattern |
|---|---|---|
| `application/services/expense_accounting_service.rs` | ~6 | journal_entry mul/sum |
| `application/use_cases/charge_distribution_use_cases.rs` | 1 | passe-through Expense |
| `application/use_cases/dashboard_use_cases.rs` | ~8 | `Iterator::sum::<f64>()` sur `Vec<Decimal>` |
| `application/use_cases/expense_use_cases.rs` | ?? | passe-through |
| `application/use_cases/budget_use_cases.rs` | ?? | passe-through |
| `application/use_cases/payment_reminder_use_cases.rs` | ?? | passe-through |
| `infrastructure/web/handlers/expense_handlers.rs` | 2 | mismatched types |
| `infrastructure/web/handlers/building_handlers.rs` | 1 | sum expenses |
| `infrastructure/web/handlers/mcp_sse_handlers.rs` | 2+ | sums Decimal as f64 |
| `infrastructure/database/repositories/expense_repository_impl.rs` | TBD | sqlx mapping |

## Pourquoi ce WIP ?

Discipline **Maury — rendre le problème visible** plutôt que le cacher.

Alternatives rejetées :
- ❌ Migrer 50+ sites en un seul gros PR (review impossible)
- ❌ Conversions `.to_f64()` partout (anti-pattern explicit ADR-0007 — leak précision à chaque boundary)
- ❌ Revenir en arrière (perd l'investissement entity+DTO solide)

## Découpage proposé pour finir la migration

| Story | Périmètre | Effort |
|---|---|---|
| **EXP-003a (cette PR)** | entity expense + invoice_line_item + DTO | M (livré) |
| **EXP-003b** (NEW) | services + use_cases consumming Expense (`expense_accounting_service`, `charge_distribution`, `expense_use_cases`, `budget_use_cases`, `payment_reminder`) | M |
| **EXP-003c** (NEW) | repositories + handlers + SQL migration ALTER TABLE expenses | M |
| **EXP-003d** (NEW) | modules périphériques avec sum() (`dashboard_use_cases`, `building_handlers`, `mcp_sse_handlers`) | S-M |

**Total réel EXP-003** : ~3-4 stories M, ~1 semaine. Sprint W19 minimum.

## Action requise côté humain

- ✋ **Ne pas merger cette PR seule** — elle casse le build
- ✅ Soit attendre EXP-003b/c/d avant merge groupé
- ✅ Soit valider le découpage proposé et ouvrir 3 nouvelles stories sur l'umbrella issue #433
- ✅ Soit décider d'un autre approach (e.g., rollback EXP-003 et faire one big-bang vertical sur sprint dédié)

## Refs

- Audit f64 : doc `docs/audit/2026-04-30-f64-monetary-audit.md` (PR #434)
- ADRs : 0007 / 0008 / 0009 (PR #435)
- Umbrella migration : #433
- Sprint pilote : #430

🤖 `rust-expert` (Claude) — Tier 2 logué. Honnêteté sur scope > faux sentiment de progression.