### PR TITLE
feat(gitops): 4 promotion workflows for infra branches (RFC #466)

### DIFF
--- a/.github/workflows/backsync-infra-prod.yml
+++ b/.github/workflows/backsync-infra-prod.yml
@@ -1,0 +1,102 @@
+name: Back-sync infra-prod → staging, integration, main
+
+# Decision: RFC #466 (Alternative D — release train + back-sync).
+# Trigger: any push (i.e. merge) on infra-prod. Opens 3 PRs:
+#   - infra-prod → infra-staging
+#   - infra-prod → infra-integration
+#   - infra-prod → main
+# Conflict handling: PRs are opened in merge mode. If a PR becomes
+# CONFLICTING, the `needs-resolution` label is applied — a human resolves it.
+# No destructive override.
+
+on:
+  push:
+    branches:
+      - infra-prod
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backsync:
+    name: Open back-sync PR to ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [infra-staging, infra-integration, main]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify diff exists infra-prod vs ${{ matrix.target }}
+        id: diff
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch origin infra-prod "${{ matrix.target }}"
+          if git diff --quiet "origin/${{ matrix.target }}..origin/infra-prod"; then
+            echo "::notice::No diff between infra-prod and ${{ matrix.target }} — back-sync already in sync"
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update back-sync PR
+        if: steps.diff.outputs.has_diff == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list --base "${{ matrix.target }}" --head infra-prod --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            pr_number="$existing"
+            echo "::notice::Existing PR #$pr_number — head moves automatically"
+          else
+            head_sha=$(git rev-parse origin/infra-prod)
+            gh pr create \
+              --base "${{ matrix.target }}" \
+              --head infra-prod \
+              --title "backsync: infra-prod → ${{ matrix.target }} (auto)" \
+              --body "$(cat <<EOF
+Automated back-sync — propagates the new infra-prod state to ${{ matrix.target }}.
+
+Per RFC #466 (Alternative D), every push to infra-prod triggers this workflow
+to keep lower envs aligned with prod and avoid drift.
+
+If this PR is labelled \`needs-resolution\`, a conflict was detected:
+a human must rebase or merge manually. No destructive override.
+EOF
+)"
+            pr_number=$(gh pr list --base "${{ matrix.target }}" --head infra-prod --state open --json number --jq '.[0].number')
+          fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Detect conflict and label
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pr="${{ steps.pr.outputs.pr_number }}"
+          # gh may report CONFLICTING, MERGEABLE, or UNKNOWN (mergeability not
+          # computed yet). Poll briefly to give GitHub time to compute.
+          for i in 1 2 3 4 5; do
+            state=$(gh pr view "$pr" --json mergeable --jq .mergeable)
+            if [ "$state" != "UNKNOWN" ]; then break; fi
+            sleep 3
+          done
+          echo "::notice::PR #$pr mergeable state = $state"
+          if [ "$state" = "CONFLICTING" ]; then
+            gh pr edit "$pr" --add-label "needs-resolution" || \
+              echo "::warning::could not apply needs-resolution label (does it exist? create it on the repo)"
+          else
+            # Conflict resolved or never present — remove the label if any
+            gh pr edit "$pr" --remove-label "needs-resolution" 2>/dev/null || true
+          fi

--- a/.github/workflows/promote-infra-dev-to-integration.yml
+++ b/.github/workflows/promote-infra-dev-to-integration.yml
@@ -1,0 +1,69 @@
+name: Promote infra-dev → infra-integration
+
+# Decision: RFC #466 (Alternative D — release train + back-sync).
+# Trigger: after ci-infra.yml completes successfully on infra-dev, open a PR
+# from infra-dev to infra-integration. If no diff, no PR. If a promotion PR
+# is already open for the same head→base, do nothing (avoid duplicates).
+# Auto-merge enabled — branch protection on infra-integration enforces required
+# checks before the actual merge happens.
+
+on:
+  workflow_run:
+    workflows: ["CI Infra"]
+    types: [completed]
+    branches: [infra-dev]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    name: Open PR infra-dev → infra-integration
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify diff exists infra-dev vs infra-integration
+        id: diff
+        run: |
+          set -euo pipefail
+          git fetch origin infra-dev infra-integration
+          if git diff --quiet origin/infra-integration..origin/infra-dev; then
+            echo "::notice::No diff — nothing to promote"
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update promotion PR
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list --base infra-integration --head infra-dev --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            echo "::notice::Existing PR #$existing — head moves automatically; no action needed"
+            exit 0
+          fi
+          head_sha=$(git rev-parse origin/infra-dev)
+          gh pr create \
+            --base infra-integration \
+            --head infra-dev \
+            --title "promote: infra-dev → infra-integration (auto, ci green)" \
+            --body "$(cat <<EOF
+Automated promotion — ci-infra green on \`infra-dev\` @ \`${head_sha:0:7}\`.
+
+Per RFC #466 (Alternative D), this PR is auto-opened on every green ci-infra
+on infra-dev. Auto-merge enabled — branch protection on infra-integration
+gates the actual merge.
+EOF
+)"
+          new_pr=$(gh pr list --base infra-integration --head infra-dev --state open --json number --jq '.[0].number')
+          gh pr merge "$new_pr" --auto --merge || echo "::warning::auto-merge could not be enabled (likely branch protection blocks it; PR remains open for manual review)"

--- a/.github/workflows/promote-infra-integration-to-staging.yml
+++ b/.github/workflows/promote-infra-integration-to-staging.yml
@@ -1,0 +1,82 @@
+name: Promote infra-integration → infra-staging
+
+# Decision: RFC #466 (Alternative D — release train + back-sync).
+# Trigger: push of a release-candidate tag matching `infra-rc-v*` (e.g.
+# `infra-rc-v0.1.0`). Opens a PR from infra-integration to infra-staging.
+# This is the gate where human testing on infra-staging begins.
+
+on:
+  push:
+    tags:
+      - "infra-rc-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing infra-rc-v* tag to promote'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    name: Open PR infra-integration → infra-staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+          if [[ ! "$tag" =~ ^infra-rc-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '$tag' does not match infra-rc-vX.Y.Z"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Verify diff exists infra-integration vs infra-staging
+        id: diff
+        run: |
+          set -euo pipefail
+          git fetch origin infra-integration infra-staging
+          if git diff --quiet origin/infra-staging..origin/infra-integration; then
+            echo "::notice::No diff — nothing to promote"
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open promotion PR
+        if: steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list --base infra-staging --head infra-integration --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            echo "::notice::Existing PR #$existing — head moves automatically; updating title with new tag"
+            gh pr edit "$existing" --title "promote: infra-integration → infra-staging (${{ steps.tag.outputs.tag }})"
+            exit 0
+          fi
+          gh pr create \
+            --base infra-staging \
+            --head infra-integration \
+            --title "promote: infra-integration → infra-staging (${{ steps.tag.outputs.tag }})" \
+            --body "$(cat <<EOF
+Release-candidate tagged: \`${{ steps.tag.outputs.tag }}\`.
+
+Per RFC #466 (Alternative D), this PR opens the human-test window on
+infra-staging. Merge only after manual validation on the staging cluster.
+EOF
+)"

--- a/.github/workflows/promote-infra-staging-to-prod.yml
+++ b/.github/workflows/promote-infra-staging-to-prod.yml
@@ -1,0 +1,69 @@
+name: Promote infra-staging → infra-prod
+
+# Decision: RFC #466 (Alternative D — release train + back-sync).
+# Trigger: workflow_dispatch only (manual after human validation on staging).
+# Opens a PR from infra-staging to infra-prod. Merging this PR triggers
+# backsync-infra-prod.yml which propagates the new prod state backward.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag being promoted (for traceability, e.g. infra-rc-v0.1.0)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  promote:
+    name: Open PR infra-staging → infra-prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify diff exists infra-staging vs infra-prod
+        id: diff
+        run: |
+          set -euo pipefail
+          git fetch origin infra-staging infra-prod
+          if git diff --quiet origin/infra-prod..origin/infra-staging; then
+            echo "::error::No diff between infra-staging and infra-prod — nothing to promote"
+            exit 1
+          fi
+
+      - name: Open promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.release_tag }}"
+          title_suffix=""
+          if [ -n "$tag" ]; then
+            title_suffix=" ($tag)"
+          fi
+          existing=$(gh pr list --base infra-prod --head infra-staging --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            echo "::notice::Existing PR #$existing already open — refusing to duplicate. Resolve it first."
+            exit 1
+          fi
+          gh pr create \
+            --base infra-prod \
+            --head infra-staging \
+            --title "promote: infra-staging → infra-prod$title_suffix" \
+            --body "$(cat <<EOF
+**Tier 1 promotion** — manually triggered after human validation on the
+staging cluster.
+
+Per RFC #466 (Alternative D), merging this PR triggers the back-sync workflow
+which propagates the new infra-prod state to infra-staging, infra-integration,
+and main.
+
+Release tag: \`${tag:-<not specified>}\`
+EOF
+)"


### PR DESCRIPTION
## Summary

Implements the promotion strategy decided in [comment on #466](https://github.com/gilmry/koprogo/issues/466#issuecomment-4437408149) (Alternative D — release train + back-sync).

4 new workflows under \`.github/workflows/\`:

| Workflow | Trigger | Action |
|---|---|---|
| \`promote-infra-dev-to-integration.yml\` | \`workflow_run\` ci-infra success on \`infra-dev\` | Auto-PR + auto-merge |
| \`promote-infra-integration-to-staging.yml\` | Push tag \`infra-rc-v*\` | Auto-PR (human merges after staging test) |
| \`promote-infra-staging-to-prod.yml\` | \`workflow_dispatch\` (manual) | Auto-PR (Tier 1 — human validates) |
| \`backsync-infra-prod.yml\` | Push on \`infra-prod\` | 3 parallel PRs back to staging/integration/main; conflict → \`needs-resolution\` label |

## Flow

\`\`\`
infra-dev ──auto──► infra-integration ──tag──► infra-staging ──manual──► infra-prod ──┐
                                                                                       │
   ◄────── back-sync (3 PRs after merge) ─────────────────────────────────────────────┘
                                                                                  ──auto──► main
\`\`\`

## Out of scope (follow-ups)

- **Branch protection rules** on \`infra-staging\` and \`infra-prod\` (required reviewers, required CI checks) — must be set via repo settings UI, can't be done from a PR.
- **Label \`needs-resolution\`** must exist on the repo before \`backsync-infra-prod\` can apply it. Workflow has a warning if missing — non-blocking but cosmetic.
- **App-side promotion** (\`koprogo-app\` AppSet targets \`dev/integration/staging/production\` — separate cycle from \`infra-*\`). Pattern may be replicated in a future PR if the app team wants symmetry.

## Test plan

- [ ] Push a no-op commit on \`infra-dev\` after ci-infra exists there → verify \`promote-infra-dev-to-integration\` runs and either opens PR or no-ops
- [ ] Create tag \`infra-rc-v0.0.1-test\` → verify \`promote-infra-integration-to-staging\` triggers
- [ ] \`gh workflow run promote-infra-staging-to-prod.yml\` → verify PR opens
- [ ] After merge on \`infra-prod\`, verify 3 back-sync PRs appear
- [ ] Conflict simulation: introduce a divergent commit on \`infra-integration\`, then run back-sync → verify \`needs-resolution\` label applied

Refs #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)