### PR TITLE
security(deps): #432 — svelte 5.55.7 + devalue 5.8.1 (5 alerts resolved)

### DIFF
--- a/docs/agent-activity/2026-05-17-wbs-b2.md
+++ b/docs/agent-activity/2026-05-17-wbs-b2.md
@@ -114,3 +114,19 @@ available — minor bump candidate), testcontainers 0.27.3, protobuf 3.7.2
 - Residual source of truth: `backend/.cargo/audit.toml`, `SECURITY.md`
 - CI gate: `.github/workflows/security.yml` (`cargo audit`, ignores via audit.toml)
 - Dependabot: `.github/dependabot.yml` (cargo → feature/dev, weekly, grouped patch/minor)
+
+---
+
+## Resolution — 2026-05-17 (Docker restored, orchestrator completed B2)
+
+`cargo audit` (RustSec) re-run: **exit 0** — clean modulo the documented `.cargo/audit.toml` ignores (rsa/sqlx-mysql-unused, tokio-tar & rustls-pemfile test-only, rustls-webpki AWS-SDK transitive no-upstream-fix). No Rust action needed.
+
+**Real #432 = GitHub Dependabot, all npm/frontend** (the "5H/3M/6L" in the WBS was stale). Open at triage: **1 HIGH `devalue` <5.8.1 (DoS sparse-array) + 4 MEDIUM `svelte` <5.55.7 (XSS×3, ReDoS)**. `package.json` ranges (`svelte ^5.55.5`, `devalue >=5.6.4`) already permitted the patched versions → lockfile-only bump.
+
+Action: `npm update svelte devalue` → `svelte 5.55.7`, `devalue 5.8.1`. Result:
+- `npm audit --omit=dev` (production): **0 vulnerabilities** — the 5 #432 alerts RESOLVED.
+- `npm run build`: **green** (104 pages built) — no regression.
+
+**Accepted residual (1 HIGH):** `@babel/plugin-transform-modules-systemjs` 7.12.0–7.29.0 (arbitrary code on malicious input) — transitive **devDependency** (Babel transform, build-time only, never shipped to the browser). `npm audit fix` (non-force) does not resolve it; only `npm audit fix --force` would (breaking major in the build chain) — declined per CRITICAL.md (no blind breaking bumps). Not user-reachable; documented here as accepted, revisit when the babel chain offers a non-breaking patch.
+
+**Files changed:** `frontend/package-lock.json` (svelte/devalue patched) + this log.

--- a/docs/agent-activity/2026-05-17-wbs-b2.md
+++ b/docs/agent-activity/2026-05-17-wbs-b2.md
@@ -1,0 +1,116 @@
+---
+date: 2026-05-17
+persona: security-deps (WBS WP-B2)
+session: dependabot-432-security-gate-triage
+tier: 2 # diagnose/propose/patch deps only ; no prod, no issue creation, no force-push
+wbs: WP-B2 (Track B — Security gate, dependabot #432)
+branch: story/432-dependabot-security
+status: BLOCKED — Docker Desktop engine crash (env failure, host action required)
+---
+
+# Activity log — WBS WP-B2 (dependabot #432 security gate triage) 2026-05-17
+
+## Objective
+
+Triage the dependabot #432 vuln set (~14 advisories: ~5 HIGH / 3 MOD / 6 LOW),
+patch all HIGH + reachable MOD via minimal `cargo update -p <crate>` bumps,
+document accepted residuals, verify `cargo check --all-targets` stays clean.
+
+## Outcome: BLOCKED before live audit data could be captured
+
+`cargo audit` never produced advisory output. The mandatory toolchain path
+(CRITICAL.md §12 — cargo/sqlx/cargo-audit run inside `docker compose`, never the
+Windows host which has no Rust toolchain) failed at the environment level:
+
+- The dev `koprogo-postgres` container name is held by another active worktree,
+  so `docker compose run --rm backend ... cargo audit` aborted on a name
+  conflict. Worked around with `docker compose run --rm --no-deps backend ...`
+  (audit needs no Postgres).
+- The backend image had to build from scratch in this fresh worktree volume:
+  `cargo install cargo-watch + sqlx-cli + cargo-audit` (~3m22s + 2m22s + 4m32s),
+  then the Dockerfile dep-cache layer compiled the full koprogo dependency
+  tree (~400 crates) plus the cargo-audit toolchain (~1900 crates total).
+- During the heaviest parallel-compile phase (stalled visibly at
+  `Compiling lettre v0.11.22`), **Docker Desktop's Linux engine crashed**:
+  every subsequent `docker ps` / `docker compose` call returns
+  `HTTP 500 Internal Server Error` from
+  `//./pipe/dockerDesktopLinuxEngine`. Root cause: the Docker VM ran out of
+  memory under the compile load and the engine did not self-recover (still 500
+  after >15 min with the build load removed and stuck tasks killed).
+
+Resolving this requires a host-level Docker Desktop restart (GUI/admin action)
+which is outside the agent sandbox and not a step WP-B2 authorizes. No
+`backend/Cargo.toml`, `backend/Cargo.lock`, or `security.yml` change was made
+because there is no live advisory data to act on — bumping crates blind would
+violate CRITICAL.md (“ne jamais fix un test/dep ‘comme ça’ ; comprendre la
+cause”).
+
+## Pre-existing accepted-residual baseline (authoritative, from repo)
+
+CI's effective ignore list lives in `backend/.cargo/audit.toml` (referenced by
+`.github/workflows/security.yml` → `cargo audit`) and is narrated in
+`SECURITY.md`. These are the *already-accepted* residuals — the WP-B2 “before”
+state. None are production-reachable; all are transitive and upstream-blocked.
+
+| RUSTSEC ID      | Crate / ver              | Sev    | Reachability                          | Why accepted (residual)                                                                 |
+| --------------- | ------------------------ | ------ | ------------------------------------- | --------------------------------------------------------------------------------------- |
+| RUSTSEC-2023-0071 | rsa 0.9.x              | MED    | none (sqlx-mysql, MySQL not enabled)  | No fixed rsa; KoproGo is PostgreSQL-only, mysql feature off. Track sqlx.                 |
+| RUSTSEC-2025-0111 | tokio-tar 0.3.1        | n/a    | test-only (testcontainers)            | No testcontainers fix; never in prod build. Track testcontainers.                       |
+| RUSTSEC-2025-0134 | rustls-pemfile 2.2.0   | LOW    | test-only (testcontainers/bollard)    | Unmaintained; no prod path. Track testcontainers migration.                             |
+| RUSTSEC-2026-0049 | rustls-webpki 0.101.7  | MED    | AWS S3 backup TLS only (not user API) | Fix needs rustls ≥0.103 (semver-incompat); aws-smithy-http-client 1.1.12 is latest.     |
+| RUSTSEC-2026-0098 | rustls-webpki 0.101.7  | MED    | same AWS SDK chain                    | Same AWS SDK legacy-rustls block.                                                       |
+| RUSTSEC-2026-0099 | rustls-webpki 0.101.7  | MED    | same AWS SDK chain                    | Same AWS SDK legacy-rustls block.                                                       |
+| RUSTSEC-2026-0104 | rustls-webpki 0.101.7  | MED    | same AWS SDK chain                    | Same AWS SDK legacy-rustls block (reachable panic in CRL parsing — AWS uses OCSP).       |
+| RUSTSEC-2026-0002 | lru 0.12.5             | LOW    | transitive of aws-sdk-s3 (no direct)  | No lru 0.13 via aws-sdk-s3 (latest); theoretical unsoundness only. Track aws-sdk-s3.    |
+| RUSTSEC-2026-0112 | astral-tokio-tar 0.6.x | LOW    | test-only (testcontainers 0.27.x)     | Needs testcontainers >0.27.2. Dev-dependency, isolated Docker.                           |
+| RUSTSEC-2026-0113 | astral-tokio-tar 0.6.x | LOW    | test-only (testcontainers 0.27.x)     | Same testcontainers dev-only block.                                                     |
+
+Plus `CVE-2026-32766` (astral-tokio-tar 0.5.6, dev-only, mitigated by explicit
+`astral-tokio-tar = "0.6"` direct dep) — documented in SECURITY.md.
+
+These 10 RUSTSEC ignores + the SECURITY.md narrative are the residual set WP-B2
+would have re-validated against fresh `cargo audit` output. Without that output,
+no residual can be added/removed and no crate bump is safe to apply.
+
+## Lockfile snapshot (from `backend/Cargo.lock`, read-only)
+
+Key crate versions present (for the human to spot HIGH candidates once Docker
+is restored): rsa 0.9.10, astral-tokio-tar 0.6.1, rustls-webpki 0.101.7 (+
+0.103.13), lru 0.12.5, openssl 0.10.79 / openssl-sys 0.9.115 (0.10.80/0.9.116
+available — minor bump candidate), testcontainers 0.27.3, protobuf 3.7.2
+(= fixed for RUSTSEC-2024-0437), slab 0.4.12 (post-fix), zip 3.0.0 & 7.2.0
+(both post zip-2.x advisories), tokio 1.52.3 (current).
+
+## Actions (Tier 2)
+
+| Action                                                                  | Cible                                  | Tier |
+| ----------------------------------------------------------------------- | -------------------------------------- | ---- |
+| Created worktree branch `story/432-dependabot-security` from origin/feature/dev | local repo                     | 2    |
+| Ran `docker compose run --rm --no-deps backend cargo audit` (per §12)    | docker (engine crashed mid-build)      | 2    |
+| Diagnosed compose name conflict + Docker Desktop engine 500 crash       | env                                    | 2    |
+| Read `backend/.cargo/audit.toml`, `SECURITY.md`, `security.yml`, `dependabot.yml` | repo (read-only)              | 2    |
+| Catalogued pre-existing accepted-residual baseline + lockfile snapshot  | this log                               | 2    |
+| Wrote this agent-activity log                                           | repo                                   | 2    |
+
+## Next steps (human / follow-up — Docker restart required)
+
+1. **Restart Docker Desktop** (host action; WP-B2 cannot do this from sandbox).
+   Optionally raise the Docker VM memory limit — the koprogo+cargo-audit
+   compile OOM'd the engine. Free the `koprogo-postgres` name held by the
+   other worktree, or keep using `--no-deps` for audit (audit needs no DB).
+2. Re-run `docker compose run --rm --no-deps backend bash -c "cargo audit"`
+   (image deps are now cached in the worktree volume — should be fast).
+3. For each HIGH + reachable MOD not already in the residual table above:
+   minimal `cargo update -p <crate> [--precise <ver>]`; re-audit until
+   HIGH = 0 and reachable MOD resolved.
+4. `docker compose run --rm --no-deps backend bash -c "SQLX_OFFLINE=true cargo check --all-targets"`
+   must stay clean; revert+document any bump that breaks compilation.
+5. Update this log's residual table with the live before/after advisory data
+   and the actual crates bumped (old→new).
+
+## Links
+
+- Branch: `story/432-dependabot-security` (clean — no Cargo.toml/lock changes; only this log added)
+- Residual source of truth: `backend/.cargo/audit.toml`, `SECURITY.md`
+- CI gate: `.github/workflows/security.yml` (`cargo audit`, ignores via audit.toml)
+- Dependabot: `.github/dependabot.yml` (cargo → feature/dev, weekly, grouped patch/minor)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5880,9 +5880,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -6597,6 +6597,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11119,9 +11120,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.5",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-      "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -11133,7 +11134,7 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
         "esrap": "^2.2.4",
         "is-reference": "^3.0.3",


### PR DESCRIPTION
WBS WP-B2. Closes the actionable part of #432.

GitHub Dependabot #432 (the real source; the WBS "14 vulns" figure was stale) was **entirely npm/frontend**: 1 HIGH `devalue` <5.8.1 (DoS) + 4 MEDIUM `svelte` <5.55.7 (XSS×3 / ReDoS). `package.json` ranges already allowed the patched versions → lockfile-only bump.

- `npm audit --omit=dev` (production): **0 vulnerabilities** — 5 alerts resolved
- `npm run build`: green (104 pages), no regression
- `cargo audit` (RustSec): exit 0, clean modulo documented `.cargo/audit.toml` ignores

**Accepted residual (1 HIGH):** `@babel/plugin-transform-modules-systemjs` — transitive **devDependency** (build-only, never shipped); only fixable via `audit fix --force` (breaking) — declined per CRITICAL.md, documented.

Note: overlaps pre-existing Dependabot PR #533 (devalue 5.8.1) — this PR additionally covers the 4 svelte alerts. Refs #432