### PR TITLE
fix(test-infra): aggregate BDD failures across features (closes #524)

### DIFF
--- a/backend/src/application/dto/dashboard_dto.rs
+++ b/backend/src/application/dto/dashboard_dto.rs
@@ -119,7 +119,11 @@ mod tests {
     #[test]
     fn monetary_fields_remain_json_strings() {
         let json: Value = serde_json::to_value(sample(dec!(50), dec!(50))).unwrap();
-        for field in ["total_expenses_current_month", "total_paid", "total_pending"] {
+        for field in [
+            "total_expenses_current_month",
+            "total_paid",
+            "total_pending",
+        ] {
             assert!(
                 json[field].is_string(),
                 "{} must stay JSON string (Decimal exact), got {:?}",

--- a/backend/tests/bdd.rs
+++ b/backend/tests/bdd.rs
@@ -384,66 +384,45 @@ async fn then_building_in_city(world: &mut BuildingWorld, city: String) {
 
 #[tokio::main]
 async fn main() {
-    // Only load features that have step definitions in THIS file.
-    // Features migrated to bdd_governance/bdd_financial/bdd_operations/bdd_community
+    // Issue #524: aggregate failures across all features so CI exit code
+    // reflects ANY failed scenario, not just the last `.run_and_exit()`.
+    // Only loads features that have step definitions in THIS file — features
+    // migrated to bdd_governance/bdd_financial/bdd_operations/bdd_community
     // are excluded to avoid skip noise.
-    BuildingWorld::cucumber()
-        .run("tests/features/auth.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/building.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/meetings.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/meetings_manage.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/documents.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/documents_delete.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/documents_linking.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/documents_expenses.feature")
-        .await;
-    // invoices: No step definitions in this file — pending migration
-    BuildingWorld::cucumber()
-        .run("tests/features/expenses_pagination.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/expenses_pcn.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/gdpr.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/i18n.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/multitenancy.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/pagination_filtering.feature")
-        .await;
-    // payment_recovery, local_exchange, polls, budget, etat_date:
-    // No step definitions in this file — covered by bdd_financial/bdd_governance or pending migration
-    BuildingWorld::cucumber()
-        .run("tests/features/board.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/board_members.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run("tests/features/board_decisions.feature")
-        .await;
-    BuildingWorld::cucumber()
-        .run_and_exit("tests/features/board_dashboard.feature")
-        .await;
+    use cucumber::writer::Stats as _;
+    let features = [
+        "tests/features/auth.feature",
+        "tests/features/building.feature",
+        "tests/features/meetings.feature",
+        "tests/features/meetings_manage.feature",
+        "tests/features/documents.feature",
+        "tests/features/documents_delete.feature",
+        "tests/features/documents_linking.feature",
+        "tests/features/documents_expenses.feature",
+        // invoices: no step definitions in this file — pending migration
+        "tests/features/expenses_pagination.feature",
+        "tests/features/expenses_pcn.feature",
+        "tests/features/gdpr.feature",
+        "tests/features/i18n.feature",
+        "tests/features/multitenancy.feature",
+        "tests/features/pagination_filtering.feature",
+        // payment_recovery, local_exchange, polls, budget, etat_date:
+        // no step definitions in this file — covered elsewhere or pending migration
+        "tests/features/board.feature",
+        "tests/features/board_members.feature",
+        "tests/features/board_decisions.feature",
+        "tests/features/board_dashboard.feature",
+    ];
+    let mut had_failures = false;
+    for f in features {
+        let writer = BuildingWorld::cucumber().run(f).await;
+        if writer.execution_has_failed() {
+            had_failures = true;
+        }
+    }
+    if had_failures {
+        std::process::exit(1);
+    }
 }
 
 // Meetings BDD

--- a/backend/tests/bdd_community.rs
+++ b/backend/tests/bdd_community.rs
@@ -5145,22 +5145,25 @@ async fn then_all_of_type(world: &mut CommunityWorld, expected: String) {
 
 #[tokio::main]
 async fn main() {
-    CommunityWorld::cucumber()
-        .run("tests/features/notices.feature")
-        .await;
-    CommunityWorld::cucumber()
-        .run("tests/features/skills.feature")
-        .await;
-    CommunityWorld::cucumber()
-        .run("tests/features/shared_objects.feature")
-        .await;
-    CommunityWorld::cucumber()
-        .run("tests/features/resource_bookings.feature")
-        .await;
-    CommunityWorld::cucumber()
-        .run("tests/features/gamification.feature")
-        .await;
-    CommunityWorld::cucumber()
-        .run_and_exit("tests/features/local_exchange.feature")
-        .await;
+    // Issue #524: aggregate failures across all features so CI exit code
+    // reflects ANY failed scenario, not just the last `.run_and_exit()`.
+    use cucumber::writer::Stats as _;
+    let features = [
+        "tests/features/notices.feature",
+        "tests/features/skills.feature",
+        "tests/features/shared_objects.feature",
+        "tests/features/resource_bookings.feature",
+        "tests/features/gamification.feature",
+        "tests/features/local_exchange.feature",
+    ];
+    let mut had_failures = false;
+    for f in features {
+        let writer = CommunityWorld::cucumber().run(f).await;
+        if writer.execution_has_failed() {
+            had_failures = true;
+        }
+    }
+    if had_failures {
+        std::process::exit(1);
+    }
 }

--- a/backend/tests/bdd_financial.rs
+++ b/backend/tests/bdd_financial.rs
@@ -7479,7 +7479,9 @@ async fn when_bob_requests_urgent_tasks(world: &mut FinancialWorld) {
         .as_ref()
         .expect("stats_use_cases initialized")
         .clone();
-    let other_org_id = world.other_org_id.expect("other_org_id (security scenario)");
+    let other_org_id = world
+        .other_org_id
+        .expect("other_org_id (security scenario)");
     let result = std::panic::AssertUnwindSafe(uc.get_syndic_urgent_tasks(other_org_id));
     use futures_util::FutureExt;
     let outcome = result.catch_unwind().await;
@@ -7510,11 +7512,7 @@ async fn then_urgent_tasks_no_panic(world: &mut FinancialWorld) {
         .as_ref()
         .expect("when step ran");
     if let Err(msg) = result {
-        assert!(
-            !msg.starts_with("PANIC"),
-            "urgent tasks panicked: {}",
-            msg
-        );
+        assert!(!msg.starts_with("PANIC"), "urgent tasks panicked: {}", msg);
     }
 }
 
@@ -7559,8 +7557,12 @@ async fn then_task_title_is(world: &mut FinancialWorld, expected: String) {
         .as_ref()
         .expect("Ok result");
     let first = tasks.first().expect("at least one task");
-    assert_eq!(first.title, expected, "title mismatch; titles: {:?}",
-        tasks.iter().map(|t| &t.title).collect::<Vec<_>>());
+    assert_eq!(
+        first.title,
+        expected,
+        "title mismatch; titles: {:?}",
+        tasks.iter().map(|t| &t.title).collect::<Vec<_>>()
+    );
 }
 
 #[then(regex = r#"^the returned task list does NOT contain a task referencing "([^"]*)"$"#)]
@@ -7585,43 +7587,32 @@ async fn then_task_list_excludes(world: &mut FinancialWorld, needle: String) {
 
 #[tokio::main]
 async fn main() {
-    FinancialWorld::cucumber()
-        .run("tests/features/payments.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/payment_methods.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/journal_entries.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/call_for_funds.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/owner_contributions.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/charge_distribution.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/dashboard.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/stats_urgent_tasks.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/invoices.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/payment_recovery.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/budget.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run("tests/features/accounts.feature")
-        .await;
-    FinancialWorld::cucumber()
-        .run_and_exit("tests/features/expenses.feature")
-        .await;
+    // Issue #524: aggregate failures across all features so CI exit code
+    // reflects ANY failed scenario, not just the last `.run_and_exit()`.
+    use cucumber::writer::Stats as _;
+    let features = [
+        "tests/features/payments.feature",
+        "tests/features/payment_methods.feature",
+        "tests/features/journal_entries.feature",
+        "tests/features/call_for_funds.feature",
+        "tests/features/owner_contributions.feature",
+        "tests/features/charge_distribution.feature",
+        "tests/features/dashboard.feature",
+        "tests/features/stats_urgent_tasks.feature",
+        "tests/features/invoices.feature",
+        "tests/features/payment_recovery.feature",
+        "tests/features/budget.feature",
+        "tests/features/accounts.feature",
+        "tests/features/expenses.feature",
+    ];
+    let mut had_failures = false;
+    for f in features {
+        let writer = FinancialWorld::cucumber().run(f).await;
+        if writer.execution_has_failed() {
+            had_failures = true;
+        }
+    }
+    if had_failures {
+        std::process::exit(1);
+    }
 }

--- a/backend/tests/bdd_governance.rs
+++ b/backend/tests/bdd_governance.rs
@@ -8068,34 +8068,29 @@ async fn then_shares_pct_missing(world: &mut GovernanceWorld, expected: f64) {
 
 #[tokio::main]
 async fn main() {
-    GovernanceWorld::cucumber()
-        .run("tests/features/resolutions.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/convocations.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/quotes.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/two_factor.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/organizations.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/public_syndic.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/polls.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/etat_date.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run("tests/features/ag_sessions.feature")
-        .await;
-    GovernanceWorld::cucumber()
-        .run_and_exit("tests/features/age_requests.feature")
-        .await;
+    // Issue #524: aggregate failures across all features so CI exit code
+    // reflects ANY failed scenario, not just the last `.run_and_exit()`.
+    use cucumber::writer::Stats as _;
+    let features = [
+        "tests/features/resolutions.feature",
+        "tests/features/convocations.feature",
+        "tests/features/quotes.feature",
+        "tests/features/two_factor.feature",
+        "tests/features/organizations.feature",
+        "tests/features/public_syndic.feature",
+        "tests/features/polls.feature",
+        "tests/features/etat_date.feature",
+        "tests/features/ag_sessions.feature",
+        "tests/features/age_requests.feature",
+    ];
+    let mut had_failures = false;
+    for f in features {
+        let writer = GovernanceWorld::cucumber().run(f).await;
+        if writer.execution_has_failed() {
+            had_failures = true;
+        }
+    }
+    if had_failures {
+        std::process::exit(1);
+    }
 }

--- a/backend/tests/bdd_operations.rs
+++ b/backend/tests/bdd_operations.rs
@@ -4815,25 +4815,26 @@ async fn then_deletion_fails(world: &mut OperationsWorld) {
 
 #[tokio::main]
 async fn main() {
-    OperationsWorld::cucumber()
-        .run("tests/features/tickets.feature")
-        .await;
-    OperationsWorld::cucumber()
-        .run("tests/features/notifications.feature")
-        .await;
-    OperationsWorld::cucumber()
-        .run("tests/features/energy_campaigns.feature")
-        .await;
-    OperationsWorld::cucumber()
-        .run("tests/features/iot.feature")
-        .await;
-    OperationsWorld::cucumber()
-        .run("tests/features/work_reports.feature")
-        .await;
-    OperationsWorld::cucumber()
-        .run("tests/features/technical_inspections.feature")
-        .await;
-    OperationsWorld::cucumber()
-        .run_and_exit("tests/features/contractor_reports.feature")
-        .await;
+    // Issue #524: aggregate failures across all features so CI exit code
+    // reflects ANY failed scenario, not just the last `.run_and_exit()`.
+    use cucumber::writer::Stats as _;
+    let features = [
+        "tests/features/tickets.feature",
+        "tests/features/notifications.feature",
+        "tests/features/energy_campaigns.feature",
+        "tests/features/iot.feature",
+        "tests/features/work_reports.feature",
+        "tests/features/technical_inspections.feature",
+        "tests/features/contractor_reports.feature",
+    ];
+    let mut had_failures = false;
+    for f in features {
+        let writer = OperationsWorld::cucumber().run(f).await;
+        if writer.execution_has_failed() {
+            had_failures = true;
+        }
+    }
+    if had_failures {
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #524. Replaces the `.run("...").await × N + final .run_and_exit("...")` pattern in 5 of 6 `bdd*.rs` files with an accumulator that tracks `execution_has_failed()` on every feature's writer (via `cucumber::writer::Stats`), then exits 1 if ANY scenario across ANY feature failed.

Before: only the LAST feature's failures triggered non-zero exit. ~10 pre-existing panics across features in CI run [25843439317](https://github.com/gilmry/koprogo/actions/runs/25843439317) were masked, falsely reporting **BDD Tests: success**.

## Local validation

\`\`\`bash
docker compose exec backend bash -c \"SQLX_OFFLINE=true cargo test --test bdd_community\"
# exit status 1 (was 0 silently)
\`\`\`

## Expected CI behavior

This PR's CI run will show **BDD Tests: FAILURE** — that is the intended proof of correctness. The failures revealed are pre-existing (board_members, call_for_funds, resolution quota Decimal/FLOAT8 cf. #525, etc.), not introduced by this PR.

Once merged, those pre-existing failures become visible and trackable (some already filed: #525, #526).

## Test plan

- [x] cargo check passes for all 6 bdd*.rs files
- [x] Local cargo test exits 1 when scenarios fail (validated bdd_community.rs)
- [ ] CI run on this PR shows BDD Tests RED (expected — proof)

Refs #521 (unblocks RED visibility for Story A)