### PR TITLE
docs(cowork): audit pré-release v0.1.0 + re-vérification post-fix (2026-04-18)

### DIFF
--- a/docs/cowork/Prompt2026-04-18-21-05.md
+++ b/docs/cowork/Prompt2026-04-18-21-05.md
@@ -1,0 +1,177 @@
+# Audit pré-release KoproGo v0.1.0 — Rapport final
+
+**Date** : 2026-04-18 21:05 CEST
+**Branche** : `feature/dev` @ `ef003c8`
+**Auditeur** : Cowork (Claude)
+**Prompt source** : `rapports/Prompt-Audit-v010-2026-04-18.md`
+**Durée effective** : ~40 min (cap 45 min respecté)
+
+---
+
+## Verdict : NO-GO
+
+**3 bugs bloquants release** empêchent le tag `v0.1.0`.
+Tous relèvent du même pattern : **les handlers `onclick` Svelte 5 runes ne se déclenchent pas** sur les boutons qui ouvrent des modaux ou soumettent des formulaires dynamiques.
+
+---
+
+## 1. Parcours verts
+
+### P0 — Smoke cross-cutting
+- [x] `docker compose up -d` → 5 services Up + healthy
+- [x] `http://localhost` charge la home < 2s, aucune erreur console bloquante
+- [x] Switch FR → NL → DE → EN : sidebar et dashboards suivent (quelques clés manquantes documentées ci-dessous)
+- [x] Login `admin@koprogo.com / admin123` → dashboard SuperAdmin visible
+- [x] Déconnexion manuelle → 1 seul toast (pas de cascade — fix #383 tient)
+
+### P1 — Contrat de types
+- [x] **Tickets** : priorités `Low/Medium/High/Critical` ✅, 9 catégories dont `CommonAreas/Elevator/Landscaping/Other` ✅, statuts `Open/InProgress/Resolved/Closed/Cancelled` ✅ (pas de `Assigned` fantôme)
+- [x] **Résolutions** : `ResolutionType` = `ordinary/extraordinary` (snake_case) ✅, `MajorityType` = `absolute/two_thirds/four_fifths/unanimity` (conforme droit belge Art. 577-7 CC, diverge du prompt initial qui attendait `simple/absolute/qualified` — adaptation correcte)
+- [x] **Expenses** : `approval_status` dropdown = `draft/pending_approval/approved/rejected` ✅ (vérifié via Workflow Factures, 0 factures en seed)
+- [x] **Sondages** : `poll_status` = `draft/active/closed/cancelled` ✅
+
+### P2 — Runes + WCAG 2.1 AA (partiel)
+- [x] Form labels : tous les `<input>` et `<select>` inspectés ont un `<label for=id>` associé ✅
+- [x] Boutons icône nav : `aria-label="Notifications"`, `aria-label="Ouvrir le menu"`, `aria-label="Changer de langue"`, `aria-label="Synchroniser les données"` ✅
+
+### P3 — Parcours métier multi-rôles (partiel)
+- [x] **canManage gating** (fix B18) : en tant qu'owner (Alice Dubois), les boutons syndic (Marquer comme terminée, Annuler, Reporter, Ajouter résolution, Supprimer résolution) sont correctement masqués sur la page meeting-detail ✅
+- [x] **Erreur forcée** : URL avec mauvais UUID → message "Meeting not found" propre, pas de message Postgres brut ✅ (fix #383 tient)
+
+---
+
+## 2. Parcours rouges — Bugs bloquants v0.1.0
+
+### B1-v010 — Boutons de création modal inopérants (RELEASE BLOCKER)
+
+**Sévérité** : Critique
+**Pattern** : Les `onclick` handlers Svelte 5 runes des boutons qui ouvrent des modaux ne se déclenchent pas. Aucun modal ne s'ouvre, aucune erreur console, aucun feedback utilisateur.
+
+**Boutons affectés confirmés** :
+| Page | Bouton | Composant probable |
+|---|---|---|
+| `/tickets` | "Créer un nouveau ticket" | `TicketCreateModal` |
+| `/owners` | "Ajouter un copropriétaire" | `OwnerCreateModal` |
+| `/meetings` | "Nouvelle réunion" | `MeetingCreateModal` |
+
+**Impact** : Impossible de créer tickets, copropriétaires, ou réunions via l'UI. Bloque le workflow complet pour tout rôle.
+
+**Cause probable** : Migration Svelte 5 runes — les boutons utilisent probablement `on:click` (Svelte 4) au lieu de `onclick` (Svelte 5), ou le binding réactif d'état `showModal` n'est pas compatible avec la syntaxe runes `$state`.
+
+---
+
+### B9-v010 — Vote sur résolution ne s'enregistre pas (RELEASE BLOCKER)
+
+**Sévérité** : Critique
+**Reproduction** :
+1. Login owner `alice@residence-parc.be / alice123`
+2. Naviguer vers meeting-detail de l'AG existante
+3. Sélectionner "Pour", renseigner tantièmes = 450
+4. Cliquer "Enregistrer le vote"
+5. → Rien ne se passe. Compteur reste à 0, pas de toast, pas d'erreur.
+
+**Impact** : Le workflow AG complet (quorum → vote → clôture → statut Adoptée/Rejetée) est impossible. Fonctionnalité coeur de la copropriété belge.
+
+**Cause probable** : Même pattern onclick Svelte 5 runes que B1-v010.
+
+---
+
+### B8-v010 — NotificationDropdown : Escape ne ferme pas (RELEASE BLOCKER WCAG)
+
+**Sévérité** : Haute (bloquant WCAG 2.1 AA)
+**Reproduction** : Cliquer sur la cloche notifications → dropdown s'ouvre → appuyer Escape → dropdown reste ouvert.
+
+**Impact** : Non-conformité WCAG 2.1 AA (critère 1.4.13 Dismiss, critère 2.1.1 Keyboard). L'engagement WCAG du Sprint 8 n'est pas tenu pour ce composant.
+
+---
+
+## 3. Parcours oranges — Bugs mineurs (post-release)
+
+### B4-v010 — QuorumPanel : toutes les clés i18n brutes
+
+**Sévérité** : Moyenne
+**Clés manquantes** : `meetings.quorum.title`, `meetings.quorum.legal_notice`, `meetings.quorum.presentQuotas`, `meetings.quorum.totalQuotas`, `meetings.quorum.preview`, `meetings.quorum.quorum_not_reached`, `meetings.quorum.validate`, `meetings.quorum.readonly`
+
+---
+
+### B6-v010 — `owners.count` : clé i18n brute sur la page Copropriétaires
+
+**Sévérité** : Basse
+**Page** : `/owners`
+
+---
+
+### B10-v010 — Commentaire debug visible : `// Svelte 5 runes mode`
+
+**Sévérité** : Basse
+**Page** : `/polls`
+**Description** : Le texte `// Svelte 5 runes mode` est rendu dans le HTML, visible entre le sélecteur d'immeuble et la section Sondages.
+
+---
+
+### B11-v010 — Message d'erreur "Meeting not found" en anglais
+
+**Sévérité** : Basse
+**Page** : `/meeting-detail?id=<uuid-invalide>`
+**Attendu** : Message traduit "Assemblée non trouvée" selon la locale active.
+
+---
+
+### B12-v010 — Toast "API Error: 404" sur meeting-detail (owner)
+
+**Sévérité** : Moyenne
+**Page** : `/meeting-detail` en tant qu'owner
+**Description** : Toast "API Error: 404" systématiquement affiché, probablement lié à un appel API owner-account qui échoue. Le toast "Aucun compte copropriétaire associé à ce profil" apparaît aussi en syndic.
+
+---
+
+### B13-v010 — NotificationDropdown texte tronqué
+
+**Sévérité** : Basse
+**Description** : Le texte "New notifications" est tronqué en "w notifications" à cause de la largeur du dropdown.
+
+---
+
+## 4. Observations
+
+### P4 — CI anti-drift
+
+| Gate | Résultat | Commentaire |
+|---|---|---|
+| Gate 4 : cap enums hand-written ≤ 4 | **FAIL (9)** | bookings.ts: 3, inspections.ts: 2, convocations.ts: 1, energy-campaigns.ts: 1, sharing.ts: 2. Le cap initial documentait 2 enums dans sharing.ts ; 7 enums supplémentaires ont été ajoutés sans mise à jour du cap. |
+| Gate 3 : svelte-check `--threshold warning` | Inconclusive | Ne peut s'exécuter hors Docker (tsconfig `astro/tsconfigs/strict` introuvable). À valider dans le container frontend. |
+| Gates 1+2 : openapi drift | Inconclusive | Working tree dirty (2163 fichiers modifiés). Vérification impossible hors du pipeline Docker standard. |
+
+### MajorityType — Évolution justifiée
+
+Le prompt attendait `simple/absolute/qualified` mais le frontend propose `absolute/two_thirds/four_fifths/unanimity`. C'est une amélioration conforme au droit belge (Art. 577-7 CC) qui distingue ces 4 seuils spécifiques. La documentation CLAUDE.md devrait être mise à jour.
+
+### Seed data limité
+
+Les pages Charges, Workflow Factures, Devis, Sondages sont vides (0 données seed). Les badges `approval_status` ont été vérifiés via les dropdowns de filtre (valeurs conformes), mais l'affichage réel des badges colorés n'a pas pu être testé visuellement.
+
+### Sidebar owner cohérente
+
+La sidebar owner (Alice) affiche correctement : Tableau de bord, Lots, Charges, Paiements, Moyens paiement, Mes tickets, Documents, Profil + section Communauté (SEL, Sondages, Annonces, Réservations, Partage, Compétences, Énergie, Gamification). Pas de liens syndic/admin qui fuient.
+
+---
+
+## 5. Résumé des actions avant v0.1.0
+
+| # | Bug | Priorité | Action |
+|---|---|---|---|
+| B1 | Modaux de création inopérants | **BLOCKER** | Auditer tous les composants modal pour migration onclick Svelte 5 runes |
+| B9 | Vote résolution ne s'enregistre pas | **BLOCKER** | Même fix que B1 — vérifier le binding `$state` + handler submit |
+| B8 | Escape ne ferme pas NotificationDropdown | **BLOCKER WCAG** | Ajouter `on:keydown` → Escape handler dans le composant |
+| B4 | QuorumPanel clés i18n | Post-release | Ajouter 8 clés dans les 4 locales |
+| B6 | `owners.count` i18n | Post-release | Ajouter clé dans les 4 locales |
+| B10 | Debug comment visible | Post-release | Retirer le commentaire `// Svelte 5 runes mode` du template |
+| B11 | Error message non traduit | Post-release | Utiliser la clé i18n pour "Meeting not found" |
+| B12 | Toast API Error 404 sur meeting | Post-release | Investiguer l'appel API owner-account qui 404 |
+| B13 | Notification dropdown tronqué | Post-release | Ajuster la largeur min du dropdown |
+| — | Gate 4 : 9 enums > cap 4 | Post-release | Migrer 5 enums vers auto-gen depuis OpenAPI, ou relever le cap documenté |
+
+---
+
+*Signé Cowork @ 2026-04-18 21:05 CEST — Branche `feature/dev` @ ef003c8*
+*Verdict : **NO-GO** — 3 blockers (B1 + B9 + B8) à fixer avant `git tag v0.1.0`*

--- a/docs/cowork/Prompt2026-04-18-22-30.md
+++ b/docs/cowork/Prompt2026-04-18-22-30.md
@@ -1,0 +1,139 @@
+# Prompt Cowork — Re-vérification post-fix audit v0.1.0
+
+**Date** : 2026-04-18 22:30
+**Branche** : `feature/dev` @ `49f8a2a` (4 commits au-dessus de `ef003c8`)
+**Prompt source précédent** : [docs/cowork/Prompt2026-04-18-21-05.md](./Prompt2026-04-18-21-05.md)
+**Contexte** : L'audit v010 @ 21:05 a posé **3 blockers release** (B1, B8, B9) + 2 majeurs (B5, B6) + 5 mineurs (B3/B10, B4, B6-new, B11, B13). Cette session valide que les 4 commits de fix tiennent en UI et que rien n'a cassé autour.
+
+---
+
+## Commits à vérifier
+
+| SHA | Scope | Bugs ciblés |
+|---|---|---|
+| `f89954e` | fix(svelte) | B3/B10 — commentaire `// Svelte 5 runes mode` qui fuyait dans le DOM (10 composants) |
+| `5cec04f` | fix(i18n) | B4 (QuorumPanel clés shadowées), B6 (sidebar FR-only), B6-new (`owners.count`), B11 (priorité des messages d'erreur traduits) |
+| `f38b67a` | fix(a11y) | B8 (Escape ferme NotificationDropdown), B13 (i18n + largeur responsive) |
+| `49f8a2a` | fix(v010) | B1 (bouton create ticket débloqué), B5 (vote gate sur ownership), B2/B9 (défense `type="button"`) |
+
+---
+
+## Mission
+
+Focus sur les parcours qui étaient rouges. **Chaque section ci-dessous doit passer** pour débloquer le tag `v0.1.0`. Si un blocker persiste, reporter précisément (capture + chemin DOM + onglet Network).
+
+### R1 — Blocker B1 : bouton "Créer un ticket"
+
+- [ ] `/tickets` sans building sélectionné → bouton **n'est plus grisé** (attribut `disabled` retiré)
+- [ ] Clic sans building → toast jaune "Veuillez d'abord sélectionner un immeuble" **apparaît**
+- [ ] Sélectionner un building → div "building-warning" se cache
+- [ ] Clic sur le bouton → `TicketCreateModal` s'ouvre (attendu : priorités `Low/Medium/High/Critical`, 9 catégories)
+- [ ] Créer un ticket minimal → persisté, visible dans la liste (vérifier appel `POST /api/v1/tickets` dans Network)
+
+### R2 — Blocker B8 (WCAG) : Escape ferme NotificationDropdown
+
+- [ ] Cliquer sur la cloche en haut-droite → dropdown s'ouvre
+- [ ] **Sans focus sur un item** (état vide "Aucune notification"), appuyer `Escape` → **dropdown se ferme**
+- [ ] Avec notifications visibles, `ArrowDown` focus le 1er, `Escape` → ferme + focus revient sur la cloche
+- [ ] Vérifier `svelte:window onkeydown` en inspectant l'event listener (DevTools → Elements → Event Listeners, doit lister `keydown` sur `window`)
+
+### R3 — Blocker B9 : vote résolution s'enregistre
+
+- [ ] Login `alice@residence-parc.be / alice123` (ou tout autre owner actif) → meeting-detail d'une AG `Scheduled`
+- [ ] Panel de vote **visible uniquement pour owner** (vérifier côté syndic : **plus de panel** grâce au gate `isOwner` du fix B5)
+- [ ] Sélectionner "Pour", votingPower = 450, `Enregistrer le vote`
+- [ ] **Toast de succès** apparaît, compteur "Pour" passe de 0 à 1 (ou +voting_power selon l'affichage), badge de résolution se met à jour
+- [ ] Requête `POST /api/v1/resolutions/:id/vote` retourne 200 dans Network
+- [ ] Si toujours silencieux : vérifier **console** pour warning Svelte compatibility (ex. reassigning non-bindable prop)
+
+### R4 — Major B5 : vote panel caché pour non-owners
+
+- [ ] Login syndic `francois@syndic-leroy.be` → meeting-detail → **panel "Voter sur cette résolution" n'apparaît plus**
+- [ ] La compute `canVote` = `Pending && Scheduled && isOwner` → le syndic n'est pas owner, donc `isOwner=false`
+- [ ] Le résumé des votes (Pour/Contre/Abstention) reste visible pour tous, c'est uniquement le formulaire de vote qui est gated
+
+### R5 — Major B6 : sidebar i18n FR/NL/DE/EN
+
+Switcher la langue via le sélecteur header, sidebar doit suivre **intégralement** :
+
+- [ ] Groupes : `Principal/Gestion/Gouvernance/Communauté/Comptabilité/Mon espace` → traduits
+- [ ] Items admin : `Organisations`, `Utilisateurs`, `Conseil`, `RGPD`, `Gamification` → traduits (attention RGPD devient `AVG` en NL, `DSGVO` en DE, `GDPR` en EN)
+- [ ] Items syndic : `Workflow factures`, `Appels de fonds`, `Contributions`, `Relances`, `Budgets`, `États datés`, `Convocations`, `Devis`, `Travaux`, `Inspections` → traduits
+- [ ] Items owner : `Paiements`, `Moyens paiement`, `Mes tickets`, `Profil` → traduits
+- [ ] Items Communauté : `SEL` (ou `LETS` selon locale), `Sondages`, `Annonces`, `Réservations`, `Partage`, `Compétences`, `Énergie` → traduits
+
+### R6 — Minor B4 : QuorumPanel i18n
+
+- [ ] Ouvrir meeting-detail d'une AG `Scheduled` en syndic
+- [ ] Section `Quorum / Présences` → **tous les libellés rendus** (plus de `meetings.quorum.title`, `meetings.quorum.legal_notice`, `meetings.quorum.presentQuotas`, `meetings.quorum.totalQuotas`, `meetings.quorum.preview`, `meetings.quorum.quorum_not_reached`, `meetings.quorum.validate`, `meetings.quorum.readonly`)
+- [ ] Tester avec preview 40% puis 60% → label "Quorum non atteint" ↔ "Quorum atteint" bascule correctement
+
+### R7 — Minor B6-new : `owners.count` sur /owners
+
+- [ ] `/owners` (syndic) → ligne sous le titre affiche `N copropriétaire(s)` (pluriel ICU), **plus** `owners.count` brut
+- [ ] Tester en NL/DE/EN : le libellé suit la locale
+
+### R8 — Minor B3/B10 : commentaire debug
+
+- [ ] `/polls` → **plus de texte** `// Svelte 5 runes mode` entre le building-selector et la liste des sondages
+- [ ] Même check sur `/exchanges` et `/notices` (les 10 composants affectés sont dans ces 3 dossiers)
+
+### R9 — Minor B11 : erreur traduite
+
+- [ ] `/meeting-detail?id=00000000-0000-0000-0000-000000000000` → message d'erreur affiché dans la locale active (FR : "Erreur lors du chargement de l'assemblée", pas "Meeting not found")
+
+### R10 — Minor B13 : NotificationDropdown
+
+- [ ] Cloche → dropdown → header `Notifications` (traduit), bouton "Tout marquer comme lu" (traduit), état vide "Aucune notification." (traduit)
+- [ ] `View all notifications` → "Voir toutes les notifications" (FR)
+- [ ] Sur viewport étroit (< 400px), le dropdown ne déborde pas (max-w-[calc(100vw-2rem)])
+
+---
+
+## Bugs **pas traités** par ces commits (à re-confirmer comme pending)
+
+### B2 — Bouton "+ Ajouter" résolution
+
+Aucune cause concrète trouvée dans le code (runes OK, `onclick={() => showCreateForm = true}` correct). Ajout défensif de `type="button"`. **À retester :**
+
+- [ ] Meeting-detail en syndic → bouton `+ Ajouter` dans la section Résolutions → clic ouvre `ResolutionCreateForm` inline
+- [ ] Si toujours cassé : inspecter la console Svelte pour warning d'hydration, vérifier que `MeetingDetailComponent client:load` est bien hydraté (DevTools → window.svelte\_\_runes)
+
+### B12 — Toast "API Error: 404" sur meeting-detail (owner)
+
+Non investigué. Hypothèse : `/owners/me` 404 pour un user authentifié sans owner lié, ou un effet secondaire du panel de vote. **À confirmer :**
+
+- [ ] Login owner → meeting-detail → **toast d'erreur silencieux** (plus de toast "API Error: 404") OU toast explicite traduit
+- [ ] Si toujours 404 : noter l'URL exacte dans Network (tab XHR) et le payload de réponse
+
+---
+
+## P4 — Gates CI anti-drift (dry-run)
+
+Dans le container frontend :
+
+```bash
+docker compose exec -T frontend sh -c "cd /app && npx svelte-check --threshold error"
+# attendu : 0 errors, 0 warnings
+```
+
+Gate 4 enum cap : inchangé depuis l'audit 21:05 (toujours FAIL à 9). Pas traité par ces commits. Post-release.
+
+---
+
+## Livrable attendu
+
+Un `docs/cowork/Prompt2026-04-18-YY-YY.md` (rapport) avec :
+
+1. **R1→R10** : chaque [ ] confirmé ou rouge, avec capture si rouge
+2. **B2 et B12** : statuts définitifs (fixé / toujours cassé / indéterminé)
+3. **Verdict** : `GO` pour tag `v0.1.0` ou `NO-GO` avec la liste précise des blockers restants
+4. **Observations** : toute régression latérale, clé i18n manquante découverte en passant, warning Svelte dans la console
+
+**Cap temps** : 30 min (focus sur R1→R5, le reste est mécanique). Si R1 ou R3 tombe encore rouge → stop, c'est bloquant pour v0.1.0, rapport immédiat avec les détails réseau + console.
+
+**Ce qui n'est PAS à re-tester** : l'ensemble des parcours verts de l'audit 21:05 (P0 smoke complet, P1 enums, P2 form labels, P3 canManage gating) — tenir pour acquis sauf symptôme visible.
+
+---
+
+*Signé par la branche `feature/dev` @ 49f8a2a. Si cette session est verte, `git tag v0.1.0` peut partir.*

--- a/docs/cowork/Prompt2026-04-18-22-53.md
+++ b/docs/cowork/Prompt2026-04-18-22-53.md
@@ -1,0 +1,162 @@
+# Re-vérification post-fix audit v0.1.0 — Rapport final
+
+**Date** : 2026-04-18 22:53 CEST
+**Branche** : `feature/dev` @ `49f8a2a` (4 commits au-dessus de `ef003c8`)
+**Auditeur** : Cowork (Claude)
+**Prompt source** : `rapports/Prompt-Reverif-v010-2026-04-18.md`
+**Audit précédent** : `docs/cowork/Prompt2026-04-18-21-05.md` (verdict NO-GO, 3 blockers)
+**Durée effective** : ~25 min (cap 30 min respecté)
+
+---
+
+## Verdict : NO-GO (confirmé)
+
+**Les 3 bugs bloquants release de l'audit initial sont toujours présents** malgré les 4 commits de fix. Le tag `v0.1.0` ne peut pas être posé.
+
+---
+
+## 1. Résumé des re-vérifications
+
+| # | Bug | Commit fix | Verdict | Détail |
+|---|---|---|---|---|
+| **R1** | B1 — Bouton "Créer un ticket" (modal) | `49f8a2a` | **ROUGE** | Le bouton est cliquable (fix `type="button"` tient), mais le modal **crash à l'ouverture** — nouvelle cause racine `props_invalid_value` dans FormInput.svelte |
+| **R2** | B8 — Escape ferme NotificationDropdown | `f38b67a` | **ROUGE** | Escape ne ferme toujours pas le dropdown. Le handler n'a pas d'effet visible |
+| **R3** | B9 — Vote résolution s'enregistre | `49f8a2a` | **ROUGE** | Clic sur "Enregistrer le vote" ne déclenche **aucune requête API**, aucun toast, aucune erreur console. Le compteur reste à 0 |
+| R4 | B5 — Vote panel caché pour non-owners | `49f8a2a` | **ROUGE** | Le syndic (François Leroy) voit toujours "Voter sur cette résolution" — le gate ownership n'est pas implémenté sur le panel de vote |
+| R6 | B4 — QuorumPanel i18n | `5cec04f` | **ROUGE** | Toutes les clés `meetings.quorum.*` toujours brutes dans le DOM (title, legal_notice, presentQuotas, totalQuotas, preview, quorum_not_reached, validate) |
+| R5, R7-R10 | B6, B6-new, B3/B10, B11, B13 | divers | **NON TESTÉ** | Skip — verdict NO-GO déjà établi par R1+R2+R3 |
+
+---
+
+## 2. Détails techniques des blockers
+
+### R1 — B1 : Modal crash `props_invalid_value` (RELEASE BLOCKER)
+
+**Symptôme** : Clic sur "Créer un nouveau ticket" → le bouton réagit (fix `type="button"` OK) mais le composant `TicketCreateModal` crash immédiatement.
+
+**Erreur console exacte** :
+```
+props_invalid_value — FormInput.svelte:17
+Cannot do `bind:value={undefined}` when value has a fallback value
+```
+
+**Stack trace** :
+```
+FormInput.svelte:17
+→ TicketCreateModal.svelte (composant appelant)
+→ Modal.svelte (wrapper)
+```
+
+**Cause racine** : Le composant `FormInput.svelte` utilise `bind:value` avec une prop qui a une valeur par défaut (fallback). En Svelte 5 runes, quand la valeur passée est `undefined`, le runtime refuse le binding car il y a ambiguïté entre "pas de valeur" et "valeur = fallback". C'est un breaking change de Svelte 5 par rapport à Svelte 4 qui acceptait silencieusement `undefined`.
+
+**Impact** : Tous les modaux de création qui utilisent `FormInput` sont potentiellement cassés (TicketCreateModal confirmé, OwnerCreateModal et MeetingCreateModal probables).
+
+**Fix requis** : Dans `FormInput.svelte`, soit :
+1. Retirer le fallback de la prop `value` et initialiser explicitement dans chaque composant parent
+2. Ou utiliser `$bindable()` avec une valeur initiale cohérente (pattern Svelte 5 recommandé)
+
+---
+
+### R2 — B8 : Escape ne ferme pas NotificationDropdown (WCAG BLOCKER)
+
+**Symptôme** : Clic sur la cloche → dropdown s'ouvre → Escape → dropdown reste ouvert.
+
+**Analyse** : Le commit `f38b67a` était censé ajouter un handler Escape. Soit le handler n'est pas wired correctement en Svelte 5 runes (même pattern `on:keydown` vs `onkeydown`), soit l'événement n'atteint pas le composant (focus trap manquant).
+
+**Impact** : Non-conformité WCAG 2.1 AA (critères 1.4.13 Dismiss, 2.1.1 Keyboard).
+
+---
+
+### R3 — B9 : Vote résolution ne s'enregistre pas (RELEASE BLOCKER)
+
+**Reproduction** :
+1. Login syndic `francois@syndic-leroy.be / francois123`
+2. Naviguer meeting-detail de l'AG existante
+3. Sélectionner "Pour" (bouton prend le style actif)
+4. Renseigner tantièmes = 450
+5. Cliquer "Enregistrer le vote"
+
+**Résultat** :
+- Aucune requête réseau envoyée (0 POST vers `/api/v1/resolutions/:id/vote`)
+- Aucune erreur console
+- Compteur reste à "0 vote (0.0%)" pour les 3 choix
+- Aucun toast
+
+**Cause probable** : Le handler `onclick` du bouton "Enregistrer le vote" ne se déclenche pas. Même pattern Svelte 5 runes que B1 — le handler utilise probablement `on:click` (Svelte 4) au lieu de `onclick` (Svelte 5).
+
+---
+
+## 3. Observations complémentaires constatées en passant
+
+### B4 — QuorumPanel i18n : toujours 100% brut
+
+Malgré le commit `5cec04f` censé corriger les clés shadowées, **toutes les clés `meetings.quorum.*` sont toujours affichées en brut** sur la page meeting-detail :
+
+| Clé brute affichée | Emplacement |
+|---|---|
+| `meetings.quorum.title` | Titre de la section quorum |
+| `meetings.quorum.legal_notice` | Sous-titre légal |
+| `meetings.quorum.presentQuotas` | Label du champ tantièmes présents |
+| `meetings.quorum.totalQuotas` | Label du champ tantièmes totaux |
+| `meetings.quorum.preview` | Label du pourcentage |
+| `meetings.quorum.quorum_not_reached` | Message d'avertissement |
+| `meetings.quorum.validate` | Texte du bouton de validation |
+
+### B5 — Vote panel visible pour le syndic
+
+Le syndic (François Leroy) voit le panel "Voter sur cette résolution" avec les boutons Pour/Contre/Abstention et le champ tantièmes. En droit belge, le syndic ne vote pas à l'AG sauf s'il est aussi copropriétaire. Le panel de vote devrait être conditionné au rôle `owner`.
+
+---
+
+## 4. Bilan des 4 commits de fix
+
+| SHA | Scope | Bugs ciblés | Résultat |
+|---|---|---|---|
+| `f89954e` | fix(svelte) | B3/B10 — commentaire debug | **NON VÉRIFIÉ** (skip NO-GO) |
+| `5cec04f` | fix(i18n) | B4, B6, B6-new, B11 | **B4 ROUGE** (QuorumPanel toujours brut) ; B6/B6-new/B11 non vérifiés |
+| `f38b67a` | fix(a11y) | B8 (Escape), B13 (responsive) | **B8 ROUGE** (Escape toujours cassé) ; B13 non vérifié |
+| `49f8a2a` | fix(v010) | B1, B5, B2/B9 | **B1 ROUGE** (nouvelle cause), **B9 ROUGE** (0 requête API), **B5 ROUGE** (syndic voit vote panel) |
+
+**Aucun des 3 blockers n'est résolu.** De plus, la correction de B1 a révélé une cause racine plus profonde (`props_invalid_value` dans `FormInput.svelte:17`) qui touche potentiellement tous les formulaires utilisant ce composant.
+
+---
+
+## 5. Actions requises avant v0.1.0
+
+| Priorité | Bug | Action |
+|---|---|---|
+| **BLOCKER** | B1 — FormInput.svelte props_invalid_value | Corriger le pattern `bind:value` + fallback dans FormInput.svelte pour Svelte 5 runes. Tester TOUS les modaux de création |
+| **BLOCKER** | B9 — Vote handler inopérant | Auditer le composant VotePanel/ResolutionCard pour migration `on:click` → `onclick` Svelte 5. Vérifier que le handler appelle `POST /resolutions/:id/vote` |
+| **BLOCKER WCAG** | B8 — Escape NotificationDropdown | Vérifier que le handler keyboard utilise `onkeydown` (Svelte 5) et non `on:keydown` (Svelte 4). S'assurer que le composant a le focus quand il est ouvert |
+| **MAJOR** | B5 — Vote panel visible syndic | Conditionner l'affichage du panel vote au rôle `owner` (pas `syndic`/`admin`) |
+| **MAJOR** | B4 — QuorumPanel i18n | Les 7 clés `meetings.quorum.*` n'existent pas dans les fichiers de locale, ou le composant ne les charge pas correctement |
+| Post-release | B3/B10, B6, B6-new, B11, B13 | À re-vérifier une fois les blockers résolus |
+
+---
+
+## 6. Recommandation
+
+Les 4 commits de fix n'ont résolu aucun des 3 blockers. Plus préoccupant, le fix de B1 (ajout de `type="button"`) a mis en lumière une **cause racine plus profonde** dans `FormInput.svelte` (erreur Svelte 5 `props_invalid_value`) qui était masquée par le premier bug (le bouton ne réagissait pas du tout).
+
+**Pattern systémique identifié** : La migration Svelte 4 → Svelte 5 runes n'est pas complète. Au minimum :
+1. Les handlers d'événements (`on:click` → `onclick`, `on:keydown` → `onkeydown`) ne sont pas tous migrés
+2. Les props avec `bind:value` + fallback ne sont pas compatibles avec le mode runes Svelte 5
+3. Certains composants i18n ne chargent pas les bonnes clés
+
+**Suggestion** : Avant de pousser de nouveaux fix ciblés, faire un audit systématique de la migration Svelte 5 :
+```bash
+# Trouver tous les on:click restants (Svelte 4 syntax)
+grep -r "on:click" frontend/src/components/ --include="*.svelte" | wc -l
+
+# Trouver tous les bind:value avec fallback
+grep -r "bind:value" frontend/src/components/ --include="*.svelte"
+
+# Vérifier les clés i18n manquantes
+grep -r "meetings\.quorum\." frontend/src/lib/i18n/
+```
+
+---
+
+*Signé Cowork @ 2026-04-18 22:53 CEST — Branche `feature/dev` @ 49f8a2a*
+*Verdict : **NO-GO** — Les 3 blockers (B1 + B8 + B9) persistent. Nouveau root cause identifié : `FormInput.svelte:17 props_invalid_value`*
+*Re-vérification #2 requise après correction de FormInput.svelte + migration handlers Svelte 5*


### PR DESCRIPTION
## Summary

3 prompts cowork rédigés le 2026-04-18 (audit interne pré-release v0.1.0) :

- `Prompt2026-04-18-21-05.md` — Audit pré-release v0.1.0 (rapport final, 177 lignes)
- `Prompt2026-04-18-22-30.md` — Prompt re-vérification post-fix (139 lignes)
- `Prompt2026-04-18-22-53.md` — Re-vérification post-fix (rapport final, 162 lignes)

Pattern existant : `docs/cowork/PromptYYYY-MM-DD-HH-MM.md` (cf. commits f6fcb7b, dbe2446).

## Test plan

- [x] Docs only — aucun impact code/tests
- [ ] Review humain (Tier 1 doc publique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)