### PR TITLE
chore(deps): dependabot target feature/dev + group patch/minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,62 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot config — KoproGo
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot-yml-file
+#
+# All PRs target `feature/dev` so they go through the official GitFlow:
+#   feature/dev → dev → integration → staging → production → main
+# Direct dependency bumps to `main` would bypass the CI gates configured in PR-E
+# (ci.yml + security.yml + docker-build-push.yml triggers).
 
 version: 2
 updates:
   # Backend dependencies (Rust/Cargo)
   - package-ecosystem: "cargo"
     directory: "/backend"
+    target-branch: "feature/dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    # Group patch + minor bumps — reduces PR noise
+    groups:
+      cargo-patch:
+        update-types:
+          - "patch"
+      cargo-minor:
+        update-types:
+          - "minor"
 
   # Frontend dependencies (npm)
   - package-ecosystem: "npm"
     directory: "/frontend"
+    target-branch: "feature/dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    groups:
+      npm-patch:
+        update-types:
+          - "patch"
+      npm-minor:
+        update-types:
+          - "minor"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "feature/dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    groups:
+      gh-actions:
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
## Summary

Avant : dependabot ouvrait les PRs directement sur \`main\` → bypass complet du GitFlow (PR-E #450 ci.yml + security.yml + docker-build-push.yml ne s'appliquent pas).

Après :
- \`target-branch: feature/dev\` pour cargo / npm / github-actions
- \`groups: patch + minor\` → 1 PR groupée par ecosystem (au lieu de 1 par dépendance)
- Major bumps (typescript 5→6, sha2 0.10→0.11) gardent leur PR isolée

## Action de suivi (humain ou agent autorisé)

Re-targeter les 22 PRs dependabot existantes :
\`\`\`bash
for pr in 411 412 413 414 415 416 417 418 419 420 421 422 423 424 356 360 362 364 369 375 376 377; do
  gh pr edit \$pr --base feature/dev
done
\`\`\`

Une fois sur feature/dev, la CI (PR-E) tournera et les bumps safes peuvent merger via auto-merge squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)