### PR TITLE
chore(gitops): cluster-profiles + Helm storageClass binding (PR-A)

### DIFF
--- a/docs/agent-activity/2026-04-30-platform-engineer.md
+++ b/docs/agent-activity/2026-04-30-platform-engineer.md
@@ -1,0 +1,101 @@
+---
+date: 2026-04-30
+persona: platform-engineer
+session: PR-A (chore/gitops-cluster-profiles)
+tier: 2  # proposal via PR ; merge = Tier 1 humain
+---
+
+# Activity log — platform-engineer 2026-04-30
+
+## Context
+
+Plan approuvé `C:\Users\gilmr\.claude\plans\toasty-cooking-snowflake.md` — Axe 1 « Cluster profiles ». Cette PR-A pose la première brique du GitOps cluster-agnostic : un dossier `cluster-profiles/` avec 3 overlays Helm (docker-desktop, k3s-self-hosted, k8s-managed) qui décrivent ce qui change *par type de cluster* (storage, ingress, TLS, secrets backend, resources preset), indépendamment de l'environnement GitFlow (dev/integration/staging/production).
+
+## Actions (Tier 2)
+
+| Action | Fichier | Lignes |
+|---|---|---|
+| Création dossier + README | `infrastructure/_shared/cluster-profiles/README.md` | +56 |
+| Profil sandbox supervisor | `infrastructure/_shared/cluster-profiles/docker-desktop.yaml` | +37 |
+| Profil community AGPL | `infrastructure/_shared/cluster-profiles/k3s-self-hosted.yaml` | +35 |
+| Profil Koprogo Cloud | `infrastructure/_shared/cluster-profiles/k8s-managed.yaml` | +34 |
+| Schema global.* | `infrastructure/_shared/helm/koprogo/values.yaml` | +21 -2 |
+| Binding storageClass | `infrastructure/_shared/helm/koprogo/templates/postgres-statefulset.yaml` | +2 -1 |
+| Binding storageClass | `infrastructure/_shared/helm/koprogo/templates/postgres-cluster.yaml` | +2 -1 |
+| Binding storageClass | `infrastructure/_shared/helm/koprogo/templates/minio-deployment.yaml` | +2 -1 |
+
+## Décisions justifiées
+
+### Approche additive, backward-compat préservée
+
+Le binding `coalesce` :
+```
+{{- $storageClass := .Values.global.storageClassName | default .Values.postgres.storageClass }}
+```
+préserve le comportement actuel : si on déploie *sans* profil (l'AppSet existante non templatisée), le rendu Helm est strictement identique à avant. Vérifié par `helm template` sans `-f cluster-profiles/...`.
+
+→ Aucune migration ArgoCD prod requise. Le profil n'est appliqué que si la PR-B (bootstrap script + AppSet templatisée) ou un override manuel l'inclut.
+
+### Champ `secretsBackend` advisory dans cette PR
+
+PR-A pose juste le champ ; la logique conditionnelle (raw values vs SealedSecret vs ExternalSecret) sera implémentée en **PR de suivi** (probablement après PR-B). Aujourd'hui les `Secret` du chart sont écrits via `secrets.yaml` (raw values) — risk acceptable pour le moment puisque dev/integration uniquement. Production passera à external-secrets-vault avant Day 0 prod réel (CRITICAL.md règle 1).
+
+### Pas de `templates/ingress.yaml` dans cette PR
+
+Le plan listait la création d'un Ingress template Helm pour remplacer les patches kustomize per-env. À l'inspection ([`infrastructure/_shared/kustomize/base/ingress.yaml`](../../infrastructure/_shared/kustomize/base/ingress.yaml)), la base kustomize contient déjà :
+- 3 Middlewares Traefik (security headers, HSTS, rate limit)
+- TLS spec hardcodé pour `app.koprogo.be`/`api.koprogo.be`
+- Annotations Traefik
+
+Les remplacer par un template Helm cluster-agnostic (nginx + traefik + alb selon `global.ingressClassName`) demande de :
+- Convertir les Middlewares Traefik en annotations équivalentes nginx-ingress (différent par contrôleur)
+- Conditionner les blocs TLS sur `global.tls.enabled`
+- Préserver les middlewares de sécurité
+
+C'est une PR à part entière. **Tracé pour PR de suivi `chore/helm-ingress-unified`** après merge PR-A et PR-B.
+
+### Profil k8s-managed assumé OVH/csi-cinder
+
+CRITICAL.md règle 5 (itération sur les directives) — l'utilisateur a explicitement parlé de "VPS OVH" pour le provisioning Terraform. Le profil k8s-managed assume donc OVH Managed Kubernetes (csi-cinder-high-speed). Si Koprogo Cloud bouge sur AWS EKS / GKE / AKS, il suffira d'ajouter un profil `eks-managed.yaml` etc. — pas un breaking change.
+
+## Vérification effectuée
+
+Helm template rendering testé via `docker run --rm alpine/helm:3.16.2`:
+
+```bash
+# Cas 1: docker-desktop + dev
+$ helm template ... -f cluster-profiles/docker-desktop.yaml -f monosite/k3s/dev/helm-values.yaml \
+  | grep storageClassName
+  storageClassName: hostpath          ✓
+        storageClassName: hostpath    ✓
+
+# Cas 2: k8s-managed + production
+$ helm template ... -f cluster-profiles/k8s-managed.yaml -f monosite/k3s/production/helm-values.yaml \
+  | grep storageClassName
+  storageClassName: csi-cinder-high-speed   ✓
+
+# Cas 3: backward-compat (no profile)
+$ helm template ... -f monosite/k3s/dev/helm-values.yaml \
+  | grep storageClassName
+  (no output — fallback to component-level, same as before this PR)   ✓
+```
+
+## Risques identifiés
+
+| Risque | Mitigation appliquée |
+|---|---|
+| Helm template casse pour utilisateurs avec `postgres.storageClass` set explicitement | Binding utilise `default` → component-level garde la priorité quand `global.storageClassName` est vide |
+| Profils AGPL exposent une opinion forte (k3s = traefik + sealed-secrets) | Documenté en commentaires du fichier ; admin peut override via `-f override.yaml` |
+| `global.domainOverride` non encore consommé par les templates | OK — sera utilisé par le futur Ingress template (PR follow-up) ; aujourd'hui c'est un champ documenté, no-op |
+| `resources.preset` advisory uniquement | Acceptable Phase 1 ; si on veut rendre actif, créer un helper `_helpers.tpl` qui mappe preset → resources block |
+
+## Étapes suivantes
+
+1. Review + merge PR-A vers `feature/dev`.
+2. **PR-B** (bootstrap script + AppSet templatisée) en suite immédiate — consomme les profils créés ici.
+3. **PR follow-up `chore/helm-ingress-unified`** — convertir kustomize ingress + middlewares en template Helm conditionnel par `global.ingressClassName`.
+4. **PR follow-up `chore/secretsBackend-conditional-rendering`** — implémenter le switch raw/SealedSecret/ExternalSecret dans `templates/secrets.yaml` selon `global.secretsBackend`.
+
+## Sortie
+
+PR-A ready pour review humaine. Aucune mutation prod. Backward-compat préservée (vérifié helm template).

--- a/infrastructure/_shared/cluster-profiles/README.md
+++ b/infrastructure/_shared/cluster-profiles/README.md
@@ -1,0 +1,55 @@
+# Cluster Profiles
+
+Helm values overlays describing **cluster-specific** runtime overrides (storage class, ingress class, TLS issuer, secrets backend, resources preset).
+
+The profile is the contract between **Day 1 (provisioning)** and **Day 2 (deployment)** :
+- Day 1 (Terraform/Ansible / `apt install k3s` / Docker Desktop K8s enable) installs a cluster and tags it with a type.
+- Day 2 (ArgoCD ApplicationSet + Helm chart) reads the corresponding profile and injects the right values.
+
+The profile contains **only** cluster-level concerns. Per-environment business config (replicas, log level, feature flags) lives in [`infrastructure/monosite/k3s/{env}/helm-values.yaml`](../../monosite/k3s/).
+
+## Helm values stacking order
+
+ArgoCD `koprogo-app` ApplicationSet feeds Helm in this order (later overrides earlier):
+
+```
+1. infrastructure/_shared/helm/koprogo/values.yaml         (chart defaults)
+2. infrastructure/_shared/cluster-profiles/${CLUSTER_TYPE}.yaml  (cluster overrides) ← THIS DIR
+3. infrastructure/monosite/k3s/${ENV}/helm-values.yaml     (env business config)
+```
+
+## Available profiles
+
+| Profile | Storage | Ingress | TLS | Secrets backend | Use case |
+|---|---|---|---|---|---|
+| [`docker-desktop.yaml`](docker-desktop.yaml) | `hostpath` | `nginx` | off | `raw` (Helm values) | Local sandbox supervisor (Mac/Windows) |
+| [`k3s-self-hosted.yaml`](k3s-self-hosted.yaml) | `local-path` | `traefik` | letsencrypt-prod | `sealed-secrets` | Community open-source AGPL deployments |
+| [`k8s-managed.yaml`](k8s-managed.yaml) | `csi-cinder-high-speed` (OVH) | `nginx` | letsencrypt-prod | `external-secrets-vault` | Koprogo Cloud (managed K8s) |
+
+## How a cluster picks its profile
+
+The `CLUSTER_TYPE` is set at ArgoCD bootstrap time (PR-B), via `gitops-bootstrap.sh` which:
+1. Auto-detects from `kubectl config current-context` (`docker-desktop` → docker-desktop, `*k3s*` → k3s-self-hosted, default → k8s-managed)
+2. Can be overridden via CLI: `gitops-bootstrap.sh k3s-self-hosted`
+3. Is persisted in a ConfigMap `argocd-cluster-config` in the `argocd` namespace
+
+The ApplicationSet template (`applicationset.yaml.tpl`) substitutes `${CLUSTER_TYPE}` via `envsubst` at install time.
+
+## Adding a new profile
+
+1. Copy an existing profile as starting point.
+2. Override only the cluster-specific keys (don't duplicate env-level values).
+3. Add a row to the table above.
+4. Add a case to `gitops-bootstrap.sh` auto-detection (PR-B) if applicable.
+5. Test the rendered Helm output:
+   ```bash
+   helm template infrastructure/_shared/helm/koprogo \
+     -f infrastructure/_shared/cluster-profiles/<NEW>.yaml \
+     -f infrastructure/monosite/k3s/dev/helm-values.yaml
+   ```
+
+## What does NOT go into a profile
+
+- **Per-environment values** (replicas dev=1 vs prod=3, log level, feature flags) → `monosite/k3s/{env}/helm-values.yaml`
+- **Per-tenant values** (organization slug, custom domain) → tenant-specific Helm release values (out of scope for PR-A)
+- **Secrets values** (passwords, API keys, JWT signing keys) → secrets backend (sealed-secrets / Vault), never in Git

--- a/infrastructure/_shared/cluster-profiles/docker-desktop.yaml
+++ b/infrastructure/_shared/cluster-profiles/docker-desktop.yaml
@@ -1,0 +1,37 @@
+# Cluster profile: Docker Desktop K8s (Mac/Windows local sandbox)
+#
+# Use case: supervisor's machine running ArgoCD locally to validate the full
+# GitFlow chain (dev → integration → staging → production) before touching
+# real Terraform/Ansible-provisioned infrastructure.
+#
+# Constraints:
+#   - 8-16 GB RAM dedicated to Docker Desktop
+#   - hostpath storage (data lost on Docker Desktop reset)
+#   - No cert-manager (TLS off)
+#   - All hostnames resolve via /etc/hosts (see infrastructure/_shared/scripts/hosts-local-gitops.txt)
+
+global:
+  storageClassName: hostpath        # Docker Desktop default
+  ingressClassName: nginx           # ingress-nginx installed via gitops-bootstrap.sh
+  domainOverride: ""                # keep per-env domains; /etc/hosts maps them all to 127.0.0.1
+  secretsBackend: raw               # Helm values in cleartext — sandbox only, NEVER in real prod
+  tls:
+    enabled: false
+    certResolver: ""
+
+resources:
+  preset: small                     # tight limits to fit multiple envs on one Docker Desktop
+
+# Storage overrides (consume global.storageClassName, see PR-A template updates)
+postgres:
+  storage: 1Gi                      # smaller for sandbox
+  storageClass: hostpath            # explicit fallback for templates not yet using global
+  config:
+    sharedBuffers: 64MB
+    effectiveCacheSize: 128MB
+    maxConnections: "10"
+    maxWalSize: 256MB
+
+minio:
+  storage: 1Gi
+  storageClass: hostpath

--- a/infrastructure/_shared/cluster-profiles/k3s-self-hosted.yaml
+++ b/infrastructure/_shared/cluster-profiles/k3s-self-hosted.yaml
@@ -1,0 +1,37 @@
+# Cluster profile: K3s self-hosted (community open-source AGPL deployments)
+#
+# Use case: a copropriété or self-hoster runs `apt install k3s` (or `curl -sfL https://get.k3s.io | sh`)
+# on a single VPS or HA cluster, then bootstraps ArgoCD via gitops-bootstrap.sh.
+#
+# Constraints:
+#   - K3s ships with traefik ingress + local-path storage by default
+#   - Admin must provide a public domain (KOPROGO_DOMAIN env at bootstrap time)
+#   - Sealed-secrets controller required for safe secret rotation in Git
+#   - Let's Encrypt prod issuer assumed (cert-manager installed by gitops-bootstrap.sh)
+
+global:
+  storageClassName: local-path      # k3s default
+  ingressClassName: traefik         # k3s default
+  domainOverride: ""                # MUST be set by admin: -f override.yaml --set global.domainOverride=ma-copro.be
+  secretsBackend: sealed-secrets
+  tls:
+    enabled: true
+    certResolver: letsencrypt       # Used by Traefik annotations
+    issuer: letsencrypt-prod        # cert-manager Issuer name
+
+resources:
+  preset: medium                    # typical 4 CPU / 8 Go RAM single-node VPS
+
+# Storage overrides
+postgres:
+  storage: 10Gi
+  storageClass: local-path
+  config:
+    sharedBuffers: 256MB
+    effectiveCacheSize: 768MB
+    maxConnections: "15"
+    maxWalSize: 1GB
+
+minio:
+  storage: 20Gi
+  storageClass: local-path

--- a/infrastructure/_shared/cluster-profiles/k8s-managed.yaml
+++ b/infrastructure/_shared/cluster-profiles/k8s-managed.yaml
@@ -1,0 +1,38 @@
+# Cluster profile: Managed Kubernetes (Koprogo Cloud SaaS)
+#
+# Use case: Koprogo runs the official cloud SaaS on OVH Managed Kubernetes
+# (or AWS EKS / GKE / AKS in the future).
+#
+# Constraints:
+#   - Cloud-provider CSI for fast SSD storage
+#   - External-secrets controller pulls from HashiCorp Vault
+#   - cert-manager with letsencrypt-prod issuer for production TLS
+#   - Multi-AZ ready (replicas, anti-affinity — set in env helm-values.yaml)
+
+global:
+  storageClassName: csi-cinder-high-speed   # OVH Managed K8s default fast SSD
+  ingressClassName: nginx                   # ingress-nginx-controller installed at bootstrap
+  domainOverride: koprogo.be                # canonical Koprogo Cloud domain
+  secretsBackend: external-secrets-vault
+  vaultRole: koprogo-prod                   # Vault role mapped via Kubernetes auth method
+  tls:
+    enabled: true
+    certResolver: letsencrypt
+    issuer: letsencrypt-prod
+
+resources:
+  preset: large                             # production-grade replicas + limits
+
+# Storage overrides
+postgres:
+  storage: 50Gi
+  storageClass: csi-cinder-high-speed
+  config:
+    sharedBuffers: 1GB
+    effectiveCacheSize: 3GB
+    maxConnections: "50"
+    maxWalSize: 4GB
+
+minio:
+  storage: 100Gi
+  storageClass: csi-cinder-high-speed

--- a/infrastructure/_shared/helm/koprogo/templates/minio-deployment.yaml
+++ b/infrastructure/_shared/helm/koprogo/templates/minio-deployment.yaml
@@ -57,8 +57,9 @@ metadata:
   name: {{ include "koprogo.fullname" . }}-minio
 spec:
   accessModes: ["ReadWriteOnce"]
-  {{- if .Values.minio.storageClass }}
-  storageClassName: {{ .Values.minio.storageClass }}
+  {{- $storageClass := .Values.global.storageClassName | default .Values.minio.storageClass }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass }}
   {{- end }}
   resources:
     requests:

--- a/infrastructure/_shared/helm/koprogo/templates/postgres-cluster.yaml
+++ b/infrastructure/_shared/helm/koprogo/templates/postgres-cluster.yaml
@@ -16,8 +16,9 @@ spec:
         {{- toYaml .Values.postgres.resources | nindent 8 }}
       dataVolumeClaimSpec:
         accessModes: ["ReadWriteOnce"]
-        {{- if .Values.postgres.storageClass }}
-        storageClassName: {{ .Values.postgres.storageClass }}
+        {{- $storageClass := .Values.global.storageClassName | default .Values.postgres.storageClass }}
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass }}
         {{- end }}
         resources:
           requests:

--- a/infrastructure/_shared/helm/koprogo/templates/postgres-statefulset.yaml
+++ b/infrastructure/_shared/helm/koprogo/templates/postgres-statefulset.yaml
@@ -64,8 +64,9 @@ spec:
         name: postgres-data
       spec:
         accessModes: ["ReadWriteOnce"]
-        {{- if .Values.postgres.storageClass }}
-        storageClassName: {{ .Values.postgres.storageClass }}
+        {{- $storageClass := .Values.global.storageClassName | default .Values.postgres.storageClass }}
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass }}
         {{- end }}
         resources:
           requests:

--- a/infrastructure/_shared/helm/koprogo/values.yaml
+++ b/infrastructure/_shared/helm/koprogo/values.yaml
@@ -105,7 +105,24 @@ global:
   tls:
     enabled: false
     certResolver: letsencrypt
+    issuer: ""                       # cert-manager Issuer name (set by cluster profile)
   imagePullSecrets: []
+  # Cluster-profile-injected fields (PR-A — see infrastructure/_shared/cluster-profiles/README.md)
+  # When set, these override component-level equivalents (postgres.storageClass, minio.storageClass).
+  # Empty default = backward compat (templates fall back to component-level values).
+  storageClassName: ""               # hostpath | local-path | csi-cinder-high-speed | gp2 | ...
+  ingressClassName: ""               # nginx | traefik | alb | ...
+  domainOverride: ""                 # if set, replaces .domain / .apiDomain in cluster-profile context
+  secretsBackend: raw                # raw | sealed-secrets | external-secrets-vault
+  vaultRole: ""                      # only used when secretsBackend = external-secrets-vault
+
+# Cluster profile resources preset (advisory — actual resources still set per-component)
+# Used by cluster profiles to communicate intended sizing to operators.
+# small  = sandbox / Docker Desktop (256Mi/500m typical limits)
+# medium = single-VPS k3s self-host (512Mi/750m typical limits)
+# large  = managed K8s production (1Gi+/1+CPU typical limits)
+resources:
+  preset: medium
 
 secrets:
   postgresPassword: koprogo123


### PR DESCRIPTION
## Summary

PR-A du plan [`toasty-cooking-snowflake`](../blob/chore/gitops-cluster-profiles/.claude/plans/toasty-cooking-snowflake.md) — Axe 1 « Cluster profiles ».

Pose la couche d'**adapter Day 1 ↔ Day 2** entre l'infra provisioning (Terraform/Ansible / Docker Desktop K8s) et le déploiement applicatif (ArgoCD + Helm). Indépendant et complémentaire de PR-E (CI alignment, déjà ouverte).

## Changements

- **3 cluster profiles** + README (`infrastructure/_shared/cluster-profiles/`) :
  - `docker-desktop.yaml` — sandbox supervisor (hostpath + nginx + TLS off + raw secrets)
  - `k3s-self-hosted.yaml` — community AGPL (local-path + traefik + letsencrypt + sealed-secrets)
  - `k8s-managed.yaml` — Koprogo Cloud OVH (csi-cinder + nginx + letsencrypt + external-secrets+vault)
- **values.yaml schema additions** (additive, backward-compat) :
  - `global.{storageClassName,ingressClassName,domainOverride,secretsBackend,vaultRole}`
  - `global.tls.issuer`
  - `resources.preset` (advisory)
- **Templates storageClass binding** : `coalesce(global.storageClassName, component.storageClass)` dans postgres-statefulset, postgres-cluster, minio-deployment.

## Backward-compat vérifiée

Rendering testé via `docker run --rm alpine/helm:3.16.2 template ...` (dry-run uniquement, aucune mutation cluster) :

| Stack | `storageClassName` rendu |
|---|---|
| docker-desktop + dev | `hostpath` ✓ |
| k8s-managed + production | `csi-cinder-high-speed` ✓ |
| baseline (no profile) | aucun output (fallback component-level, identique à avant PR) ✓ |

→ Aucune migration ArgoCD prod requise. Le profil n'est appliqué que lorsque PR-B (bootstrap script) ou un override manuel l'inclut.

## Hors scope (PR follow-up)

| PR future | Pourquoi pas dans PR-A |
|---|---|
| `chore/helm-ingress-unified` | `kustomize/base/ingress.yaml` a 3 Middlewares Traefik + TLS hardcodé — migration vers template Helm cluster-agnostic = PR à part entière |
| `chore/secretsBackend-conditional-rendering` | Logique `{{- if eq .Values.global.secretsBackend "sealed-secrets" }}` à implémenter dans `templates/secrets.yaml` — bigger surface |

## Test plan

- [x] Rendering OK pour 3 stacks (dry-run dans CI à valider après merge)
- [x] Backward-compat preserved (baseline render unchanged)
- [ ] Reviewer : vérifier mentalement qu'aucun `helm-values.yaml` per-env n'est cassé par les nouveaux defaults `global.*: ""`
- [ ] Post-merge : kicker PR-B (bootstrap + AppSet templatisée) qui consomme ces profils

## Notes Tier 1/2 (CRITICAL.md règle 11)

- **Tier 2** : création fichiers + édition templates Helm en mode additif. Tout via PR.
- **Tier 1** : merge cette PR ; aucune mutation cluster exécutée par l'agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
