### PR TITLE
chore(ci): route Dependabot to feature/dev + auto-merge when CI green

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,62 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Dependabot config — KoproGo
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot-yml-file
+#
+# All PRs target `feature/dev` so they go through the official GitFlow:
+#   feature/dev → dev → integration → staging → production → main
+# Direct dependency bumps to `main` would bypass the CI gates configured in PR-E
+# (ci.yml + security.yml + docker-build-push.yml triggers).
 
 version: 2
 updates:
   # Backend dependencies (Rust/Cargo)
   - package-ecosystem: "cargo"
     directory: "/backend"
+    target-branch: "feature/dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    # Group patch + minor bumps — reduces PR noise
+    groups:
+      cargo-patch:
+        update-types:
+          - "patch"
+      cargo-minor:
+        update-types:
+          - "minor"
 
   # Frontend dependencies (npm)
   - package-ecosystem: "npm"
     directory: "/frontend"
+    target-branch: "feature/dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    groups:
+      npm-patch:
+        update-types:
+          - "patch"
+      npm-minor:
+        update-types:
+          - "minor"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "feature/dev"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    groups:
+      gh-actions:
+        update-types:
+          - "patch"
+          - "minor"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,49 @@
+# Auto-merge Dependabot PRs vers feature/dev quand la CI passe.
+#
+# Politique (décision humaine 2026-05-11, gilmry) :
+#   - TOUS les bumps Dependabot (security + patch + minor + major) sont
+#     auto-merge dès que la CI est verte, y compris les breaking changes.
+#   - Rationale : une faille connue non patchée est pire qu'une régression
+#     fonctionnelle sur feature/dev (qui sera rattrapée avant prod via le
+#     GitFlow dev → integration → staging → production, humain à chaque
+#     gate). Cf. règle #2 CRITICAL.md : prod reste sous contrôle humain.
+#
+# Pré-requis côté repo (à configurer hors fichier, dans Settings → Branches) :
+#   - Branch protection sur `feature/dev` avec required status checks
+#     (au minimum : ci.yml, security.yml). Sans cela, `--auto` merge
+#     immédiatement sans attendre la CI — ce qui contredit la politique.
+#   - "Allow auto-merge" activé dans Settings → General.
+#   - Dependabot doit avoir les permissions write (Settings → Code security
+#     → Dependabot → Allow GitHub Actions to create and approve pull requests).
+
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches:
+      - feature/dev
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash, gated by branch protection)
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
+          DEP_NAMES: ${{ steps.meta.outputs.dependency-names }}
+        run: |
+          echo "Dependabot bump: $UPDATE_TYPE on $DEP_NAMES"
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Pourquoi

Sur `main` aujourd'hui, `dependabot.yml` n'a pas de `target-branch`, donc Dependabot ouvre toutes ses PRs (security comprises) sur `main`, court-circuitant le GitFlow `dev → integration → staging → production`. Conséquence : 19 alertes Dependabot ouvertes sur la default branch + 11 PRs Dependabot stagnant car personne ne merge directement sur `main`.

## Ce que fait ce PR

Cherry-pick de deux commits déjà reviewés sur d'autres branches :

1. **`bd7bece`** — `dependabot.yml` : `target-branch: feature/dev` + groups patch/minor (cargo, npm, github-actions).
2. **`8e24074`** (= `f7b7fa8` sur l'autre branche) — Workflow `dependabot-auto-merge.yml` qui arme `gh pr merge --auto --squash` sur toute PR Dependabot ciblant `feature/dev`. Tous écosystèmes, tous update-types (patch/minor/**major**/security), gated par les required status checks de `feature/dev`.

## Politique

Décidée 2026-05-11 (gilmry) : auto-merge **tous** les bumps Dependabot, y compris breaking, dès que CI verte sur `feature/dev`. Rationale : faille connue > régression rattrapable dans le GitFlow (humain à chaque gate avant prod). Cf. règle #2 CRITICAL.md : prod reste sous contrôle humain car `main` n'est pas touchée automatiquement.

## Pré-requis post-merge (action humaine)

Trois toggles dans Settings GitHub (je ne peux pas les faire) :

- [ ] **Settings → General → Pull Requests** : *Allow auto-merge* coché
- [ ] **Settings → Branches** : protection sur `feature/dev` avec *Require status checks to pass* (au minimum `ci.yml`, `security.yml`)
- [ ] **Settings → Code security → Dependabot** : *Allow GitHub Actions to create and approve pull requests*

Sans le check #2, `--auto` mergerait instantanément sans attendre la CI — ce qui casse la politique.

## Effet attendu sur les 19 alertes

Après merge + 3 toggles, Dependabot rebase les PRs existantes vers `feature/dev`. L'auto-merge les liquide une par une au fil des CI vertes. Aucun bump manuel nécessaire.

## Test plan

- [ ] Merge ce PR sur `main`
- [ ] Activer les 3 toggles Settings
- [ ] Vérifier qu'une PR Dependabot suivante cible bien `feature/dev`
- [ ] Vérifier que le workflow `dependabot-auto-merge` se déclenche dessus et arme `auto-merge`
- [ ] Vérifier qu'elle merge automatiquement quand CI verte (et pas avant)
- [ ] Re-check `gh api repos/gilmry/koprogo/dependabot/alerts` : compteur d'alertes ouvertes baisse

🤖 Generated with [Claude Code](https://claude.com/claude-code)