### PR TITLE
chore(clippy): remove redundant Decimal::from_f64 conversions in tests

### DIFF
--- a/backend/tests/bdd_financial.rs
+++ b/backend/tests/bdd_financial.rs
@@ -3447,14 +3447,12 @@ async fn then_owner_should_owe(
         world.distribution_amounts
     );
     let (_, amount) = found.unwrap();
-    let expected_dec = <Decimal as rust_decimal::prelude::FromPrimitive>::from_f64(expected)
-        .unwrap_or(Decimal::ZERO);
-    let diff = (*amount - expected_dec).abs();
+    let diff = (*amount - expected).abs();
     assert!(
         diff < dec!(0.02),
         "Expected {} to owe {}, got {} (diff: {})",
         name,
-        expected_dec,
+        expected,
         amount,
         diff
     );
@@ -3621,13 +3619,11 @@ async fn then_total_due_amount(
     _total: Decimal,
 ) {
     let total = world.total_due.expect("total due");
-    let expected_dec =
-        rust_decimal::prelude::FromPrimitive::from_f64(expected).unwrap_or(Decimal::ZERO);
-    let diff = (total - expected_dec).abs();
+    let diff = (total - expected).abs();
     assert!(
         diff < dec!(1),
         "Expected total due {}, got {} (diff: {})",
-        expected_dec,
+        expected,
         total,
         diff
     );
@@ -4170,12 +4166,10 @@ async fn then_invoice_status(world: &mut FinancialWorld, expected: String) {
 async fn then_invoice_vat_amount(world: &mut FinancialWorld, expected: Decimal) {
     let inv = world.last_invoice.as_ref().expect("no invoice");
     let vat = inv.vat_amount.unwrap_or(Decimal::ZERO);
-    let expected_dec =
-        rust_decimal::prelude::FromPrimitive::from_f64(expected).unwrap_or(Decimal::ZERO);
     assert!(
-        (vat - expected_dec).abs() < dec!(0.01),
+        (vat - expected).abs() < dec!(0.01),
         "Expected VAT {}, got {}",
-        expected_dec,
+        expected,
         vat
     );
 }
@@ -4184,10 +4178,8 @@ async fn then_invoice_vat_amount(world: &mut FinancialWorld, expected: Decimal) 
 async fn then_invoice_total_ttc(world: &mut FinancialWorld, expected: Decimal) {
     let inv = world.last_invoice.as_ref().expect("no invoice");
     let ttc = inv.amount_incl_vat.unwrap_or(inv.amount);
-    let expected_dec =
-        rust_decimal::prelude::FromPrimitive::from_f64(expected).unwrap_or(Decimal::ZERO);
     assert!(
-        (ttc - expected_dec).abs() < dec!(0.01),
+        (ttc - expected).abs() < dec!(0.01),
         "Expected TTC {}, got {}",
         expected,
         ttc
@@ -4961,12 +4953,10 @@ async fn when_request_total_due(world: &mut FinancialWorld) {
 }
 
 #[then(regex = r#"^the total amount due should be ([0-9.]+) EUR$"#)]
-async fn then_total_due(world: &mut FinancialWorld, expected: f64) {
+async fn then_total_due(world: &mut FinancialWorld, expected: Decimal) {
     let total = world.total_due.unwrap_or(Decimal::ZERO);
-    let expected_dec = <Decimal as rust_decimal::prelude::FromPrimitive>::from_f64(expected)
-        .unwrap_or(Decimal::ZERO);
     assert!(
-        (total - expected_dec).abs() < dec!(0.01),
+        (total - expected).abs() < dec!(0.01),
         "Expected {}, got {}",
         expected,
         total
@@ -6819,12 +6809,10 @@ async fn then_expense_created(world: &mut FinancialWorld) {
 async fn then_amount_incl_vat(world: &mut FinancialWorld, expected: Decimal) {
     if let Some(ref inv) = world.last_invoice {
         let ttc = inv.amount_incl_vat.unwrap_or(inv.amount);
-        let expected_dec = <Decimal as rust_decimal::prelude::FromPrimitive>::from_f64(expected)
-            .unwrap_or(Decimal::ZERO);
         assert!(
-            (ttc - expected_dec).abs() < dec!(0.01),
+            (ttc - expected).abs() < dec!(0.01),
             "Expected amount_incl_vat {}, got {}",
-            expected_dec,
+            expected,
             ttc
         );
     } else {

--- a/backend/tests/e2e_call_for_funds.rs
+++ b/backend/tests/e2e_call_for_funds.rs
@@ -9,7 +9,6 @@ use actix_web::{test, App};
 use koprogo_api::application::dto::{CreateBuildingDto, CreateOwnerDto, CreateUnitDto};
 use koprogo_api::domain::entities::UnitType;
 use koprogo_api::infrastructure::web::configure_routes;
-use rust_decimal_macros::dec;
 use serde_json::json;
 use serial_test::serial;
 use uuid::Uuid;


### PR DESCRIPTION
## Summary

CI clippy échouait sur feature/dev post-PR #459 (fmt fix). 4 fonctions BDD avaient \`expected: Decimal\` en signature (cucumber capture decimal nativement via FromStr) mais utilisaient encore \`from_f64(expected)\` qui attend f64 → type mismatch.

## Fix

- \`bdd_financial.rs\` : 4 fonctions — suppression \`let expected_dec = from_f64(expected)\`, utilisation directe de \`expected\` (déjà Decimal). 1 fonction \`then_total_due\` passe de \`expected: f64\` à \`expected: Decimal\` pour cohérence.
- \`e2e_call_for_funds.rs\` : suppression \`use rust_decimal_macros::dec\` (usages FQN après cargo fmt).

## Vérifications

- ✅ \`cargo fmt --check\` clean
- ✅ \`cargo clippy --all-targets --all-features -- -D warnings\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)