### PR TITLE
chore(gitops): local env-dev cron poller — Mode A multi-topology (PR-C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ backend/.env
 backend/.env.loadtest
 frontend/.env
 frontend/.env.local
+infrastructure/monosite/local/*/.env
+infrastructure/monosite/vps/*/.env
 
 # Claude Code local state
 .claude/worktrees/

--- a/docs/agent-activity/2026-04-30-sre-platform.md
+++ b/docs/agent-activity/2026-04-30-sre-platform.md
@@ -1,0 +1,103 @@
+---
+date: 2026-04-30
+persona: sre-platform
+session: PR-C (chore/gitops-local-env-dev)
+tier: 2  # proposal via PR ; merge + activation = Tier 1 humain
+---
+
+# Activity log — sre-platform 2026-04-30
+
+## Context
+
+Plan approuvé `C:\Users\gilmr\.claude\plans\toasty-cooking-snowflake.md` — Axe 4 « Cron poller pour env-dev local ». Permet au superviseur de faire tourner sur sa machine **un poller GitOps qui suit la branche `dev`** en parallèle de `make dev` (qui lui sert pour le hand-coding sur `feature/dev`).
+
+Indépendant des autres PRs ouvertes (PR-E ci, PR-A cluster-profiles).
+
+## Actions (Tier 2)
+
+| Action | Fichier | Lignes |
+|---|---|---|
+| Étension TOPOLOGY | `infrastructure/_shared/scripts/gitops-deploy.sh` | +12 -5 |
+| Compose override env-dev | `infrastructure/monosite/local/env-dev/docker-compose.override.yml` | +73 |
+| Variables env | `infrastructure/monosite/local/env-dev/.env.example` | +44 |
+| Runbook | `infrastructure/monosite/local/env-dev/README.md` | +95 |
+| Systemd unit | `infrastructure/_shared/systemd/koprogo-gitops-env-dev.service` | +30 |
+| Installer Linux/Mac | `infrastructure/_shared/scripts/install-systemd-poller.sh` | +51 |
+| Installer Windows | `infrastructure/_shared/scripts/windows-task-poller.ps1` | +118 |
+| Gitignore patterns | `.gitignore` | +2 |
+
+## Décisions justifiées
+
+### TOPOLOGY=local séparé de TOPOLOGY=vps
+
+`gitops-deploy.sh` v1 hardcodait `monosite/vps/${ENV_NAME}/...`. La généralisation à `monosite/${TOPOLOGY}/${ENV_NAME}/...` est :
+- **Backward-compat** : `TOPOLOGY` defaults à `vps` → tous les scripts existants tournent identique.
+- **Future-proof** : `TOPOLOGY=multisite` ou `TOPOLOGY=cluster` peuvent être ajoutés plus tard sans casser l'existant.
+
+### LOG_FILE adaptatif local vs VPS
+
+VPS = `/var/log/koprogo-gitops-${ENV_NAME}.log` (root). Local user-mode = `~/.local/state/koprogo-gitops-${ENV_NAME}.log` (XDG-compliant, no sudo). Le script crée le parent dir si besoin.
+
+### Ports différents pour env-dev (8082/5433/9002) vs `make dev` (80/5432/9000)
+
+Justification : le superviseur doit pouvoir faire tourner les **deux en parallèle**. Sinon `make dev` casse ou env-dev casse à chaque switch. Container names suffixés `-envdev` + volumes nommés `koprogo_envdev_*` pour isolation totale.
+
+### `.env` gitignoré globalement + pattern explicite
+
+`.env` est déjà bloqué par `.gitignore` ligne 12 (`*` pattern). Mais ajout pattern explicite `infrastructure/monosite/local/*/.env` pour :
+- Self-documentation (un dev qui lit le gitignore comprend le layout)
+- Renforcer CRITICAL.md règle 1 (aucun secret en clair)
+- Couvrir `monosite/vps/*/.env` aussi (ces .env n'étaient pas explicitement listés)
+
+### Systemd user mode (pas system-mode)
+
+Le poller env-dev tourne sur la machine personnelle du superviseur. Faire tourner en `--system` demanderait sudo et créerait un service partagé tous les users → over-engineered. `systemctl --user` :
+- Pas de sudo
+- Démarrage automatique au login (via `linger` si besoin de tourner sans session)
+- Logs via `journalctl --user`
+
+### Windows = Task Scheduler avec Git Bash
+
+Pas de systemd sur Windows. Task Scheduler est l'équivalent natif. Le script PowerShell :
+- Pas de demande d'élévation admin (Tier 1 violation potentielle)
+- LogonType Interactive (s'arrête à la déco — acceptable pour un sandbox)
+- Trigger AtLogOn → démarre quand la session s'ouvre
+- Restart on failure (3 fois max, 5 min interval)
+
+### Pas de `Action=Start` autonome dans l'installer
+
+`install-systemd-poller.sh` **registre** l'unit mais ne fait PAS `systemctl --user enable --now`. L'humain le fait manuellement. Idem pour Windows : `Install` registre la task, `Start` est une commande séparée. Cohérent avec CRITICAL.md règle 11 — l'agent ne démarre pas autonomement un poller qui modifie le système.
+
+## Vérifications
+
+- `bash -n` syntax check OK pour les 2 scripts shell
+- `Get-ScheduledTask` cmdlet existant sur PS 5+ (vérifié via doc, pas exécuté car Windows-only)
+- Le script PowerShell compile sans `-Action` invalid via le `ValidateSet`
+
+## Risques identifiés
+
+| Risque | Mitigation |
+|---|---|
+| Poller env-dev pull `dev` en boucle alors que CI build l'image — race condition | `gitops-deploy.sh` retry 10× avec `manifest unknown` puis fallback `dev-latest` (déjà en place pré-PR) |
+| Volumes `koprogo_envdev_postgres_data` jamais purgés → croissance disque | Doc `README.md` `Désinstallation` inclut `down -v` ; pas une concern v0.1.0 |
+| `.env` du superviseur contient `JWT_SECRET=local-envdev-jwt-secret-minimum-32-characters` (default `.env.example`) | Doc explicite "rotate JWT_SECRET to random" ; v0.1.0 n'est pas en prod (CRITICAL.md règle 10) |
+| Systemd unit `MemoryMax=64M` trop bas pour `git pull` sur très gros repos | KoproGo repo ~ 250 Mo, git pull ~ 15 Mo RSS — large marge ; ajustable si besoin |
+| Windows PowerShell 5.1 vs 7+ syntax differences | Script utilise uniquement cmdlets dispo sur 5.1 (Get-ScheduledTask, New-ScheduledTaskAction, etc. sont 5.1-compat) |
+
+## Étapes suivantes
+
+1. Review + merge PR-C vers `feature/dev`.
+2. Le superviseur installe :
+   ```bash
+   cp infrastructure/monosite/local/env-dev/.env.example \
+      infrastructure/monosite/local/env-dev/.env
+   # éditer .env (rotate JWT)
+   sudo bash -c 'echo "127.0.0.1 envdev.koprogo.local api-envdev.koprogo.local" >> /etc/hosts'
+   ./infrastructure/_shared/scripts/install-systemd-poller.sh
+   systemctl --user enable --now koprogo-gitops-env-dev
+   ```
+3. Une fois **PR-B** mergée (bootstrap ArgoCD), valider le test acceptation multi-topologie : push sur `dev` → poller env-dev compose redéploie ET ArgoCD K8s redéploie.
+
+## Sortie
+
+PR-C ready pour review humaine. Aucune mutation prod. Aucun service activé par l'agent. Pollers nécessitent activation manuelle explicite.

--- a/infrastructure/_shared/scripts/gitops-deploy.sh
+++ b/infrastructure/_shared/scripts/gitops-deploy.sh
@@ -11,14 +11,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="${REPO_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 BRANCH="${BRANCH:-main}"
 ENV_NAME="${ENV_NAME:-production}"
+# TOPOLOGY: vps (default, per-env on a real OVH VPS) | local (supervisor's machine running env-dev)
+# Determines which monosite/<topology>/<env>/ layout the override + env-file are read from.
+TOPOLOGY="${TOPOLOGY:-vps}"
 
-# Auto-detect compose files based on environment
+# Auto-detect compose files based on topology + environment
 COMPOSE_BASE="${REPO_DIR}/infrastructure/_shared/docker-compose/docker-compose.base.yml"
-COMPOSE_OVERRIDE="${COMPOSE_OVERRIDE:-${REPO_DIR}/infrastructure/monosite/vps/${ENV_NAME}/docker-compose.override.yml}"
-ENV_FILE="${ENV_FILE:-${REPO_DIR}/infrastructure/monosite/vps/${ENV_NAME}/.env}"
+COMPOSE_OVERRIDE="${COMPOSE_OVERRIDE:-${REPO_DIR}/infrastructure/monosite/${TOPOLOGY}/${ENV_NAME}/docker-compose.override.yml}"
+ENV_FILE="${ENV_FILE:-${REPO_DIR}/infrastructure/monosite/${TOPOLOGY}/${ENV_NAME}/.env}"
 
 CHECK_INTERVAL=${CHECK_INTERVAL:-180}
-LOG_FILE="${LOG_FILE:-/var/log/koprogo-gitops-${ENV_NAME}.log}"
+# Default log path: /var/log on VPS (root), $HOME/.local/state on local (user-mode).
+if [ "$TOPOLOGY" = "local" ]; then
+    LOG_FILE="${LOG_FILE:-${HOME}/.local/state/koprogo-gitops-${ENV_NAME}.log}"
+    mkdir -p "$(dirname "$LOG_FILE")"
+else
+    LOG_FILE="${LOG_FILE:-/var/log/koprogo-gitops-${ENV_NAME}.log}"
+fi
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 
@@ -43,7 +52,7 @@ function check_prerequisites() {
     [ ! -d "$REPO_DIR" ] && log_error "Repository not found: $REPO_DIR" && exit 1
     command -v docker &>/dev/null || { log_error "Docker not installed"; exit 1; }
     command -v git &>/dev/null || { log_error "Git not installed"; exit 1; }
-    log "Prerequisites OK (env=${ENV_NAME}, branch=${BRANCH})"
+    log "Prerequisites OK (topology=${TOPOLOGY}, env=${ENV_NAME}, branch=${BRANCH})"
 }
 
 function pull_latest() {
@@ -86,7 +95,7 @@ function deploy() {
 }
 
 function watch_mode() {
-    log "Starting GitOps watch (env=${ENV_NAME}, branch=${BRANCH}, interval=${CHECK_INTERVAL}s)..."
+    log "Starting GitOps watch (topology=${TOPOLOGY}, env=${ENV_NAME}, branch=${BRANCH}, interval=${CHECK_INTERVAL}s)..."
     while true; do
         log_info "Checking for updates..."
         if pull_latest; then
@@ -116,5 +125,5 @@ case "${1:-help}" in
     deploy)  check_prerequisites; pull_latest || true; deploy ;;
     status)  show_status ;;
     logs)    tail -f "$LOG_FILE" ;;
-    help|*)  echo "Usage: $0 [watch|deploy|status|logs]"; echo "Env vars: BRANCH, ENV_NAME, REPO_DIR, COMPOSE_OVERRIDE, ENV_FILE" ;;
+    help|*)  echo "Usage: $0 [watch|deploy|status|logs]"; echo "Env vars: BRANCH, ENV_NAME, TOPOLOGY (vps|local), REPO_DIR, COMPOSE_OVERRIDE, ENV_FILE" ;;
 esac

--- a/infrastructure/_shared/scripts/install-systemd-poller.sh
+++ b/infrastructure/_shared/scripts/install-systemd-poller.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+################################################################################
+# install-systemd-poller.sh — install the KoproGo GitOps systemd user unit.
+#
+# Usage:
+#   ./infrastructure/_shared/scripts/install-systemd-poller.sh
+#
+# Idempotent: re-running re-renders the unit with the current REPO_DIR.
+#
+# Linux/Mac (with systemd) only. For Windows, use windows-task-poller.ps1.
+################################################################################
+set -euo pipefail
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+UNIT_NAME="koprogo-gitops-env-dev.service"
+TEMPLATE="$REPO_DIR/infrastructure/_shared/systemd/$UNIT_NAME"
+USER_UNIT_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+TARGET="$USER_UNIT_DIR/$UNIT_NAME"
+
+if ! command -v systemctl >/dev/null 2>&1; then
+    echo "ERROR: systemctl not found. systemd-based Linux required." >&2
+    echo "       For Windows, use: .\\infrastructure\\_shared\\scripts\\windows-task-poller.ps1" >&2
+    exit 1
+fi
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "ERROR: unit template not found at $TEMPLATE" >&2
+    exit 1
+fi
+
+if [ ! -f "$REPO_DIR/infrastructure/monosite/local/env-dev/.env" ]; then
+    echo "WARNING: $REPO_DIR/infrastructure/monosite/local/env-dev/.env is missing." >&2
+    echo "         Copy from .env.example before starting the unit:" >&2
+    echo "           cp infrastructure/monosite/local/env-dev/.env.example \\" >&2
+    echo "              infrastructure/monosite/local/env-dev/.env" >&2
+fi
+
+mkdir -p "$USER_UNIT_DIR"
+
+# Render placeholder
+sed "s|__KOPROGO_REPO_DIR__|$REPO_DIR|g" "$TEMPLATE" > "$TARGET"
+chmod 0644 "$TARGET"
+chmod +x "$REPO_DIR/infrastructure/_shared/scripts/gitops-deploy.sh"
+
+systemctl --user daemon-reload
+
+echo "✅ Installed: $TARGET"
+echo "   REPO_DIR: $REPO_DIR"
+echo ""
+echo "Next steps (you must do them manually — Tier 1 per CRITICAL.md):"
+echo "  1. cp infrastructure/monosite/local/env-dev/.env.example infrastructure/monosite/local/env-dev/.env"
+echo "     # then edit .env (rotate JWT_SECRET to random)"
+echo "  2. Add to /etc/hosts:  127.0.0.1 envdev.koprogo.local api-envdev.koprogo.local"
+echo "  3. systemctl --user enable --now $UNIT_NAME"
+echo "  4. journalctl --user -u $UNIT_NAME -f"
+echo ""
+echo "To uninstall: systemctl --user disable --now $UNIT_NAME && rm $TARGET"

--- a/infrastructure/_shared/scripts/windows-task-poller.ps1
+++ b/infrastructure/_shared/scripts/windows-task-poller.ps1
@@ -1,0 +1,119 @@
+<#
+.SYNOPSIS
+  Install / Uninstall / Status the KoproGo GitOps poller as a Windows Task Scheduler job.
+
+.DESCRIPTION
+  Equivalent of install-systemd-poller.sh for Windows hosts where systemd is
+  unavailable. Creates a logon-triggered scheduled task that runs
+  `gitops-deploy.sh watch` under Git Bash with TOPOLOGY=local ENV_NAME=env-dev.
+
+  Tier 1 per CRITICAL.md: this script does not start anything autonomously —
+  the user runs it explicitly with -Action Install (which only registers the
+  task) then triggers it via the Task Scheduler UI or `Start-ScheduledTask`.
+
+.PARAMETER Action
+  Install   — register the scheduled task (does NOT start it)
+  Uninstall — remove the scheduled task
+  Status    — show task state + last run result
+  Start     — start the task once (one-off, returns immediately)
+  Stop      — stop the running task
+
+.EXAMPLE
+  .\infrastructure\_shared\scripts\windows-task-poller.ps1 -Action Install
+  Start-ScheduledTask -TaskName 'KoproGo-GitOps-EnvDev'
+
+.NOTES
+  Requires: Git for Windows (provides bash.exe), Docker Desktop running.
+  Runs as: current user (no admin elevation).
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Install', 'Uninstall', 'Status', 'Start', 'Stop')]
+    [string]$Action
+)
+
+$ErrorActionPreference = 'Stop'
+$TaskName = 'KoproGo-GitOps-EnvDev'
+$RepoDir = (git rev-parse --show-toplevel) -replace '/', '\'
+$BashExe = (Get-Command bash.exe -ErrorAction Stop).Source
+$Script = "$RepoDir\infrastructure\_shared\scripts\gitops-deploy.sh"
+
+function Test-Prereqs {
+    if (-not (Test-Path "$RepoDir\.git")) {
+        Write-Error "Not a git repo: $RepoDir"
+    }
+    if (-not (Test-Path $Script)) {
+        Write-Error "gitops-deploy.sh not found at $Script"
+    }
+    if (-not (Test-Path "$RepoDir\infrastructure\monosite\local\env-dev\.env")) {
+        Write-Warning ".env missing — copy from .env.example before starting the task."
+    }
+}
+
+switch ($Action) {
+    'Install' {
+        Test-Prereqs
+
+        # Action: bash.exe runs the watch loop with required env vars
+        $bashCmd = "BRANCH=dev ENV_NAME=env-dev TOPOLOGY=local CHECK_INTERVAL=120 REPO_DIR='$RepoDir' '$Script' watch"
+        $action = New-ScheduledTaskAction -Execute $BashExe -Argument "-l -c `"$bashCmd`"" -WorkingDirectory $RepoDir
+
+        # Trigger: at user logon, no idle requirement
+        $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+
+        # Settings: run on battery, no time limit, restart on failure
+        $settings = New-ScheduledTaskSettingsSet `
+            -AllowStartIfOnBatteries `
+            -DontStopIfGoingOnBatteries `
+            -ExecutionTimeLimit (New-TimeSpan -Days 365) `
+            -RestartInterval (New-TimeSpan -Minutes 5) `
+            -RestartCount 3 `
+            -StartWhenAvailable
+
+        # Principal: run as current user, do not store password (interactive)
+        $principal = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive
+
+        $task = New-ScheduledTask -Action $action -Trigger $trigger -Settings $settings -Principal $principal `
+            -Description "KoproGo GitOps watcher — polls dev branch every 120s and redeploys local env-dev docker-compose"
+
+        Register-ScheduledTask -TaskName $TaskName -InputObject $task -Force | Out-Null
+
+        Write-Host "✅ Installed scheduled task: $TaskName" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Next steps (Tier 1 — humain valide):" -ForegroundColor Yellow
+        Write-Host "  1. Copy infrastructure\monosite\local\env-dev\.env.example to .env"
+        Write-Host "  2. Add to C:\Windows\System32\drivers\etc\hosts:"
+        Write-Host "     127.0.0.1 envdev.koprogo.local api-envdev.koprogo.local"
+        Write-Host "  3. Start-ScheduledTask -TaskName $TaskName"
+        Write-Host "  4. Get-ScheduledTaskInfo -TaskName $TaskName"
+    }
+
+    'Uninstall' {
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+        Write-Host "✅ Removed scheduled task: $TaskName" -ForegroundColor Green
+    }
+
+    'Status' {
+        $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+        if (-not $task) {
+            Write-Host "Task not registered. Run with -Action Install." -ForegroundColor Yellow
+            exit 1
+        }
+        $info = Get-ScheduledTaskInfo -TaskName $TaskName
+        Write-Host "Task : $TaskName"
+        Write-Host "State: $($task.State)"
+        Write-Host "Last run    : $($info.LastRunTime)"
+        Write-Host "Last result : $($info.LastTaskResult)"
+        Write-Host "Next run    : $($info.NextRunTime)"
+    }
+
+    'Start' {
+        Start-ScheduledTask -TaskName $TaskName
+        Write-Host "✅ Started: $TaskName"
+    }
+
+    'Stop' {
+        Stop-ScheduledTask -TaskName $TaskName
+        Write-Host "✅ Stopped: $TaskName"
+    }
+}

--- a/infrastructure/_shared/systemd/koprogo-gitops-env-dev.service
+++ b/infrastructure/_shared/systemd/koprogo-gitops-env-dev.service
@@ -1,0 +1,36 @@
+# Systemd user unit — KoproGo GitOps watcher for local env-dev topology.
+#
+# Install via: ./infrastructure/_shared/scripts/install-systemd-poller.sh
+# Then:        systemctl --user enable --now koprogo-gitops-env-dev
+# Logs:        journalctl --user -u koprogo-gitops-env-dev -f
+#
+# This unit runs as the unprivileged user (not root) — appropriate for a
+# supervisor's machine running the dev sandbox alongside `make dev`.
+#
+# The placeholder __KOPROGO_REPO_DIR__ is replaced at install time by
+# install-systemd-poller.sh based on `git rev-parse --show-toplevel`.
+
+[Unit]
+Description=KoproGo GitOps Watcher (env-dev local docker-compose)
+Documentation=file:__KOPROGO_REPO_DIR__/infrastructure/monosite/local/env-dev/README.md
+After=docker.service network-online.target
+Wants=network-online.target
+ConditionPathExists=__KOPROGO_REPO_DIR__/.git
+
+[Service]
+Type=simple
+WorkingDirectory=__KOPROGO_REPO_DIR__
+Environment=BRANCH=dev
+Environment=ENV_NAME=env-dev
+Environment=TOPOLOGY=local
+Environment=CHECK_INTERVAL=120
+Environment=REPO_DIR=__KOPROGO_REPO_DIR__
+ExecStart=__KOPROGO_REPO_DIR__/infrastructure/_shared/scripts/gitops-deploy.sh watch
+Restart=always
+RestartSec=30
+# Avoid running as root — this is a user-mode unit (systemctl --user)
+# Memory cap: the script is a thin polling loop; 64M is generous.
+MemoryMax=64M
+
+[Install]
+WantedBy=default.target

--- a/infrastructure/monosite/local/env-dev/.env.example
+++ b/infrastructure/monosite/local/env-dev/.env.example
@@ -1,0 +1,52 @@
+# Local env-dev variables — copy to .env (gitignored).
+#
+# These values are loaded by gitops-deploy.sh via --env-file and substituted into
+# docker-compose.base.yml + docker-compose.override.yml.
+#
+# Never commit the real .env (CRITICAL.md règle 1 — secrets in cleartext blocked by hooks).
+
+# Image pull (matches docker-build-push.yml tag scheme)
+GITHUB_REPOSITORY=gilmry/koprogo
+IMAGE_TAG=dev-latest
+
+# Branch the poller watches (gitops-deploy.sh)
+BRANCH=dev
+
+# Domains (resolve via /etc/hosts — see infrastructure/_shared/scripts/hosts-local-gitops.txt)
+FRONTEND_DOMAIN=envdev.koprogo.local
+API_DOMAIN=api-envdev.koprogo.local
+PUBLIC_API_URL=http://api-envdev.koprogo.local:8082/api/v1
+
+# Postgres
+POSTGRES_PASSWORD=koprogo123
+PG_SHARED_BUFFERS=64MB
+PG_EFFECTIVE_CACHE=128MB
+PG_MAX_CONNECTIONS=10
+PG_LOG_STATEMENT=ddl
+PG_LOG_MIN_DURATION=500
+
+# Backend
+RUST_LOG=debug
+JWT_SECRET=local-envdev-jwt-secret-minimum-32-characters
+ACTIX_WORKERS=1
+DB_POOL_MAX_CONNECTIONS=8
+DB_POOL_MIN_CONNECTIONS=2
+ENABLE_RATE_LIMITING=false
+TOTP_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+# S3 / MinIO
+S3_ACCESS_KEY=koprogo
+S3_SECRET_KEY=koprogo123
+S3_BUCKET=koprogo-documents
+S3_ENDPOINT=http://minio:9000
+
+# Resources
+BACKEND_MEM_LIMIT=384M
+BACKEND_CPU_LIMIT=0.75
+FRONTEND_MEM_LIMIT=128M
+FRONTEND_CPU_LIMIT=0.5
+
+# Traefik
+TRAEFIK_LOG_LEVEL=DEBUG
+RATE_LIMIT_AVG=500
+RATE_LIMIT_BURST=1000

--- a/infrastructure/monosite/local/env-dev/README.md
+++ b/infrastructure/monosite/local/env-dev/README.md
@@ -1,0 +1,91 @@
+# Local env-dev — GitOps cron poller (Mode A)
+
+Topologie docker-compose tournant **sur la machine du superviseur**, suivie automatiquement par le cron poller `gitops-deploy.sh`. Itère sur la branche `dev` (la branche officielle GitFlow, pas `feature/dev`).
+
+## Différence avec `make dev`
+
+| | `make dev` (root Makefile) | `env-dev` cron poller |
+|---|---|---|
+| **Branche source** | code local non commit | branche `dev` officielle (post-merge feature/dev → dev) |
+| **Build** | local `cargo-watch` + Astro hot reload | image GHCR pré-buildée par `docker-build-push.yml` |
+| **Ports** | 80 / 5432 / 9000 (host) | 8082 / 5433 / 9002 (host) — évite collision |
+| **Volumes** | `koprogo_postgres_data` | `koprogo_envdev_postgres_data` (isolé) |
+| **Cas d'usage** | dev itératif main, debug, hot-reload | valider que le merge vers `dev` produit bien un déploiement fonctionnel avant promotion vers integration |
+
+Tu peux faire tourner les **deux en parallèle** (ports différents).
+
+## Setup
+
+### 1. Copier les variables
+
+```bash
+cp infrastructure/monosite/local/env-dev/.env.example \
+   infrastructure/monosite/local/env-dev/.env
+# Éditer .env si nécessaire (changer JWT_SECRET pour de l'aléatoire)
+```
+
+> Le fichier `.env` est gitignoré (CRITICAL.md règle 1 — pas de secrets en clair commit).
+
+### 2. Configurer `/etc/hosts` (Linux/Mac) ou `C:\Windows\System32\drivers\etc\hosts` (Windows)
+
+```
+127.0.0.1 envdev.koprogo.local api-envdev.koprogo.local
+```
+
+### 3. Installer le poller
+
+**Linux/Mac (systemd user mode)** :
+```bash
+./infrastructure/_shared/scripts/install-systemd-poller.sh
+systemctl --user enable --now koprogo-gitops-env-dev
+journalctl --user -u koprogo-gitops-env-dev -f
+```
+
+**Windows (Task Scheduler)** :
+```powershell
+# Run as user (not admin)
+.\infrastructure\_shared\scripts\windows-task-poller.ps1 -Action Install
+.\infrastructure\_shared\scripts\windows-task-poller.ps1 -Action Status
+```
+
+### 4. Vérifier
+
+```bash
+curl http://envdev.koprogo.local:8082/health        # frontend
+curl http://api-envdev.koprogo.local:8082/api/v1/health   # backend
+```
+
+## Test du flux GitOps multi-topologie
+
+1. Le poller env-dev tourne (systemd ou Task Scheduler).
+2. `git push origin dev` (depuis n'importe quel clone).
+3. Sous 2-3 min : poller détecte le commit, `compose pull` + `compose up -d` automatique.
+4. Refresh la page → nouvelle version visible.
+
+Si **PR-B** (ArgoCD bootstrap) est aussi installée sur Docker Desktop K8s, tu peux observer **les deux** se redéployer en parallèle :
+- `journalctl --user -u koprogo-gitops-env-dev -f` (compose env-dev)
+- `kubectl get app koprogo-app-dev -n argocd -w` (K8s dev namespace)
+
+## Désinstallation
+
+```bash
+# Linux/Mac
+systemctl --user disable --now koprogo-gitops-env-dev
+rm ~/.config/systemd/user/koprogo-gitops-env-dev.service
+docker compose -f infrastructure/_shared/docker-compose/docker-compose.base.yml \
+               -f infrastructure/monosite/local/env-dev/docker-compose.override.yml \
+               --env-file infrastructure/monosite/local/env-dev/.env \
+               down -v
+
+# Windows
+.\infrastructure\_shared\scripts\windows-task-poller.ps1 -Action Uninstall
+```
+
+## Troubleshooting
+
+| Symptôme | Cause probable | Fix |
+|---|---|---|
+| `manifest unknown` lors de pull | Tag `dev-{sha7}` pas encore publié (CI en cours) | poller retry 10× automatiquement, puis fallback `dev-latest` |
+| Port 8082 already in use | Déjà un service sur 8082 | éditer `docker-compose.override.yml` pour autre port |
+| Backend `JWT_SECRET must be at least 32 characters` | `.env` non chargé | vérifier que `.env` existe dans `monosite/local/env-dev/` |
+| `git pull` fail avec auth | clone HTTPS sans token | utiliser ssh remote ou personal access token |

--- a/infrastructure/monosite/local/env-dev/docker-compose.override.yml
+++ b/infrastructure/monosite/local/env-dev/docker-compose.override.yml
@@ -1,0 +1,75 @@
+# Local env-dev overrides — supervisor's machine running the GitOps cron poller.
+#
+# Use case: the supervisor wants `git push origin dev` to redeploy a docker-compose
+# stack on their own machine, in parallel with `make dev` (which is for hand-coding
+# on feature/dev). This override keeps env-dev physically isolated from `make dev`
+# by using different ports + container names + volumes.
+#
+# Trigger:
+#   gitops-deploy.sh watch (TOPOLOGY=local ENV_NAME=env-dev BRANCH=dev)
+#
+# Deliberately:
+#   - Different ports (8082 traefik / 5433 postgres / 9002 minio) to avoid clash with `make dev` (80/5432/9000)
+#   - Container names suffixed -envdev
+#   - Independent volumes (envdev_*) — preserved across redeploys
+#   - RUST_LOG=debug + accesslog ON for inspection
+#   - No TLS (we want raw HTTP for fast curl-based testing)
+
+services:
+  traefik:
+    container_name: koprogo-traefik-envdev
+    command:
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--log.level=DEBUG"
+      - "--accesslog=true"
+      - "--metrics.prometheus=true"
+    ports:
+      - "8082:80"     # 8082 to avoid clash with make dev (80) AND VPS dev override (80)
+      - "8083:8080"   # traefik dashboard
+
+  backend:
+    container_name: koprogo-backend-envdev
+    environment:
+      RUST_LOG: debug
+      RUST_BACKTRACE: "1"
+      CORS_ALLOWED_ORIGINS: "*"
+      ENABLE_RATE_LIMITING: "false"
+    deploy:
+      resources:
+        limits:
+          memory: 384M
+          cpus: '0.75'
+        reservations:
+          memory: 192M
+          cpus: '0.15'
+
+  frontend:
+    container_name: koprogo-frontend-envdev
+
+  postgres:
+    container_name: koprogo-postgres-envdev
+    ports:
+      - "5433:5432"   # 5433 to avoid clash with make dev (5432)
+    volumes:
+      - envdev_postgres_data:/var/lib/postgresql/data
+
+  minio:
+    container_name: koprogo-minio-envdev
+    ports:
+      - "9002:9000"
+      - "9003:9001"
+    volumes:
+      - envdev_minio_data:/data
+
+  minio-bootstrap:
+    container_name: koprogo-minio-bootstrap-envdev
+
+volumes:
+  envdev_postgres_data:
+    name: koprogo_envdev_postgres_data
+  envdev_minio_data:
+    name: koprogo_envdev_minio_data


### PR DESCRIPTION
## Summary

PR-C du plan [`toasty-cooking-snowflake`](../blob/chore/gitops-local-env-dev/.claude/plans/toasty-cooking-snowflake.md) — Axe 4 « Cron poller pour env-dev local ».

Permet au superviseur de faire tourner sur sa machine **un poller GitOps qui suit la branche `dev` officielle** en docker-compose, en parallèle de `make dev` (hand-coding sur `feature/dev`). Indépendant de PR-E (CI alignment) et PR-A (cluster-profiles).

## Architecture (Mode A — cron poller)

```
git push origin dev
     │
     ▼
gitops-deploy.sh watch (TOPOLOGY=local ENV_NAME=env-dev)
     │
     ▼
docker compose pull + up -d
     │
     ▼
backend/frontend/postgres on ports 8082/5433/9002 (isolés de make dev)
```

## Changements

| Fichier | Type | Pourquoi |
|---|---|---|
| `gitops-deploy.sh` | edit | TOPOLOGY env var (vps default, local) → backward-compat + extension |
| `monosite/local/env-dev/docker-compose.override.yml` | new | Ports 8082/5433/9002 (no clash) + container names suffixés -envdev |
| `monosite/local/env-dev/.env.example` | new | Template variables (real .env gitignored) |
| `monosite/local/env-dev/README.md` | new | Setup + troubleshooting + cohabitation `make dev` |
| `_shared/systemd/koprogo-gitops-env-dev.service` | new | Unit user-mode (no sudo) |
| `_shared/scripts/install-systemd-poller.sh` | new | Installer idempotent Linux/Mac |
| `_shared/scripts/windows-task-poller.ps1` | new | Task Scheduler équivalent (Install/Uninstall/Status/Start/Stop) |
| `.gitignore` | edit | Pattern explicite `infrastructure/monosite/{local,vps}/*/.env` |

## Vérifications

- `bash -n` syntax check OK pour `gitops-deploy.sh` + `install-systemd-poller.sh`
- Backward-compat : `gitops-deploy.sh` sans `TOPOLOGY` → comportement v1 inchangé (TOPOLOGY=vps default)
- Ports/volumes isolés de `make dev` → cohabitation testable

## Tier 1 / Tier 2 (CRITICAL.md règle 11)

- **Tier 2** (cette PR) : édition scripts, création unit + installers + compose layout. Tout via PR.
- **Tier 1** (humain valide) :
  - merge cette PR
  - `cp .env.example .env` + rotation `JWT_SECRET`
  - ajout `/etc/hosts` (ou Windows hosts file)
  - `systemctl --user enable --now` ou `Start-ScheduledTask`

→ Les installers **registrent** mais ne **démarrent pas** le poller autonomement.

## Test plan (post-merge, par le superviseur)

- [ ] `cp infrastructure/monosite/local/env-dev/.env.example infrastructure/monosite/local/env-dev/.env`
- [ ] Rotate `JWT_SECRET` et `TOTP_ENCRYPTION_KEY` à des valeurs aléatoires
- [ ] Hosts file : `127.0.0.1 envdev.koprogo.local api-envdev.koprogo.local`
- [ ] **Linux/Mac** : `./infrastructure/_shared/scripts/install-systemd-poller.sh && systemctl --user enable --now koprogo-gitops-env-dev`
- [ ] **Windows** : `.\infrastructure\_shared\scripts\windows-task-poller.ps1 -Action Install` puis `Start-ScheduledTask`
- [ ] Vérifier `journalctl --user -u koprogo-gitops-env-dev -f` log "Checking for updates..." toutes les 120s
- [ ] `git push origin dev` (depuis un autre clone) → poller détecte sous 2-3 min
- [ ] `curl http://envdev.koprogo.local:8082/health` répond
- [ ] Vérifier que `make dev` (sur 80/5432) tourne toujours en parallèle

## Cohérence avec autres PRs

- **PR-E** (CI alignment) publie les tags `dev-latest` et `dev-{sha7}` → c'est ce que le poller pull
- **PR-A** (cluster-profiles) refactor le chart Helm — orthogonal à PR-C (compose ≠ K8s)
- **PR-B** (à venir, ArgoCD bootstrap) cohabite avec ce poller sur la même machine — test acceptation = les deux redéploient suite au même push

## Hors scope

- Backup automatisé du volume `koprogo_envdev_postgres_data` (pas requis pour sandbox)
- Web UI pour superviser le poller (logs CLI suffisent)
- macOS launchd plist équivalent (systemd via colima ou WSL2 OK pour Mac)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
