### PR TITLE
chore(ci): unblock cargo clippy + fmt + prettier (#443 partial)

### DIFF
--- a/backend/benches/load_tests.rs
+++ b/backend/benches/load_tests.rs
@@ -2,6 +2,7 @@ use chrono::Utc;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use koprogo_api::domain::entities::{Building, Expense, ExpenseCategory, Owner, Unit, UnitType};
 use koprogo_api::domain::services::ExpenseCalculator;
+use rust_decimal_macros::dec;
 use std::hint::black_box;
 use uuid::Uuid;
 
@@ -37,7 +38,7 @@ fn benchmark_unit_creation(c: &mut Criterion) {
                 black_box(UnitType::Apartment),
                 black_box(Some(1)),
                 black_box(75.5),
-                black_box(50.0),
+                black_box(dec!(50)),
             )
         });
     });
@@ -75,7 +76,7 @@ fn benchmark_expense_calculation(c: &mut Criterion) {
                     building_id,
                     ExpenseCategory::Maintenance,
                     format!("Expense {}", i),
-                    100.0,
+                    dec!(100),
                     Utc::now(),
                     None,
                     None,
@@ -105,7 +106,7 @@ fn benchmark_unit_share_calculation(c: &mut Criterion) {
         building_id,
         ExpenseCategory::Maintenance,
         "Test".to_string(),
-        1000.0,
+        dec!(1000),
         Utc::now(),
         None,
         None,
@@ -120,7 +121,7 @@ fn benchmark_unit_share_calculation(c: &mut Criterion) {
         UnitType::Apartment,
         Some(1),
         75.0,
-        50.0,
+        dec!(50),
     )
     .unwrap();
 

--- a/backend/src/application/error.rs
+++ b/backend/src/application/error.rs
@@ -111,9 +111,9 @@ impl ResponseError for AppError {
     fn status_code(&self) -> StatusCode {
         match self {
             AppError::Validation(_) => StatusCode::BAD_REQUEST,
-            AppError::Unauthorized
-            | AppError::InvalidCredentials
-            | AppError::TokenError(_) => StatusCode::UNAUTHORIZED,
+            AppError::Unauthorized | AppError::InvalidCredentials | AppError::TokenError(_) => {
+                StatusCode::UNAUTHORIZED
+            }
             AppError::Forbidden(_) | AppError::AccountDeactivated => StatusCode::FORBIDDEN,
             AppError::NotFound(_) => StatusCode::NOT_FOUND,
             AppError::Conflict(_) => StatusCode::CONFLICT,

--- a/backend/src/application/use_cases/call_for_funds_use_cases.rs
+++ b/backend/src/application/use_cases/call_for_funds_use_cases.rs
@@ -409,7 +409,10 @@ mod tests {
         async fn has_active_owners(&self, _unit_id: Uuid) -> Result<bool, String> {
             unimplemented!()
         }
-        async fn get_total_ownership_percentage(&self, _unit_id: Uuid) -> Result<rust_decimal::Decimal, String> {
+        async fn get_total_ownership_percentage(
+            &self,
+            _unit_id: Uuid,
+        ) -> Result<rust_decimal::Decimal, String> {
             unimplemented!()
         }
         async fn find_active_by_unit_and_owner(
@@ -529,7 +532,8 @@ mod tests {
         let contributions = contrib_repo.store.lock().unwrap();
         assert_eq!(contributions.len(), 2);
 
-        let mut amounts: Vec<rust_decimal::Decimal> = contributions.iter().map(|c| c.amount).collect();
+        let mut amounts: Vec<rust_decimal::Decimal> =
+            contributions.iter().map(|c| c.amount).collect();
         amounts.sort();
         // 40% of 5000 = 2000, 60% of 5000 = 3000
         assert_eq!(amounts[0], rust_decimal_macros::dec!(2_000));

--- a/backend/src/application/use_cases/etat_date_use_cases.rs
+++ b/backend/src/application/use_cases/etat_date_use_cases.rs
@@ -392,7 +392,13 @@ mod tests {
     }
 
     fn make_unit_owner(unit_id: Uuid) -> UnitOwner {
-        UnitOwner::new(unit_id, Uuid::new_v4(), rust_decimal_macros::dec!(0.5), true).unwrap()
+        UnitOwner::new(
+            unit_id,
+            Uuid::new_v4(),
+            rust_decimal_macros::dec!(0.5),
+            true,
+        )
+        .unwrap()
     }
 
     fn make_etat_date(org_id: Uuid, building_id: Uuid, unit_id: Uuid) -> EtatDate {

--- a/backend/src/application/use_cases/expense_use_cases.rs
+++ b/backend/src/application/use_cases/expense_use_cases.rs
@@ -869,7 +869,10 @@ mod tests {
         let invoice = result.unwrap();
 
         // 1000 * 21% = 210 VAT, total = 1210
-        assert_eq!(invoice.amount_excl_vat, Some(rust_decimal_macros::dec!(1000)));
+        assert_eq!(
+            invoice.amount_excl_vat,
+            Some(rust_decimal_macros::dec!(1000))
+        );
         assert_eq!(invoice.vat_rate, Some(rust_decimal_macros::dec!(21)));
         assert_eq!(invoice.vat_amount, Some(rust_decimal_macros::dec!(210.00)));
         assert_eq!(

--- a/backend/src/application/use_cases/financial_report_use_cases.rs
+++ b/backend/src/application/use_cases/financial_report_use_cases.rs
@@ -132,7 +132,10 @@ impl FinancialReportUseCases {
         let mut revenue_accounts = Vec::new();
 
         for account in all_accounts {
-            let amount = account_balances.get(&account.code).cloned().unwrap_or(Decimal::ZERO);
+            let amount = account_balances
+                .get(&account.code)
+                .cloned()
+                .unwrap_or(Decimal::ZERO);
 
             let line = AccountLine {
                 code: account.code.clone(),
@@ -228,7 +231,10 @@ impl FinancialReportUseCases {
         let mut revenue_accounts = Vec::new();
 
         for account in all_accounts {
-            let amount = expense_amounts.get(&account.code).cloned().unwrap_or(Decimal::ZERO);
+            let amount = expense_amounts
+                .get(&account.code)
+                .cloned()
+                .unwrap_or(Decimal::ZERO);
 
             // Only include accounts with non-zero amounts
             if amount == Decimal::ZERO {
@@ -329,7 +335,10 @@ impl FinancialReportUseCases {
         let mut liability_accounts = Vec::new();
 
         for account in all_accounts {
-            let balance = account_balances.get(&account.code).cloned().unwrap_or(Decimal::ZERO);
+            let balance = account_balances
+                .get(&account.code)
+                .cloned()
+                .unwrap_or(Decimal::ZERO);
             if balance == Decimal::ZERO {
                 continue;
             }
@@ -431,7 +440,10 @@ impl FinancialReportUseCases {
         let mut revenue_accounts = Vec::new();
 
         for account in all_accounts {
-            let amount = account_balances.get(&account.code).cloned().unwrap_or(Decimal::ZERO);
+            let amount = account_balances
+                .get(&account.code)
+                .cloned()
+                .unwrap_or(Decimal::ZERO);
             if amount == Decimal::ZERO {
                 continue;
             }

--- a/backend/src/application/use_cases/pcn_use_cases.rs
+++ b/backend/src/application/use_cases/pcn_use_cases.rs
@@ -45,8 +45,7 @@ impl PcnUseCases {
         let report_lines = PcnMapper::generate_report(&expenses);
 
         // Calculate totals
-        let total_amount: rust_decimal::Decimal =
-            report_lines.iter().map(|l| l.total_amount).sum();
+        let total_amount: rust_decimal::Decimal = report_lines.iter().map(|l| l.total_amount).sum();
         let total_entries: usize = report_lines.iter().map(|l| l.entry_count).sum();
 
         // Convert to DTOs

--- a/backend/src/application/use_cases/poll_use_cases.rs
+++ b/backend/src/application/use_cases/poll_use_cases.rs
@@ -811,7 +811,10 @@ mod tests {
             unimplemented!()
         }
 
-        async fn get_total_ownership_percentage(&self, _unit_id: Uuid) -> Result<rust_decimal::Decimal, String> {
+        async fn get_total_ownership_percentage(
+            &self,
+            _unit_id: Uuid,
+        ) -> Result<rust_decimal::Decimal, String> {
             unimplemented!()
         }
 
@@ -830,7 +833,13 @@ mod tests {
             // Return 10 unique owners (unit_id, owner_id, ownership_percentage)
             // This matches the old hardcoded total_eligible_voters = 10
             Ok((0..10)
-                .map(|_| (Uuid::new_v4(), Uuid::new_v4(), rust_decimal_macros::dec!(0.1)))
+                .map(|_| {
+                    (
+                        Uuid::new_v4(),
+                        Uuid::new_v4(),
+                        rust_decimal_macros::dec!(0.1),
+                    )
+                })
                 .collect())
         }
     }

--- a/backend/src/application/use_cases/unit_owner_use_cases_test.rs
+++ b/backend/src/application/use_cases/unit_owner_use_cases_test.rs
@@ -530,7 +530,9 @@ async fn test_update_ownership_percentage_success() {
         .unwrap();
 
     // Update percentage
-    let result = use_cases.update_ownership_percentage(uo.id, dec!(0.75)).await;
+    let result = use_cases
+        .update_ownership_percentage(uo.id, dec!(0.75))
+        .await;
 
     assert!(result.is_ok());
     let updated = result.unwrap();
@@ -563,7 +565,9 @@ async fn test_update_percentage_exceeds_limit() {
         .unwrap();
 
     // Try to increase owner1 to 0.7 (would make total 1.1)
-    let result = use_cases.update_ownership_percentage(uo1.id, dec!(0.7)).await;
+    let result = use_cases
+        .update_ownership_percentage(uo1.id, dec!(0.7))
+        .await;
 
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("exceed 100%"));

--- a/backend/src/domain/entities/achievement.rs
+++ b/backend/src/domain/entities/achievement.rs
@@ -16,7 +16,9 @@ pub enum AchievementCategory {
 }
 
 /// Achievement tier for progression
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, utoipa::ToSchema,
+)]
 pub enum AchievementTier {
     Bronze,   // Entry-level achievements
     Silver,   // Intermediate achievements

--- a/backend/src/domain/entities/building.rs
+++ b/backend/src/domain/entities/building.rs
@@ -170,8 +170,7 @@ impl Building {
     ) -> Result<(), String> {
         // Quotas en millièmes — Decimal exact, conversion via .trunc() vers i32 pour la borne 1000.
         use rust_decimal::prelude::ToPrimitive;
-        let total_shares_decimal: rust_decimal::Decimal =
-            units.iter().map(|u| u.quota).sum();
+        let total_shares_decimal: rust_decimal::Decimal = units.iter().map(|u| u.quota).sum();
         let total_shares: i32 = total_shares_decimal.trunc().to_i32().unwrap_or(0);
 
         // Note: During setup, units may not sum to total_shares yet (incomplete distribution is OK)

--- a/backend/src/domain/entities/charge_distribution.rs
+++ b/backend/src/domain/entities/charge_distribution.rs
@@ -307,12 +307,9 @@ mod tests {
         ];
 
         let total_invoice = dec!(5000);
-        let distributions = ChargeDistribution::calculate_distributions(
-            expense_id,
-            total_invoice,
-            unit_ownerships,
-        )
-        .unwrap();
+        let distributions =
+            ChargeDistribution::calculate_distributions(expense_id, total_invoice, unit_ownerships)
+                .unwrap();
 
         assert_eq!(distributions.len(), 5);
         assert_eq!(distributions[0].amount_due, dec!(1250.00)); // 25%

--- a/backend/src/domain/entities/invoice_line_item.rs
+++ b/backend/src/domain/entities/invoice_line_item.rs
@@ -161,10 +161,22 @@ mod tests {
         let expense_id = Uuid::new_v4();
 
         let lines = vec![
-            InvoiceLineItem::new(expense_id, "Item 1".to_string(), dec!(2), dec!(100), dec!(21))
-                .unwrap(),
-            InvoiceLineItem::new(expense_id, "Item 2".to_string(), dec!(1), dec!(300), dec!(21))
-                .unwrap(),
+            InvoiceLineItem::new(
+                expense_id,
+                "Item 1".to_string(),
+                dec!(2),
+                dec!(100),
+                dec!(21),
+            )
+            .unwrap(),
+            InvoiceLineItem::new(
+                expense_id,
+                "Item 2".to_string(),
+                dec!(1),
+                dec!(300),
+                dec!(21),
+            )
+            .unwrap(),
             InvoiceLineItem::new(expense_id, "Item 3".to_string(), dec!(3), dec!(50), dec!(6))
                 .unwrap(),
         ];
@@ -302,13 +314,8 @@ mod tests {
     #[test]
     fn security_create_line_item_empty_description_fails() {
         let expense_id = Uuid::new_v4();
-        let line = InvoiceLineItem::new(
-            expense_id,
-            "   ".to_string(),
-            dec!(1),
-            dec!(100),
-            dec!(21),
-        );
+        let line =
+            InvoiceLineItem::new(expense_id, "   ".to_string(), dec!(1), dec!(100), dec!(21));
         assert!(line.is_err());
         assert_eq!(line.unwrap_err(), "Description cannot be empty");
     }
@@ -318,13 +325,8 @@ mod tests {
         // Empêche un client malveillant de créer une 'remise' déguisée
         // en prix négatif qui contournerait les workflows d'approbation.
         let expense_id = Uuid::new_v4();
-        let line = InvoiceLineItem::new(
-            expense_id,
-            "Test".to_string(),
-            dec!(1),
-            dec!(-50),
-            dec!(21),
-        );
+        let line =
+            InvoiceLineItem::new(expense_id, "Test".to_string(), dec!(1), dec!(-50), dec!(21));
         assert!(line.is_err());
         assert_eq!(line.unwrap_err(), "Unit price cannot be negative");
     }
@@ -347,13 +349,8 @@ mod tests {
     #[test]
     fn security_create_line_item_negative_vat_rate_fails() {
         let expense_id = Uuid::new_v4();
-        let line = InvoiceLineItem::new(
-            expense_id,
-            "Test".to_string(),
-            dec!(1),
-            dec!(100),
-            dec!(-1),
-        );
+        let line =
+            InvoiceLineItem::new(expense_id, "Test".to_string(), dec!(1), dec!(100), dec!(-1));
         assert!(line.is_err());
     }
 
@@ -411,8 +408,13 @@ mod tests {
     #[test]
     fn negative_description_only_whitespace_fails() {
         let expense_id = Uuid::new_v4();
-        let line =
-            InvoiceLineItem::new(expense_id, "\t\n  ".to_string(), dec!(1), dec!(100), dec!(21));
+        let line = InvoiceLineItem::new(
+            expense_id,
+            "\t\n  ".to_string(),
+            dec!(1),
+            dec!(100),
+            dec!(21),
+        );
         assert!(line.is_err());
     }
 }

--- a/backend/src/domain/entities/shared_object.rs
+++ b/backend/src/domain/entities/shared_object.rs
@@ -24,7 +24,9 @@ pub enum SharedObjectCategory {
 }
 
 /// Condition of shared object
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, utoipa::ToSchema,
+)]
 pub enum ObjectCondition {
     /// Excellent condition (like new)
     Excellent,

--- a/backend/src/domain/entities/skill.rs
+++ b/backend/src/domain/entities/skill.rs
@@ -34,7 +34,9 @@ pub enum SkillCategory {
 }
 
 /// Expertise level for skill proficiency
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, utoipa::ToSchema)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, utoipa::ToSchema,
+)]
 pub enum ExpertiseLevel {
     /// Beginner (< 1 year experience)
     Beginner,

--- a/backend/src/domain/entities/user.rs
+++ b/backend/src/domain/entities/user.rs
@@ -8,8 +8,8 @@ pub enum UserRole {
     SuperAdmin,
     Syndic,
     Accountant,
-    BoardMember,  // Membre du conseil de copropriété
-    Contractor,   // Prestataire externe (plombier, électricien, etc.)
+    BoardMember, // Membre du conseil de copropriété
+    Contractor,  // Prestataire externe (plombier, électricien, etc.)
     Owner,
 }
 

--- a/backend/src/domain/services/annual_report_exporter.rs
+++ b/backend/src/domain/services/annual_report_exporter.rs
@@ -172,7 +172,9 @@ impl AnnualReportExporter {
         let mut category_totals: HashMap<String, Decimal> = HashMap::new();
         for expense in expenses {
             let category_name = Self::category_name(&expense.category);
-            *category_totals.entry(category_name).or_insert(Decimal::ZERO) += expense.amount;
+            *category_totals
+                .entry(category_name)
+                .or_insert(Decimal::ZERO) += expense.amount;
         }
 
         // Sort categories by amount (descending)

--- a/backend/src/domain/services/ownership_contract_exporter.rs
+++ b/backend/src/domain/services/ownership_contract_exporter.rs
@@ -169,7 +169,10 @@ impl OwnershipContractExporter {
         y -= 6.0;
 
         current_layer.use_text(
-            format!("Quote-part: {:.2}%", ownership_percentage * rust_decimal_macros::dec!(100)),
+            format!(
+                "Quote-part: {:.2}%",
+                ownership_percentage * rust_decimal_macros::dec!(100)
+            ),
             10.0,
             Mm(20.0),
             Mm(y),

--- a/backend/src/domain/services/pcn_mapper.rs
+++ b/backend/src/domain/services/pcn_mapper.rs
@@ -130,9 +130,10 @@ impl PcnMapper {
         // Aggregate expenses by PCN account code
         for expense in expenses {
             let account = Self::map_expense_to_pcn(&expense.category);
-            let entry = aggregated
-                .entry(account.code.clone())
-                .or_insert((account, Decimal::ZERO, 0));
+            let entry =
+                aggregated
+                    .entry(account.code.clone())
+                    .or_insert((account, Decimal::ZERO, 0));
             entry.1 += expense.amount;
             entry.2 += 1;
         }

--- a/backend/src/infrastructure/database/repositories/unit_owner_repository_impl.rs
+++ b/backend/src/infrastructure/database/repositories/unit_owner_repository_impl.rs
@@ -327,13 +327,7 @@ impl UnitOwnerRepository for PostgresUnitOwnerRepository {
 
         Ok(results
             .into_iter()
-            .map(|row| {
-                (
-                    row.unit_id,
-                    row.owner_id,
-                    row.ownership_percentage,
-                )
-            })
+            .map(|row| (row.unit_id, row.owner_id, row.ownership_percentage))
             .collect())
     }
 }

--- a/backend/src/infrastructure/database/seed.rs
+++ b/backend/src/infrastructure/database/seed.rs
@@ -593,8 +593,8 @@ impl DatabaseSeeder {
             unit1_id,
             owner1_db_id,
             rust_decimal_macros::dec!(1), // 100%
-            true, // primary contact
-            None, // no end_date (active)
+            true,                         // primary contact
+            None,                         // no end_date (active)
         )
         .await?;
 
@@ -603,7 +603,7 @@ impl DatabaseSeeder {
             unit2_id,
             owner2_db_id,
             rust_decimal_macros::dec!(0.6), // 60%
-            true, // primary contact
+            true,                           // primary contact
             None,
         )
         .await?;
@@ -611,8 +611,8 @@ impl DatabaseSeeder {
         self.create_demo_unit_owner(
             unit2_id,
             owner3_db_id,
-            rust_decimal_macros::dec!(0.4),   // 40%
-            false, // not primary contact
+            rust_decimal_macros::dec!(0.4), // 40%
+            false,                          // not primary contact
             None,
         )
         .await?;
@@ -622,7 +622,7 @@ impl DatabaseSeeder {
             unit3_id,
             owner1_db_id,
             rust_decimal_macros::dec!(0.5), // 50%
-            true, // primary contact
+            true,                           // primary contact
             None,
         )
         .await?;
@@ -650,7 +650,7 @@ impl DatabaseSeeder {
             unit4_id,
             owner3_db_id,
             rust_decimal_macros::dec!(1), // 100%
-            true, // primary contact
+            true,                         // primary contact
             None,
         )
         .await?;

--- a/backend/src/infrastructure/web/handlers/ticket_handlers.rs
+++ b/backend/src/infrastructure/web/handlers/ticket_handlers.rs
@@ -974,15 +974,9 @@ pub async fn list_assignable_users(
                 .into_iter()
                 .filter(|u| {
                     // Same org check
-                    u.organization_id.as_ref().map(|o| o.as_str())
-                        == Some(&organization_id.to_string())
+                    u.organization_id.as_deref() == Some(&organization_id.to_string())
                 })
-                .filter(|u| {
-                    matches!(
-                        u.role.as_str(),
-                        "syndic" | "board_member" | "contractor"
-                    )
-                })
+                .filter(|u| matches!(u.role.as_str(), "syndic" | "board_member" | "contractor"))
                 .map(|u| AssignableUserDto {
                     id: u.id.parse().unwrap_or_default(),
                     first_name: u.first_name.clone(),

--- a/backend/tests/bdd_financial.rs
+++ b/backend/tests/bdd_financial.rs
@@ -3,8 +3,6 @@
 // Phase 2: payments + payment_methods step definitions
 
 use chrono::{DateTime, Datelike, Duration as ChronoDuration, Utc};
-use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use cucumber::{gherkin::Step, given, then, when, World};
 use koprogo_api::application::dto::{
     AccountantDashboardStats, ApproveInvoiceDto, CreateBudgetRequest, CreateInvoiceDraftDto,
@@ -22,6 +20,8 @@ use koprogo_api::domain::entities::{
     Account, AccountType, ContributionPaymentMethod, ContributionType, ExpenseCategory,
     JournalEntry, JournalEntryLine, OwnerContribution, ReminderLevel,
 };
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 // Two separate PaymentMethodType enums exist in the domain:
 // payment.rs defines one (for Payment entity), payment_method.rs defines another (for PaymentMethod entity)
 use koprogo_api::domain::entities::payment_method::PaymentMethodType as PmMethodType;
@@ -111,8 +111,8 @@ pub struct FinancialWorld {
 
     // Charge distribution tracking
     distribution_list_count: usize,
-    distribution_amounts: Vec<(String, f64)>,
-    total_due: Option<f64>,
+    distribution_amounts: Vec<(String, Decimal)>,
+    total_due: Option<Decimal>,
 
     // Dashboard tracking
     dashboard_stats: Option<AccountantDashboardStats>,
@@ -1785,8 +1785,18 @@ async fn given_journal_entries_ach_ods(world: &mut FinancialWorld) {
 
     for jtype in &["ACH", "ODS"] {
         let lines = vec![
-            ("604000".to_string(), dec!(100.0), dec!(0.0), "Debit".to_string()),
-            ("440000".to_string(), dec!(0.0), dec!(100.0), "Credit".to_string()),
+            (
+                "604000".to_string(),
+                dec!(100.0),
+                dec!(0.0),
+                "Debit".to_string(),
+            ),
+            (
+                "440000".to_string(),
+                dec!(0.0),
+                dec!(100.0),
+                "Credit".to_string(),
+            ),
         ];
         uc.create_manual_entry(
             org_id,
@@ -1916,8 +1926,18 @@ async fn given_journal_entries_2_buildings(world: &mut FinancialWorld) {
 
     // Create entry for main building
     let lines = vec![
-        ("604000".to_string(), dec!(200.0), dec!(0.0), "Debit".to_string()),
-        ("440000".to_string(), dec!(0.0), dec!(200.0), "Credit".to_string()),
+        (
+            "604000".to_string(),
+            dec!(200.0),
+            dec!(0.0),
+            "Debit".to_string(),
+        ),
+        (
+            "440000".to_string(),
+            dec!(0.0),
+            dec!(200.0),
+            "Credit".to_string(),
+        ),
     ];
     uc.create_manual_entry(
         org_id,
@@ -1950,8 +1970,18 @@ async fn given_journal_entries_2_buildings(world: &mut FinancialWorld) {
     building_repo.create(&b2).await.expect("create building 2");
 
     let lines2 = vec![
-        ("604000".to_string(), dec!(300.0), dec!(0.0), "Debit".to_string()),
-        ("440000".to_string(), dec!(0.0), dec!(300.0), "Credit".to_string()),
+        (
+            "604000".to_string(),
+            dec!(300.0),
+            dec!(0.0),
+            "Debit".to_string(),
+        ),
+        (
+            "440000".to_string(),
+            dec!(0.0),
+            dec!(300.0),
+            "Credit".to_string(),
+        ),
     ];
     uc.create_manual_entry(
         org_id,
@@ -2001,8 +2031,18 @@ async fn given_journal_entry_exists(world: &mut FinancialWorld) {
     let building_id = world.building_id;
 
     let lines = vec![
-        ("604000".to_string(), dec!(50.0), dec!(0.0), "Debit".to_string()),
-        ("440000".to_string(), dec!(0.0), dec!(50.0), "Credit".to_string()),
+        (
+            "604000".to_string(),
+            dec!(50.0),
+            dec!(0.0),
+            "Debit".to_string(),
+        ),
+        (
+            "440000".to_string(),
+            dec!(0.0),
+            dec!(50.0),
+            "Credit".to_string(),
+        ),
     ];
     let entry = uc
         .create_manual_entry(
@@ -2585,7 +2625,11 @@ async fn given_call_of_amount_sent(world: &mut FinancialWorld, amount: Decimal) 
 }
 
 #[then(regex = r#"^owner with (\d+)% should have contribution of (\d+) EUR$"#)]
-async fn then_owner_pct_contribution(world: &mut FinancialWorld, _pct: Decimal, expected_amount: Decimal) {
+async fn then_owner_pct_contribution(
+    world: &mut FinancialWorld,
+    _pct: Decimal,
+    expected_amount: Decimal,
+) {
     let uc = world.owner_contribution_use_cases.as_ref().unwrap().clone();
     // Find the owner with matching percentage
     for (_name, owner_id) in &world.owner_by_name {
@@ -2595,7 +2639,7 @@ async fn then_owner_pct_contribution(world: &mut FinancialWorld, _pct: Decimal, 
             .unwrap_or_default();
         for contrib in &contribs {
             let diff = (contrib.amount - expected_amount).abs();
-            if diff < 1.0 {
+            if diff < dec!(1) {
                 return; // Found matching contribution
             }
         }
@@ -2767,7 +2811,7 @@ async fn given_owner_with_unit(world: &mut FinancialWorld, name: String) {
 async fn when_create_contribution(world: &mut FinancialWorld, name: String, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     let mut description = "BDD contribution".to_string();
-    let mut amount = 0.0;
+    let mut amount = Decimal::ZERO;
     let mut contribution_type = ContributionType::Regular;
     let mut account_code: Option<String> = None;
 
@@ -2776,7 +2820,7 @@ async fn when_create_contribution(world: &mut FinancialWorld, name: String, step
         let val = row[1].as_str();
         match key {
             "description" => description = val.to_string(),
-            "amount" => amount = val.parse().unwrap_or(0.0),
+            "amount" => amount = val.parse().unwrap_or(Decimal::ZERO),
             "contribution_type" => contribution_type = parse_contribution_type(val),
             "account_code" => account_code = Some(val.to_string()),
             _ => {}
@@ -2876,7 +2920,7 @@ async fn then_contribution_details(world: &mut FinancialWorld) {
 #[then("the amount should be correct")]
 async fn then_amount_correct(world: &mut FinancialWorld) {
     let c = world.last_contribution.as_ref().expect("contribution");
-    assert!(c.amount > 0.0, "Amount should be positive");
+    assert!(c.amount > Decimal::ZERO, "Amount should be positive");
 }
 
 #[given(regex = r#"^(\d+) contributions exist for "([^"]*)"$"#)]
@@ -2898,7 +2942,7 @@ async fn given_n_contributions(world: &mut FinancialWorld, count: usize, name: S
                 owner_id,
                 world.unit_ids.first().copied(),
                 format!("Contribution {}", i + 1),
-                100.0 * (i + 1) as f64,
+                dec!(100) * Decimal::from(i + 1),
                 ContributionType::Regular,
                 Utc::now(),
                 None,
@@ -3386,7 +3430,12 @@ async fn then_distributions_for_n_owners(world: &mut FinancialWorld, count: usiz
 }
 
 #[then(regex = r#"^"([^"]*)" should owe (\d+(?:\.\d+)?) EUR \((\d+)%\)$"#)]
-async fn then_owner_should_owe(world: &mut FinancialWorld, name: String, expected: f64, _pct: f64) {
+async fn then_owner_should_owe(
+    world: &mut FinancialWorld,
+    name: String,
+    expected: Decimal,
+    _pct: Decimal,
+) {
     let found = world
         .distribution_amounts
         .iter()
@@ -3400,7 +3449,7 @@ async fn then_owner_should_owe(world: &mut FinancialWorld, name: String, expecte
     let (_, amount) = found.unwrap();
     let diff = (amount - expected).abs();
     assert!(
-        diff < 0.02,
+        diff < dec!(0.02),
         "Expected {} to owe {}, got {} (diff: {})",
         name,
         expected,
@@ -3563,11 +3612,16 @@ async fn when_get_total_due(world: &mut FinancialWorld, name: String, _pct: f64)
 }
 
 #[then(regex = r#"^the total due should be (\d+(?:\.\d+)?) EUR \((\d+)% of (\d+) EUR\)$"#)]
-async fn then_total_due_amount(world: &mut FinancialWorld, expected: f64, _pct: f64, _total: f64) {
+async fn then_total_due_amount(
+    world: &mut FinancialWorld,
+    expected: Decimal,
+    _pct: Decimal,
+    _total: Decimal,
+) {
     let total = world.total_due.expect("total due");
     let diff = (total - expected).abs();
     assert!(
-        diff < 1.0,
+        diff < dec!(1),
         "Expected total due {}, got {} (diff: {})",
         expected,
         total,
@@ -3713,7 +3767,7 @@ async fn then_stats_include_expenses(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
     // Total expenses should be >= 0
     assert!(
-        stats.total_expenses_current_month >= 0.0,
+        stats.total_expenses_current_month >= Decimal::ZERO,
         "Expense total should be >= 0"
     );
 }
@@ -3721,13 +3775,19 @@ async fn then_stats_include_expenses(world: &mut FinancialWorld) {
 #[then("the stats should include payment totals")]
 async fn then_stats_include_payments(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
-    assert!(stats.total_paid >= 0.0, "Paid total should be >= 0");
+    assert!(
+        stats.total_paid >= Decimal::ZERO,
+        "Paid total should be >= 0"
+    );
 }
 
 #[then("the stats should include outstanding amounts")]
 async fn then_stats_include_outstanding(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
-    assert!(stats.total_pending >= 0.0, "Pending total should be >= 0");
+    assert!(
+        stats.total_pending >= Decimal::ZERO,
+        "Pending total should be >= 0"
+    );
 }
 
 #[given(regex = r#"^(\d+) transactions exist$"#)]
@@ -3830,7 +3890,7 @@ async fn then_stats_include_contributions(world: &mut FinancialWorld) {
     // Dashboard stats don't directly show contributions, but total_pending should account for them
     let stats = world.dashboard_stats.as_ref().expect("stats");
     // Just verify we have valid stats
-    assert!(stats.paid_percentage >= 0.0);
+    assert!(stats.paid_percentage >= Decimal::ZERO);
 }
 
 #[given("no financial data exists")]
@@ -3852,9 +3912,9 @@ async fn given_no_financial_data(world: &mut FinancialWorld) {
 #[then("all totals should be zero")]
 async fn then_all_totals_zero(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
-    assert_eq!(stats.total_expenses_current_month, 0.0);
-    assert_eq!(stats.total_paid, 0.0);
-    assert_eq!(stats.total_pending, 0.0);
+    assert_eq!(stats.total_expenses_current_month, Decimal::ZERO);
+    assert_eq!(stats.total_paid, Decimal::ZERO);
+    assert_eq!(stats.total_pending, Decimal::ZERO);
 }
 
 // ==================== PARSE HELPERS ====================
@@ -4030,11 +4090,11 @@ async fn when_create_invoice_draft(world: &mut FinancialWorld, step: &Step) {
     let building_id = world.building_id.unwrap();
 
     let description = get_invoice_table_value(step, "description").unwrap_or_default();
-    let amount_excl_vat: f64 = get_invoice_table_value(step, "amount_excl_vat")
+    let amount_excl_vat: Decimal = get_invoice_table_value(step, "amount_excl_vat")
         .unwrap_or("1000.0".to_string())
         .parse()
         .unwrap();
-    let vat_rate: f64 = get_invoice_table_value(step, "vat_rate")
+    let vat_rate: Decimal = get_invoice_table_value(step, "vat_rate")
         .unwrap_or("21.0".to_string())
         .parse()
         .unwrap();
@@ -4103,11 +4163,11 @@ async fn then_invoice_status(world: &mut FinancialWorld, expected: String) {
 }
 
 #[then(regex = r#"^the invoice VAT amount should be ([0-9.]+)$"#)]
-async fn then_invoice_vat_amount(world: &mut FinancialWorld, expected: f64) {
+async fn then_invoice_vat_amount(world: &mut FinancialWorld, expected: Decimal) {
     let inv = world.last_invoice.as_ref().expect("no invoice");
-    let vat = inv.vat_amount.unwrap_or(0.0);
+    let vat = inv.vat_amount.unwrap_or(Decimal::ZERO);
     assert!(
-        (vat - expected).abs() < 0.01,
+        (vat - expected).abs() < dec!(0.01),
         "Expected VAT {}, got {}",
         expected,
         vat
@@ -4115,11 +4175,11 @@ async fn then_invoice_vat_amount(world: &mut FinancialWorld, expected: f64) {
 }
 
 #[then(regex = r#"^the invoice total \(TTC\) should be ([0-9.]+)$"#)]
-async fn then_invoice_total_ttc(world: &mut FinancialWorld, expected: f64) {
+async fn then_invoice_total_ttc(world: &mut FinancialWorld, expected: Decimal) {
     let inv = world.last_invoice.as_ref().expect("no invoice");
     let ttc = inv.amount_incl_vat.unwrap_or(inv.amount);
     assert!(
-        (ttc - expected).abs() < 0.01,
+        (ttc - expected).abs() < dec!(0.01),
         "Expected TTC {}, got {}",
         expected,
         ttc
@@ -4157,8 +4217,8 @@ async fn given_draft_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Test draft invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4220,8 +4280,8 @@ async fn given_approved_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Approved invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4263,8 +4323,8 @@ async fn given_rejected_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Rejected invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4339,8 +4399,8 @@ async fn given_pending_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Pending invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4602,8 +4662,8 @@ async fn given_n_pending_invoices(world: &mut FinancialWorld, count: usize) {
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Pending invoice {}", i + 1),
-            amount_excl_vat: 1000.0,
-            vat_rate: 21.0,
+            amount_excl_vat: dec!(1000),
+            vat_rate: dec!(21),
             invoice_date: "2025-01-15T00:00:00Z".to_string(),
             due_date: None,
             supplier: None,
@@ -4632,8 +4692,8 @@ async fn given_n_approved_invoices(world: &mut FinancialWorld, count: usize) {
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Approved invoice {}", i + 1),
-            amount_excl_vat: 1000.0,
-            vat_rate: 21.0,
+            amount_excl_vat: dec!(1000),
+            vat_rate: dec!(21),
             invoice_date: "2025-01-15T00:00:00Z".to_string(),
             due_date: None,
             supplier: None,
@@ -4799,8 +4859,8 @@ async fn given_create_and_submit(world: &mut FinancialWorld) {
         building_id: world.building_id.unwrap().to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Workflow test invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4824,7 +4884,7 @@ async fn when_update_rejected(world: &mut FinancialWorld) {
     let dto = UpdateInvoiceDraftDto {
         description: Some("Corrected invoice".to_string()),
         category: None,
-        amount_excl_vat: Some(900.0),
+        amount_excl_vat: Some(dec!(900)),
         vat_rate: None,
         invoice_date: None,
         due_date: None,
@@ -4889,14 +4949,14 @@ async fn given_3_with_amounts(world: &mut FinancialWorld) {
 #[when("requesting total due for Owner 1")]
 async fn when_request_total_due(world: &mut FinancialWorld) {
     world.operation_success = true;
-    world.total_due = Some(952.50);
+    world.total_due = Some(dec!(952.50));
 }
 
 #[then(regex = r#"^the total amount due should be ([0-9.]+) EUR$"#)]
-async fn then_total_due(world: &mut FinancialWorld, expected: f64) {
-    let total = world.total_due.unwrap_or(0.0);
+async fn then_total_due(world: &mut FinancialWorld, expected: Decimal) {
+    let total = world.total_due.unwrap_or(Decimal::ZERO);
     assert!(
-        (total - expected).abs() < 0.01,
+        (total - expected).abs() < dec!(0.01),
         "Expected {}, got {}",
         expected,
         total
@@ -4904,12 +4964,12 @@ async fn then_total_due(world: &mut FinancialWorld, expected: f64) {
 }
 
 #[then(regex = r#"^Owner (\d+) amount due should be ([0-9.]+) EUR$"#)]
-async fn then_owner_amount_due(_world: &mut FinancialWorld, _owner_num: usize, _expected: f64) {
+async fn then_owner_amount_due(_world: &mut FinancialWorld, _owner_num: usize, _expected: Decimal) {
     // Distribution amounts verified through charge_distribution use cases
 }
 
 #[then(regex = r#"^the total distributed should be ([0-9.]+) EUR$"#)]
-async fn then_total_distributed(_world: &mut FinancialWorld, _expected: f64) {
+async fn then_total_distributed(_world: &mut FinancialWorld, _expected: Decimal) {
     // Verified by sum of distributions
 }
 
@@ -5058,10 +5118,12 @@ async fn when_calculate_penalty(world: &mut FinancialWorld) {
 }
 
 #[then(regex = r#"^the penalty should be (\d+) EUR$"#)]
-async fn then_penalty_amount(world: &mut FinancialWorld, expected: f64) {
-    let penalty = world.last_reminder_penalty.unwrap_or(0.0);
+async fn then_penalty_amount(world: &mut FinancialWorld, expected: Decimal) {
+    use rust_decimal::prelude::FromPrimitive;
+    let penalty_f64 = world.last_reminder_penalty.unwrap_or(0.0);
+    let penalty = Decimal::from_f64(penalty_f64).unwrap_or(Decimal::ZERO);
     assert!(
-        (penalty - expected).abs() < 1.0,
+        (penalty - expected).abs() < dec!(1),
         "Expected {} EUR, got {}",
         expected,
         penalty
@@ -5084,7 +5146,7 @@ async fn given_pending_first_reminder(world: &mut FinancialWorld) {
         world.setup_database().await;
     }
     if world.expense_id.is_none() {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
     if world.owner_by_name.is_empty() {
         let owner_id = world
@@ -5218,7 +5280,7 @@ async fn then_can_add_tracking(world: &mut FinancialWorld) {
 #[given(regex = r#"^(\d+) overdue expenses in the organization$"#)]
 async fn given_n_overdue(world: &mut FinancialWorld, count: usize) {
     for _ in 0..count {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
 }
 
@@ -5271,7 +5333,7 @@ async fn then_stats_by_level(_world: &mut FinancialWorld) {}
 #[given(regex = r#"^(\d+) overdue expenses without reminders$"#)]
 async fn given_overdue_without_reminders(world: &mut FinancialWorld, count: usize) {
     for _ in 0..count {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
 }
 
@@ -5366,7 +5428,7 @@ async fn then_request_forbidden_2(world: &mut FinancialWorld) {
 #[when("I create a payment reminder")]
 async fn when_create_reminder(world: &mut FinancialWorld) {
     if world.expense_id.is_none() {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
     if world.owner_by_name.is_empty() {
         let owner_id = world
@@ -5414,7 +5476,7 @@ async fn given_formal_notice(world: &mut FinancialWorld) {
         world.setup_database().await;
     }
     // Always create a 65-day expense: FormalNotice requires >= 60 days overdue
-    given_overdue_expense(world, 100.0, 65).await;
+    given_overdue_expense(world, dec!(100), 65).await;
     if world.owner_by_name.is_empty() {
         let owner_id = world
             .create_owner_sql("Formal", "Notice", "formal@test.be")
@@ -6612,7 +6674,7 @@ async fn given_user_with_role(world: &mut FinancialWorld, name: String, role: St
 async fn when_create_simple_expense(world: &mut FinancialWorld, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     let mut description = "BDD Expense".to_string();
-    let mut amount = 0.0f64;
+    let mut amount = Decimal::ZERO;
     let mut _category = "maintenance".to_string();
 
     for row in &table.rows {
@@ -6620,7 +6682,7 @@ async fn when_create_simple_expense(world: &mut FinancialWorld, step: &Step) {
         let val = row[1].trim();
         match key {
             "description" => description = val.to_string(),
-            "amount" => amount = val.parse().unwrap_or(0.0),
+            "amount" => amount = val.parse().unwrap_or(Decimal::ZERO),
             "category" => _category = val.to_string(),
             _ => {}
         }
@@ -6675,7 +6737,7 @@ async fn then_expense_created_with_status(world: &mut FinancialWorld, expected: 
 }
 
 #[then(regex = r#"^the amount should be (\d+(?:\.\d+)?)$"#)]
-async fn then_expense_amount(world: &mut FinancialWorld, expected: f64) {
+async fn then_expense_amount(world: &mut FinancialWorld, expected: Decimal) {
     // Amount verified through creation success
     assert!(
         world.operation_success,
@@ -6688,16 +6750,16 @@ async fn then_expense_amount(world: &mut FinancialWorld, expected: f64) {
 async fn when_create_expense_with_tva(world: &mut FinancialWorld, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     let mut description = "BDD Expense TVA".to_string();
-    let mut amount_excl_vat = 0.0f64;
-    let mut vat_rate = 21.0f64;
+    let mut amount_excl_vat = Decimal::ZERO;
+    let mut vat_rate = dec!(21);
 
     for row in &table.rows {
         let key = row[0].trim();
         let val = row[1].trim();
         match key {
             "description" => description = val.to_string(),
-            "amount_excl_vat" => amount_excl_vat = val.parse().unwrap_or(0.0),
-            "vat_rate" => vat_rate = val.parse().unwrap_or(21.0),
+            "amount_excl_vat" => amount_excl_vat = val.parse().unwrap_or(Decimal::ZERO),
+            "vat_rate" => vat_rate = val.parse().unwrap_or(dec!(21)),
             _ => {}
         }
     }
@@ -6744,11 +6806,11 @@ async fn then_expense_created(world: &mut FinancialWorld) {
 }
 
 #[then(regex = r#"^the amount_incl_vat should be (\d+(?:\.\d+)?)$"#)]
-async fn then_amount_incl_vat(world: &mut FinancialWorld, expected: f64) {
+async fn then_amount_incl_vat(world: &mut FinancialWorld, expected: Decimal) {
     if let Some(ref inv) = world.last_invoice {
         let ttc = inv.amount_incl_vat.unwrap_or(inv.amount);
         assert!(
-            (ttc - expected).abs() < 0.01,
+            (ttc - expected).abs() < dec!(0.01),
             "Expected amount_incl_vat {}, got {}",
             expected,
             ttc
@@ -6801,8 +6863,8 @@ async fn given_draft_expense(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Draft expense for BDD".to_string(),
-        amount_excl_vat: 500.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(500),
+        vat_rate: dec!(21),
         invoice_date: chrono::Utc::now().to_rfc3339(),
         due_date: None,
         supplier: None,
@@ -7030,7 +7092,7 @@ async fn given_n_expenses_for_building(world: &mut FinancialWorld, count: usize)
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Expense {} for building list test", i + 1),
-            amount: 100.0 * (i + 1) as f64,
+            amount: dec!(100) * Decimal::from(i + 1),
             expense_date: chrono::Utc::now().to_rfc3339(),
             supplier: None,
             invoice_number: None,
@@ -7084,8 +7146,8 @@ async fn given_n_expenses_with_status(world: &mut FinancialWorld, count: usize, 
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Filtered expense {} status {}", i + 1, status),
-            amount_excl_vat: 200.0,
-            vat_rate: 21.0,
+            amount_excl_vat: dec!(200),
+            vat_rate: dec!(21),
             invoice_date: chrono::Utc::now().to_rfc3339(),
             due_date: None,
             supplier: None,
@@ -7175,8 +7237,8 @@ async fn then_all_expenses_have_status(world: &mut FinancialWorld, _expected: St
 async fn when_create_expense_with_lines(world: &mut FinancialWorld, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     // Parse line items to compute total amount
-    let mut total_excl_vat = 0.0f64;
-    let mut vat_total = 0.0f64;
+    let mut total_excl_vat = Decimal::ZERO;
+    let mut vat_total = Decimal::ZERO;
     let mut headers_skipped = false;
 
     for row in &table.rows {
@@ -7185,12 +7247,12 @@ async fn when_create_expense_with_lines(world: &mut FinancialWorld, step: &Step)
             continue;
         }
         if row.len() >= 4 {
-            let qty: f64 = row[1].trim().parse().unwrap_or(1.0);
-            let unit_price: f64 = row[2].trim().parse().unwrap_or(0.0);
-            let vat_rate: f64 = row[3].trim().parse().unwrap_or(21.0);
+            let qty: Decimal = row[1].trim().parse().unwrap_or(dec!(1));
+            let unit_price: Decimal = row[2].trim().parse().unwrap_or(Decimal::ZERO);
+            let vat_rate: Decimal = row[3].trim().parse().unwrap_or(dec!(21));
             let line_excl = qty * unit_price;
             total_excl_vat += line_excl;
-            vat_total += line_excl * vat_rate / 100.0;
+            vat_total += line_excl * vat_rate / dec!(100);
         }
     }
 
@@ -7203,10 +7265,10 @@ async fn when_create_expense_with_lines(world: &mut FinancialWorld, step: &Step)
         category: ExpenseCategory::Maintenance,
         description: "Multi-line invoice expense".to_string(),
         amount_excl_vat: total_excl_vat,
-        vat_rate: if total_excl_vat > 0.0 {
-            vat_total / total_excl_vat * 100.0
+        vat_rate: if total_excl_vat > Decimal::ZERO {
+            vat_total / total_excl_vat * dec!(100)
         } else {
-            21.0
+            dec!(21)
         },
         invoice_date: chrono::Utc::now().to_rfc3339(),
         due_date: None,

--- a/backend/tests/e2e_call_for_funds.rs
+++ b/backend/tests/e2e_call_for_funds.rs
@@ -96,8 +96,10 @@ async fn create_call_for_funds_fixtures(
     let _ = app_state
         .unit_owner_use_cases
         .add_owner_to_unit(
-            unit_id, owner_id, 0.25, // 25% ownership share
-            true, // is primary contact
+            unit_id,
+            owner_id,
+            rust_decimal_macros::dec!(0.25), // 25% ownership share
+            true,                            // is primary contact
         )
         .await;
     // Note: ownership validation may require total = 100%, so we accept any result here

--- a/backend/tests/integration_unit_owner.rs
+++ b/backend/tests/integration_unit_owner.rs
@@ -4,7 +4,6 @@ use koprogo_api::domain::entities::{Owner, Unit, UnitOwner};
 use koprogo_api::infrastructure::database::{
     create_pool, PostgresOwnerRepository, PostgresUnitOwnerRepository, PostgresUnitRepository,
 };
-use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serial_test::serial;
 use testcontainers_modules::postgres::Postgres;

--- a/frontend/src/components/meetings/QuorumPanel.test.ts
+++ b/frontend/src/components/meetings/QuorumPanel.test.ts
@@ -22,7 +22,13 @@ vi.mock("../../lib/api", () => ({
   api: {
     post: vi.fn().mockResolvedValue({
       quorum_reached: true,
-      meeting: { id: "m1", quorum_validated: true, present_quotas: 800, total_quotas: 1000, quorum_percentage: 80.0 },
+      meeting: {
+        id: "m1",
+        quorum_validated: true,
+        present_quotas: 800,
+        total_quotas: 1000,
+        quorum_percentage: 80.0,
+      },
       message: "OK",
     }),
   },
@@ -53,7 +59,12 @@ describe("QuorumPanel", () => {
   it("shows validated badge when quorum already validated", () => {
     render(QuorumPanel, {
       props: {
-        meeting: { ...baseMeeting, quorum_validated: true, present_quotas: 800, quorum_percentage: 80.0 },
+        meeting: {
+          ...baseMeeting,
+          quorum_validated: true,
+          present_quotas: 800,
+          quorum_percentage: 80.0,
+        },
         canManage: true,
       },
     });
@@ -89,7 +100,9 @@ describe("QuorumPanel", () => {
     render(QuorumPanel, {
       props: { meeting: baseMeeting, canManage: true },
     });
-    const presentInput = screen.getByTestId("quorum-present-input") as HTMLInputElement;
+    const presentInput = screen.getByTestId(
+      "quorum-present-input",
+    ) as HTMLInputElement;
     await fireEvent.input(presentInput, { target: { value: "600" } });
     // Check that 60.0% is shown somewhere in the preview
     const preview = screen.getByText(/60\.0%/);

--- a/frontend/src/components/resolutions/ResolutionCreateForm.test.ts
+++ b/frontend/src/components/resolutions/ResolutionCreateForm.test.ts
@@ -54,10 +54,7 @@ describe("ResolutionCreateForm", () => {
     const options = Array.from(select.options);
     expect(options).toHaveLength(2);
     // Values should be snake_case to match backend serde
-    expect(options.map((o) => o.value)).toEqual([
-      "ordinary",
-      "extraordinary",
-    ]);
+    expect(options.map((o) => o.value)).toEqual(["ordinary", "extraordinary"]);
   });
 
   it("has majority dropdown with 4 options (absolute/two_thirds/four_fifths/unanimity)", () => {

--- a/frontend/src/components/tickets/TicketAssignModal.test.ts
+++ b/frontend/src/components/tickets/TicketAssignModal.test.ts
@@ -74,8 +74,6 @@ describe("TicketAssignModal", () => {
     render(TicketAssignModal, {
       props: { open: true, ticketId: "ticket-1" },
     });
-    expect(
-      screen.getByTestId("ticket-assign-cancel-btn"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("ticket-assign-cancel-btn")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ui/FormInput.test.ts
+++ b/frontend/src/components/ui/FormInput.test.ts
@@ -33,10 +33,7 @@ describe("FormInput", () => {
     render(FormInput, {
       props: { id: "test", label: "X", error: "Bad" },
     });
-    expect(screen.getByRole("textbox")).toHaveAttribute(
-      "aria-invalid",
-      "true",
-    );
+    expect(screen.getByRole("textbox")).toHaveAttribute("aria-invalid", "true");
   });
 
   it("shows hint text when no error", () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -105,8 +105,8 @@ export async function apiFetch<T = any>(
         "token expired": "Session expirée. Veuillez vous reconnecter.",
         "invalid token": "Session expirée. Veuillez vous reconnecter.",
         "not found": "Ressource introuvable.",
-        "unauthorized": "Authentification requise.",
-        "forbidden": "Accès refusé.",
+        unauthorized: "Authentification requise.",
+        forbidden: "Accès refusé.",
       };
       const mapped = knownErrors[errorMessage.toLowerCase().trim()];
       if (mapped) errorMessage = mapped;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -131,7 +131,12 @@ export interface Expense {
     | "Management"
     | "Other";
   payment_status: "Pending" | "Paid" | "Overdue" | "Cancelled";
-  approval_status?: "draft" | "pending_approval" | "approved" | "rejected" | null;
+  approval_status?:
+    | "draft"
+    | "pending_approval"
+    | "approved"
+    | "rejected"
+    | null;
   paid_date?: string;
   supplier?: string;
   invoice_number?: string;


### PR DESCRIPTION
## Summary

Rend `make ci` vert localement sur backend (clippy + fmt) + frontend prettier auto-formatted.

### Backend ✅
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo fmt --check` clean
- bdd_financial.rs : ~50 sites Decimal cleanup (#443 partial scope)
- ticket_handlers.rs : pre-existing clippy::option-as-ref-deref fix
- benches/load_tests.rs : 4 sites Decimal

### Frontend ✅
- `npx prettier --check .` clean (after 118 files auto-formatted)

### ⚠️ Non couvert par cette PR

- **astro check** : 60 erreurs pré-existantes (Svelte ComponentImport types) — antérieur EXP-003, à traiter en story dédiée
- **npm audit** : non exécuté (gating astro check)

## Test plan

- [ ] CI GitHub Actions vert sur cette branche
- [ ] Reviewer humain valide la promotion vers dev
- [ ] Une fois mergé : PR #441 dev → integration peut être ré-évaluée

## Refs

- Part of #443 (BDD-MIGRATION-001)
- Unblocks #441 (dev → integration) côté backend CI

🤖 Generated by Claude Opus 4.7 sous Claude Desktop primary runtime.