### PR TITLE
feat(decimal): complete EXP-003 cascade — expenses.amount NUMERIC + remove FLOAT8 casts

### DIFF
--- a/backend/migrations/20260502000000_complete_expense_decimal_cascade.sql
+++ b/backend/migrations/20260502000000_complete_expense_decimal_cascade.sql
@@ -1,0 +1,32 @@
+-- Migration: complete EXP-003 Decimal cascade — expenses.amount FLOAT8 → NUMERIC(12,2)
+--
+-- Surfacé par PR #450 (chore/ci-gitflow-alignment) — BDD ColumnDecode panics
+-- sur Expense entity avec `amount: Decimal` lecture FLOAT8 column.
+--
+-- Précision NUMERIC(12,2) = 10 chiffres avant virgule + 2 après → 9_999_999_999.99 max
+-- Aligné sur journal_entry_lines.{debit,credit} et amount_excl_vat/amount_incl_vat
+-- déjà en NUMERIC(10,2). On utilise (12,2) car expenses.amount peut représenter
+-- des montants > 9_999_999.99 (gros travaux copro).
+--
+-- Aucune dépendance view/trigger sur expenses.amount (vérifié via
+-- information_schema.view_column_usage).
+--
+-- ADR : 0007 (Decimal vs f64), 0008 (NUMERIC vs DOUBLE).
+
+BEGIN;
+
+-- 1. Drop CHECK constraint qui référence "0::double precision" (incompatible NUMERIC)
+ALTER TABLE expenses DROP CONSTRAINT IF EXISTS expenses_amount_check;
+
+-- 2. ALTER type
+ALTER TABLE expenses
+    ALTER COLUMN amount TYPE NUMERIC(12,2)
+    USING amount::NUMERIC(12,2);
+
+-- 3. Re-add CHECK avec littéral NUMERIC
+ALTER TABLE expenses
+    ADD CONSTRAINT expenses_amount_check CHECK (amount > 0);
+
+COMMIT;
+
+COMMENT ON COLUMN expenses.amount IS 'Montant total TTC en EUR (NUMERIC(12,2) — précision exacte requise pour comptabilité belge PCMN — ADR-0007/0008)';

--- a/backend/src/application/dto/filters.rs
+++ b/backend/src/application/dto/filters.rs
@@ -1,5 +1,6 @@
 use crate::domain::entities::ApprovalStatus;
 use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
 use serde::Deserialize;
 use uuid::Uuid;
 
@@ -26,8 +27,8 @@ pub struct ExpenseFilters {
     pub approval_status: Option<ApprovalStatus>, // Nouveau: pour filtrer par statut workflow
     pub date_from: Option<DateTime<Utc>>,
     pub date_to: Option<DateTime<Utc>>,
-    pub min_amount: Option<f64>,
-    pub max_amount: Option<f64>,
+    pub min_amount: Option<Decimal>,
+    pub max_amount: Option<Decimal>,
 }
 
 /// Filters for unit list queries

--- a/backend/src/infrastructure/database/repositories/call_for_funds_repository_impl.rs
+++ b/backend/src/infrastructure/database/repositories/call_for_funds_repository_impl.rs
@@ -73,7 +73,7 @@ impl CallForFundsRepository for PostgresCallForFundsRepository {
         let row = sqlx::query(
             r#"
             SELECT id, organization_id, building_id, title, description,
-                   total_amount::FLOAT8 AS total_amount, contribution_type::text AS contribution_type,
+                   total_amount, contribution_type::text AS contribution_type,
                    call_date, due_date, sent_date,
                    status::text AS status, account_code, notes,
                    created_at, updated_at, created_by
@@ -93,7 +93,7 @@ impl CallForFundsRepository for PostgresCallForFundsRepository {
         let rows = sqlx::query(
             r#"
             SELECT id, organization_id, building_id, title, description,
-                   total_amount::FLOAT8 AS total_amount, contribution_type::text AS contribution_type,
+                   total_amount, contribution_type::text AS contribution_type,
                    call_date, due_date, sent_date,
                    status::text AS status, account_code, notes,
                    created_at, updated_at, created_by
@@ -117,7 +117,7 @@ impl CallForFundsRepository for PostgresCallForFundsRepository {
         let rows = sqlx::query(
             r#"
             SELECT id, organization_id, building_id, title, description,
-                   total_amount::FLOAT8 AS total_amount, contribution_type::text AS contribution_type,
+                   total_amount, contribution_type::text AS contribution_type,
                    call_date, due_date, sent_date,
                    status::text AS status, account_code, notes,
                    created_at, updated_at, created_by
@@ -200,7 +200,7 @@ impl CallForFundsRepository for PostgresCallForFundsRepository {
         let rows = sqlx::query(
             r#"
             SELECT id, organization_id, building_id, title, description,
-                   total_amount::FLOAT8 AS total_amount, contribution_type::text AS contribution_type,
+                   total_amount, contribution_type::text AS contribution_type,
                    call_date, due_date, sent_date,
                    status::text AS status, account_code, notes,
                    created_at, updated_at, created_by

--- a/backend/tests/bdd_financial.rs
+++ b/backend/tests/bdd_financial.rs
@@ -111,8 +111,8 @@ pub struct FinancialWorld {
 
     // Charge distribution tracking
     distribution_list_count: usize,
-    distribution_amounts: Vec<(String, f64)>,
-    total_due: Option<f64>,
+    distribution_amounts: Vec<(String, Decimal)>,
+    total_due: Option<Decimal>,
 
     // Dashboard tracking
     dashboard_stats: Option<AccountantDashboardStats>,
@@ -2595,7 +2595,7 @@ async fn then_owner_pct_contribution(world: &mut FinancialWorld, _pct: Decimal, 
             .unwrap_or_default();
         for contrib in &contribs {
             let diff = (contrib.amount - expected_amount).abs();
-            if diff < 1.0 {
+            if diff < dec!(1) {
                 return; // Found matching contribution
             }
         }
@@ -2767,7 +2767,7 @@ async fn given_owner_with_unit(world: &mut FinancialWorld, name: String) {
 async fn when_create_contribution(world: &mut FinancialWorld, name: String, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     let mut description = "BDD contribution".to_string();
-    let mut amount = 0.0;
+    let mut amount = Decimal::ZERO;
     let mut contribution_type = ContributionType::Regular;
     let mut account_code: Option<String> = None;
 
@@ -2776,7 +2776,7 @@ async fn when_create_contribution(world: &mut FinancialWorld, name: String, step
         let val = row[1].as_str();
         match key {
             "description" => description = val.to_string(),
-            "amount" => amount = val.parse().unwrap_or(0.0),
+            "amount" => amount = val.parse().unwrap_or(Decimal::ZERO),
             "contribution_type" => contribution_type = parse_contribution_type(val),
             "account_code" => account_code = Some(val.to_string()),
             _ => {}
@@ -2876,7 +2876,7 @@ async fn then_contribution_details(world: &mut FinancialWorld) {
 #[then("the amount should be correct")]
 async fn then_amount_correct(world: &mut FinancialWorld) {
     let c = world.last_contribution.as_ref().expect("contribution");
-    assert!(c.amount > 0.0, "Amount should be positive");
+    assert!(c.amount > Decimal::ZERO, "Amount should be positive");
 }
 
 #[given(regex = r#"^(\d+) contributions exist for "([^"]*)"$"#)]
@@ -2898,7 +2898,7 @@ async fn given_n_contributions(world: &mut FinancialWorld, count: usize, name: S
                 owner_id,
                 world.unit_ids.first().copied(),
                 format!("Contribution {}", i + 1),
-                100.0 * (i + 1) as f64,
+                dec!(100) * Decimal::from(i + 1),
                 ContributionType::Regular,
                 Utc::now(),
                 None,
@@ -3398,12 +3398,14 @@ async fn then_owner_should_owe(world: &mut FinancialWorld, name: String, expecte
         world.distribution_amounts
     );
     let (_, amount) = found.unwrap();
-    let diff = (amount - expected).abs();
+    let expected_dec = <Decimal as rust_decimal::prelude::FromPrimitive>::from_f64(expected)
+        .unwrap_or(Decimal::ZERO);
+    let diff = (*amount - expected_dec).abs();
     assert!(
-        diff < 0.02,
+        diff < dec!(0.02),
         "Expected {} to owe {}, got {} (diff: {})",
         name,
-        expected,
+        expected_dec,
         amount,
         diff
     );
@@ -3565,11 +3567,12 @@ async fn when_get_total_due(world: &mut FinancialWorld, name: String, _pct: f64)
 #[then(regex = r#"^the total due should be (\d+(?:\.\d+)?) EUR \((\d+)% of (\d+) EUR\)$"#)]
 async fn then_total_due_amount(world: &mut FinancialWorld, expected: f64, _pct: f64, _total: f64) {
     let total = world.total_due.expect("total due");
-    let diff = (total - expected).abs();
+    let expected_dec = rust_decimal::prelude::FromPrimitive::from_f64(expected).unwrap_or(Decimal::ZERO);
+    let diff = (total - expected_dec).abs();
     assert!(
-        diff < 1.0,
+        diff < dec!(1),
         "Expected total due {}, got {} (diff: {})",
-        expected,
+        expected_dec,
         total,
         diff
     );
@@ -3713,7 +3716,7 @@ async fn then_stats_include_expenses(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
     // Total expenses should be >= 0
     assert!(
-        stats.total_expenses_current_month >= 0.0,
+        stats.total_expenses_current_month >= Decimal::ZERO,
         "Expense total should be >= 0"
     );
 }
@@ -3721,13 +3724,13 @@ async fn then_stats_include_expenses(world: &mut FinancialWorld) {
 #[then("the stats should include payment totals")]
 async fn then_stats_include_payments(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
-    assert!(stats.total_paid >= 0.0, "Paid total should be >= 0");
+    assert!(stats.total_paid >= Decimal::ZERO, "Paid total should be >= 0");
 }
 
 #[then("the stats should include outstanding amounts")]
 async fn then_stats_include_outstanding(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
-    assert!(stats.total_pending >= 0.0, "Pending total should be >= 0");
+    assert!(stats.total_pending >= Decimal::ZERO, "Pending total should be >= 0");
 }
 
 #[given(regex = r#"^(\d+) transactions exist$"#)]
@@ -3830,7 +3833,7 @@ async fn then_stats_include_contributions(world: &mut FinancialWorld) {
     // Dashboard stats don't directly show contributions, but total_pending should account for them
     let stats = world.dashboard_stats.as_ref().expect("stats");
     // Just verify we have valid stats
-    assert!(stats.paid_percentage >= 0.0);
+    assert!(stats.paid_percentage >= Decimal::ZERO);
 }
 
 #[given("no financial data exists")]
@@ -3852,9 +3855,9 @@ async fn given_no_financial_data(world: &mut FinancialWorld) {
 #[then("all totals should be zero")]
 async fn then_all_totals_zero(world: &mut FinancialWorld) {
     let stats = world.dashboard_stats.as_ref().expect("stats");
-    assert_eq!(stats.total_expenses_current_month, 0.0);
-    assert_eq!(stats.total_paid, 0.0);
-    assert_eq!(stats.total_pending, 0.0);
+    assert_eq!(stats.total_expenses_current_month, Decimal::ZERO);
+    assert_eq!(stats.total_paid, Decimal::ZERO);
+    assert_eq!(stats.total_pending, Decimal::ZERO);
 }
 
 // ==================== PARSE HELPERS ====================
@@ -4030,11 +4033,11 @@ async fn when_create_invoice_draft(world: &mut FinancialWorld, step: &Step) {
     let building_id = world.building_id.unwrap();
 
     let description = get_invoice_table_value(step, "description").unwrap_or_default();
-    let amount_excl_vat: f64 = get_invoice_table_value(step, "amount_excl_vat")
+    let amount_excl_vat: Decimal = get_invoice_table_value(step, "amount_excl_vat")
         .unwrap_or("1000.0".to_string())
         .parse()
         .unwrap();
-    let vat_rate: f64 = get_invoice_table_value(step, "vat_rate")
+    let vat_rate: Decimal = get_invoice_table_value(step, "vat_rate")
         .unwrap_or("21.0".to_string())
         .parse()
         .unwrap();
@@ -4105,11 +4108,12 @@ async fn then_invoice_status(world: &mut FinancialWorld, expected: String) {
 #[then(regex = r#"^the invoice VAT amount should be ([0-9.]+)$"#)]
 async fn then_invoice_vat_amount(world: &mut FinancialWorld, expected: f64) {
     let inv = world.last_invoice.as_ref().expect("no invoice");
-    let vat = inv.vat_amount.unwrap_or(0.0);
+    let vat = inv.vat_amount.unwrap_or(Decimal::ZERO);
+    let expected_dec = rust_decimal::prelude::FromPrimitive::from_f64(expected).unwrap_or(Decimal::ZERO);
     assert!(
-        (vat - expected).abs() < 0.01,
+        (vat - expected_dec).abs() < dec!(0.01),
         "Expected VAT {}, got {}",
-        expected,
+        expected_dec,
         vat
     );
 }
@@ -4118,8 +4122,9 @@ async fn then_invoice_vat_amount(world: &mut FinancialWorld, expected: f64) {
 async fn then_invoice_total_ttc(world: &mut FinancialWorld, expected: f64) {
     let inv = world.last_invoice.as_ref().expect("no invoice");
     let ttc = inv.amount_incl_vat.unwrap_or(inv.amount);
+    let expected_dec = rust_decimal::prelude::FromPrimitive::from_f64(expected).unwrap_or(Decimal::ZERO);
     assert!(
-        (ttc - expected).abs() < 0.01,
+        (ttc - expected_dec).abs() < dec!(0.01),
         "Expected TTC {}, got {}",
         expected,
         ttc
@@ -4157,8 +4162,8 @@ async fn given_draft_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Test draft invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4220,8 +4225,8 @@ async fn given_approved_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Approved invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4263,8 +4268,8 @@ async fn given_rejected_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Rejected invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4339,8 +4344,8 @@ async fn given_pending_invoice(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Pending invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4602,8 +4607,8 @@ async fn given_n_pending_invoices(world: &mut FinancialWorld, count: usize) {
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Pending invoice {}", i + 1),
-            amount_excl_vat: 1000.0,
-            vat_rate: 21.0,
+            amount_excl_vat: dec!(1000),
+            vat_rate: dec!(21),
             invoice_date: "2025-01-15T00:00:00Z".to_string(),
             due_date: None,
             supplier: None,
@@ -4632,8 +4637,8 @@ async fn given_n_approved_invoices(world: &mut FinancialWorld, count: usize) {
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Approved invoice {}", i + 1),
-            amount_excl_vat: 1000.0,
-            vat_rate: 21.0,
+            amount_excl_vat: dec!(1000),
+            vat_rate: dec!(21),
             invoice_date: "2025-01-15T00:00:00Z".to_string(),
             due_date: None,
             supplier: None,
@@ -4799,8 +4804,8 @@ async fn given_create_and_submit(world: &mut FinancialWorld) {
         building_id: world.building_id.unwrap().to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Workflow test invoice".to_string(),
-        amount_excl_vat: 1000.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(1000),
+        vat_rate: dec!(21),
         invoice_date: "2025-01-15T00:00:00Z".to_string(),
         due_date: None,
         supplier: None,
@@ -4824,7 +4829,7 @@ async fn when_update_rejected(world: &mut FinancialWorld) {
     let dto = UpdateInvoiceDraftDto {
         description: Some("Corrected invoice".to_string()),
         category: None,
-        amount_excl_vat: Some(900.0),
+        amount_excl_vat: Some(dec!(900)),
         vat_rate: None,
         invoice_date: None,
         due_date: None,
@@ -4889,14 +4894,16 @@ async fn given_3_with_amounts(world: &mut FinancialWorld) {
 #[when("requesting total due for Owner 1")]
 async fn when_request_total_due(world: &mut FinancialWorld) {
     world.operation_success = true;
-    world.total_due = Some(952.50);
+    world.total_due = Some(dec!(952.50));
 }
 
 #[then(regex = r#"^the total amount due should be ([0-9.]+) EUR$"#)]
 async fn then_total_due(world: &mut FinancialWorld, expected: f64) {
-    let total = world.total_due.unwrap_or(0.0);
+    let total = world.total_due.unwrap_or(Decimal::ZERO);
+    let expected_dec = <Decimal as rust_decimal::prelude::FromPrimitive>::from_f64(expected)
+        .unwrap_or(Decimal::ZERO);
     assert!(
-        (total - expected).abs() < 0.01,
+        (total - expected_dec).abs() < dec!(0.01),
         "Expected {}, got {}",
         expected,
         total
@@ -5084,7 +5091,7 @@ async fn given_pending_first_reminder(world: &mut FinancialWorld) {
         world.setup_database().await;
     }
     if world.expense_id.is_none() {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
     if world.owner_by_name.is_empty() {
         let owner_id = world
@@ -5218,7 +5225,7 @@ async fn then_can_add_tracking(world: &mut FinancialWorld) {
 #[given(regex = r#"^(\d+) overdue expenses in the organization$"#)]
 async fn given_n_overdue(world: &mut FinancialWorld, count: usize) {
     for _ in 0..count {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
 }
 
@@ -5271,7 +5278,7 @@ async fn then_stats_by_level(_world: &mut FinancialWorld) {}
 #[given(regex = r#"^(\d+) overdue expenses without reminders$"#)]
 async fn given_overdue_without_reminders(world: &mut FinancialWorld, count: usize) {
     for _ in 0..count {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
 }
 
@@ -5366,7 +5373,7 @@ async fn then_request_forbidden_2(world: &mut FinancialWorld) {
 #[when("I create a payment reminder")]
 async fn when_create_reminder(world: &mut FinancialWorld) {
     if world.expense_id.is_none() {
-        given_overdue_expense(world, 100.0, 20).await;
+        given_overdue_expense(world, dec!(100), 20).await;
     }
     if world.owner_by_name.is_empty() {
         let owner_id = world
@@ -5414,7 +5421,7 @@ async fn given_formal_notice(world: &mut FinancialWorld) {
         world.setup_database().await;
     }
     // Always create a 65-day expense: FormalNotice requires >= 60 days overdue
-    given_overdue_expense(world, 100.0, 65).await;
+    given_overdue_expense(world, dec!(100), 65).await;
     if world.owner_by_name.is_empty() {
         let owner_id = world
             .create_owner_sql("Formal", "Notice", "formal@test.be")
@@ -6612,7 +6619,7 @@ async fn given_user_with_role(world: &mut FinancialWorld, name: String, role: St
 async fn when_create_simple_expense(world: &mut FinancialWorld, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     let mut description = "BDD Expense".to_string();
-    let mut amount = 0.0f64;
+    let mut amount = Decimal::ZERO;
     let mut _category = "maintenance".to_string();
 
     for row in &table.rows {
@@ -6620,7 +6627,7 @@ async fn when_create_simple_expense(world: &mut FinancialWorld, step: &Step) {
         let val = row[1].trim();
         match key {
             "description" => description = val.to_string(),
-            "amount" => amount = val.parse().unwrap_or(0.0),
+            "amount" => amount = val.parse().unwrap_or(Decimal::ZERO),
             "category" => _category = val.to_string(),
             _ => {}
         }
@@ -6688,16 +6695,16 @@ async fn then_expense_amount(world: &mut FinancialWorld, expected: f64) {
 async fn when_create_expense_with_tva(world: &mut FinancialWorld, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     let mut description = "BDD Expense TVA".to_string();
-    let mut amount_excl_vat = 0.0f64;
-    let mut vat_rate = 21.0f64;
+    let mut amount_excl_vat = Decimal::ZERO;
+    let mut vat_rate = dec!(21);
 
     for row in &table.rows {
         let key = row[0].trim();
         let val = row[1].trim();
         match key {
             "description" => description = val.to_string(),
-            "amount_excl_vat" => amount_excl_vat = val.parse().unwrap_or(0.0),
-            "vat_rate" => vat_rate = val.parse().unwrap_or(21.0),
+            "amount_excl_vat" => amount_excl_vat = val.parse().unwrap_or(Decimal::ZERO),
+            "vat_rate" => vat_rate = val.parse().unwrap_or(dec!(21)),
             _ => {}
         }
     }
@@ -6747,10 +6754,12 @@ async fn then_expense_created(world: &mut FinancialWorld) {
 async fn then_amount_incl_vat(world: &mut FinancialWorld, expected: f64) {
     if let Some(ref inv) = world.last_invoice {
         let ttc = inv.amount_incl_vat.unwrap_or(inv.amount);
+        let expected_dec = <Decimal as rust_decimal::prelude::FromPrimitive>::from_f64(expected)
+            .unwrap_or(Decimal::ZERO);
         assert!(
-            (ttc - expected).abs() < 0.01,
+            (ttc - expected_dec).abs() < dec!(0.01),
             "Expected amount_incl_vat {}, got {}",
-            expected,
+            expected_dec,
             ttc
         );
     } else {
@@ -6801,8 +6810,8 @@ async fn given_draft_expense(world: &mut FinancialWorld) {
         building_id: building_id.to_string(),
         category: ExpenseCategory::Maintenance,
         description: "Draft expense for BDD".to_string(),
-        amount_excl_vat: 500.0,
-        vat_rate: 21.0,
+        amount_excl_vat: dec!(500),
+        vat_rate: dec!(21),
         invoice_date: chrono::Utc::now().to_rfc3339(),
         due_date: None,
         supplier: None,
@@ -7030,7 +7039,7 @@ async fn given_n_expenses_for_building(world: &mut FinancialWorld, count: usize)
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Expense {} for building list test", i + 1),
-            amount: 100.0 * (i + 1) as f64,
+            amount: dec!(100) * Decimal::from(i + 1),
             expense_date: chrono::Utc::now().to_rfc3339(),
             supplier: None,
             invoice_number: None,
@@ -7084,8 +7093,8 @@ async fn given_n_expenses_with_status(world: &mut FinancialWorld, count: usize, 
             building_id: building_id.to_string(),
             category: ExpenseCategory::Maintenance,
             description: format!("Filtered expense {} status {}", i + 1, status),
-            amount_excl_vat: 200.0,
-            vat_rate: 21.0,
+            amount_excl_vat: dec!(200),
+            vat_rate: dec!(21),
             invoice_date: chrono::Utc::now().to_rfc3339(),
             due_date: None,
             supplier: None,
@@ -7175,8 +7184,8 @@ async fn then_all_expenses_have_status(world: &mut FinancialWorld, _expected: St
 async fn when_create_expense_with_lines(world: &mut FinancialWorld, step: &Step) {
     let table = step.table.as_ref().expect("table expected");
     // Parse line items to compute total amount
-    let mut total_excl_vat = 0.0f64;
-    let mut vat_total = 0.0f64;
+    let mut total_excl_vat = Decimal::ZERO;
+    let mut vat_total = Decimal::ZERO;
     let mut headers_skipped = false;
 
     for row in &table.rows {
@@ -7185,12 +7194,12 @@ async fn when_create_expense_with_lines(world: &mut FinancialWorld, step: &Step)
             continue;
         }
         if row.len() >= 4 {
-            let qty: f64 = row[1].trim().parse().unwrap_or(1.0);
-            let unit_price: f64 = row[2].trim().parse().unwrap_or(0.0);
-            let vat_rate: f64 = row[3].trim().parse().unwrap_or(21.0);
+            let qty: Decimal = row[1].trim().parse().unwrap_or(dec!(1));
+            let unit_price: Decimal = row[2].trim().parse().unwrap_or(Decimal::ZERO);
+            let vat_rate: Decimal = row[3].trim().parse().unwrap_or(dec!(21));
             let line_excl = qty * unit_price;
             total_excl_vat += line_excl;
-            vat_total += line_excl * vat_rate / 100.0;
+            vat_total += line_excl * vat_rate / dec!(100);
         }
     }
 
@@ -7203,10 +7212,10 @@ async fn when_create_expense_with_lines(world: &mut FinancialWorld, step: &Step)
         category: ExpenseCategory::Maintenance,
         description: "Multi-line invoice expense".to_string(),
         amount_excl_vat: total_excl_vat,
-        vat_rate: if total_excl_vat > 0.0 {
-            vat_total / total_excl_vat * 100.0
+        vat_rate: if total_excl_vat > Decimal::ZERO {
+            vat_total / total_excl_vat * dec!(100)
         } else {
-            21.0
+            dec!(21)
         },
         invoice_date: chrono::Utc::now().to_rfc3339(),
         due_date: None,

--- a/backend/tests/e2e_call_for_funds.rs
+++ b/backend/tests/e2e_call_for_funds.rs
@@ -8,6 +8,7 @@ use actix_web::http::header;
 use actix_web::{test, App};
 use koprogo_api::application::dto::{CreateBuildingDto, CreateOwnerDto, CreateUnitDto};
 use koprogo_api::domain::entities::UnitType;
+use rust_decimal_macros::dec;
 use koprogo_api::infrastructure::web::configure_routes;
 use serde_json::json;
 use serial_test::serial;
@@ -96,7 +97,7 @@ async fn create_call_for_funds_fixtures(
     let _ = app_state
         .unit_owner_use_cases
         .add_owner_to_unit(
-            unit_id, owner_id, 0.25, // 25% ownership share
+            unit_id, owner_id, dec!(0.25), // 25% ownership share
             true, // is primary contact
         )
         .await;


### PR DESCRIPTION
## Summary

Complète le cascade EXP-003 (Decimal vs f64) — surfacé par PR #450 (CI alignment) qui a révélé 30+ ColumnDecode panics BDD :
> `Rust type Decimal not compatible with SQL type FLOAT8`

Implémente la story documentée dans l'issue ouverte par toi (3 causes diagnostiquées + recette en 4 phases).

## 3 causes corrigées

### 1. Schema DB : `expenses.amount` FLOAT8 → NUMERIC(12,2)

`expenses.amount` était `DOUBLE PRECISION` (migration 20240101000004) mais `Expense.amount: Decimal` côté Rust → mismatch.

Migration **20260502000000_complete_expense_decimal_cascade.sql** :
- DROP CHECK constraint `expenses_amount_check` (référence `0::double precision`)
- `ALTER COLUMN amount TYPE NUMERIC(12,2)` aligné sur `journal_entry_lines.{debit,credit}` 
- Re-ADD CHECK avec littéral NUMERIC

Aucune dépendance view/trigger sur `expenses.amount` (vérifié via `information_schema.view_column_usage`).

### 2. Casts SQL résiduels dans `call_for_funds_repository_impl.rs`

4 SELECT statements appliquaient `total_amount::FLOAT8 AS total_amount` alors que la colonne est déjà `DECIMAL(10,2)` et `CallForFunds.total_amount: Decimal`. Casts supprimés — sqlx décode NUMERIC → Decimal nativement.

### 3. DTO `ExpenseFilters` Option<f64> → Option<Decimal>

`min_amount`/`max_amount` étaient `Option<f64>` bound dans des queries qui consomment maintenant Decimal → migration vers `Option<Decimal>`.

## Cascade tests

`bdd_financial.rs` (~7000 lignes) avait des f64 literals/declarations résiduelles qui paniquaient au binding post-migration. Migration intégrale :
- `let mut amount = 0.0f64` → `Decimal::ZERO`
- `100.0 * (i + 1) as f64` → `dec!(100) * Decimal::from(i + 1)`
- `vat_rate: 21.0` → `dec!(21)`
- `(vat - expected).abs() < 0.01` → conversion via `<Decimal as FromPrimitive>::from_f64(expected)`
- `World.distribution_amounts: Vec<(String, f64)>` → `Vec<(String, Decimal)>`
- `World.total_due: Option<f64>` → `Option<Decimal>`

`e2e_call_for_funds.rs:99` : `0.25` → `dec!(0.25)`

## Vérifications

- ✅ `cargo check --tests` : 0 erreur (de 60 → 0)
- ✅ `cargo sqlx prepare --workspace` : 30 .sqlx query files régénérés (committés)
- ⏳ `cargo test --test bdd_financial` : runtime validation Monitor active — résultat dans le commentaire suivant si pas vert post-merge

## Hors scope (PRs follow-up)

| PR future | Scope |
|---|---|
| `story/EXP-005-payment-reminders-decimal` | `PaymentReminder.{amount_owed,penalty_amount,total_amount}: f64 → Decimal` + ALTER COLUMN |
| `story/EXP-006-work-report-cost-decimal` | `WorkReport.cost`, `TechnicalInspection.cost: f64 → Decimal` |
| Décision ADR-0009 follow | `units.quota`/`surface_area` : f64 OK car non-comptable, à confirmer |

## Test plan

- [x] `cargo check --tests` clean
- [x] `cargo sqlx prepare` à jour
- [ ] Reviewer : vérifier que la migration NUMERIC(12,2) est appropriée pour la limite max d'expenses (max 9_999_999.99 EUR — généreux pour gros travaux copro)
- [ ] CI BDD financial green (post-merge PR-E qui ajoute le trigger sur `story/**`)
- [ ] Reviewer : pas de régression sur cargo test --lib (1213 tests EXP-003)

## Refs

- ADR-0007 (Decimal vs f64 pour comptabilité), ADR-0008 (NUMERIC vs DOUBLE), ADR-0009 (IoT keep f64)
- PR-E #450 (CI alignment) — surface du bug
- Issue EXP-003-complete (ouverte par toi)
- Bloque : déploiement GitOps multi-topologie (PR-A/PR-C mergées ✅, PR-E + PR-B à venir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
