### PR TITLE
chore(ci): trigger workflows on GitFlow stages (dev/integration/staging/production)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI Pipeline
 
 on:
   push:
-    branches: [ main, develop, "claude/**", "release/**" ]
+    branches: [ main, dev, integration, staging, production, "claude/**", "release/**" ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev, integration, staging, production ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -16,6 +16,7 @@ on:
       - production
       - staging
       - integration
+      - dev
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security Audit
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, dev, integration, staging, production ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, dev, integration, staging, production ]
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
 


### PR DESCRIPTION
## Pourquoi

Le GitFlow KoproGo est \`feature/dev → dev → integration → staging → production → main\`, mais \`ci.yml\` / \`security.yml\` déclenchaient encore sur \`develop\` (legacy). Résultat : aucune CI ne tourne sur les promotions internes du GitFlow.

## Ce que fait ce PR

- \`ci.yml\` : push et pull_request → \`main, dev, integration, staging, production\` (remplace \`develop\`).
- \`security.yml\` : idem.
- \`docker-build-push.yml\` : ajoute \`dev\` au trigger \`pull_request\` (push l'avait déjà).
- \`feature/dev\` reste **volontairement** hors trigger — c'est le buffer d'entrée libre où Dependabot dépose ses bumps en auto-merge. Premier gate CI réel = PR \`feature/dev → dev\` (cf. décision 2026-05-11).

## Test plan

- [ ] Merge sur \`main\`
- [ ] Ouvrir une PR test \`feature/dev → dev\` : vérifier que ci.yml + security.yml se déclenchent
- [ ] Vérifier que les PRs vers \`integration\`, \`staging\`, \`production\` déclenchent aussi
- [ ] Confirmer que \`feature/dev\` reste sans CI (Dependabot draine librement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)