### PR TITLE
chore(gitignore): ignore Claude Code local-only artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ podcasts
 
 # Méthode Maury (livrables internes)
 Maury/
+
+# Claude Code local-only artifacts (the rest of .claude/ is versioned)
+.claude/_drafts/
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Adds `.claude/_drafts/`, `.claude/settings.local.json`, `.claude/worktrees/` to .gitignore. The rest of `.claude/` (rules, hooks.md, guides, settings.json, etc.) stays versioned as part of the agent guardrails (#425-#429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)