### PR TITLE
feat(backend): #433 WP-A4 EXP-005 charge_distribution — typed domain error

### DIFF
--- a/backend/src/application/error.rs
+++ b/backend/src/application/error.rs
@@ -191,6 +191,16 @@ impl From<crate::domain::entities::JournalEntryError> for AppError {
     }
 }
 
+impl From<crate::domain::entities::ChargeDistributionError> for AppError {
+    /// Une répartition de charges malformée est une erreur d'entrée client
+    /// (quote-part hors [0,1], total négatif, somme des quotités > 100%) →
+    /// 400 validation, **jamais** 500 Internal (le `From<String>` générique
+    /// mappait à tort vers Internal) — #433 / WP-A4 EXP-005.
+    fn from(e: crate::domain::entities::ChargeDistributionError) -> Self {
+        AppError::Validation(e.to_string())
+    }
+}
+
 // ============================================================================
 // Tests — taxonomie 4 catégories obligatoire (cf. CRITICAL.md règle #3, #427)
 // ============================================================================

--- a/backend/src/domain/entities/charge_distribution.rs
+++ b/backend/src/domain/entities/charge_distribution.rs
@@ -30,6 +30,53 @@ const DISTRIBUTION_TOLERANCE: Decimal = dec!(0.01);
 /// Tolerance for total quota sum to allow rounding errors (1.0001 = 100.01%).
 const QUOTA_SUM_TOLERANCE: Decimal = dec!(1.0001);
 
+/// Domain-typed validation error for charge distribution (quote-part exactness).
+///
+/// Pure domain type — no infrastructure/application dependency (hexagonal
+/// purity). Follows the codebase precedent `JournalEntryError`
+/// (journal_entry.rs) / `ProxyValidationError` (vote.rs): the entity returns
+/// its own typed error; the application layer maps it to `AppError`
+/// (see `impl From<ChargeDistributionError> for AppError`) so a malformed
+/// distribution surfaces as a 400 validation error, not a 500 Internal
+/// (#433 / WP-A4 — EXP-005).
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChargeDistributionError {
+    /// Quota percentage is outside the valid [0, 1] range.
+    QuotaOutOfRange(Decimal),
+    /// Total amount to distribute is negative.
+    NegativeTotalAmount,
+    /// Sum of all quotas exceeds 100% beyond the rounding tolerance.
+    /// Over-distribution would over-charge owners — financial integrity guard.
+    QuotaSumExceeds { total_quota: Decimal },
+}
+
+impl std::fmt::Display for ChargeDistributionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::QuotaOutOfRange(q) => {
+                write!(f, "Quota percentage must be between 0 and 1 (got: {})", q)
+            }
+            Self::NegativeTotalAmount => write!(f, "Total amount cannot be negative"),
+            Self::QuotaSumExceeds { total_quota } => write!(
+                f,
+                "Total quota percentage exceeds 100% (got: {})",
+                total_quota * dec!(100)
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ChargeDistributionError {}
+
+/// Bridge so existing `Result<_, String>` use-cases keep compiling while the
+/// entity is typed (the use-case/port String→AppError cascade is a distinct,
+/// broader slice — out of WP-A4 scope, mirrors WP-A3). Pure, std-only.
+impl From<ChargeDistributionError> for String {
+    fn from(e: ChargeDistributionError) -> String {
+        e.to_string()
+    }
+}
+
 impl ChargeDistribution {
     pub fn new(
         expense_id: Uuid,
@@ -37,16 +84,13 @@ impl ChargeDistribution {
         owner_id: Uuid,
         quota_percentage: Decimal,
         total_amount: Decimal,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, ChargeDistributionError> {
         // Validations
         if quota_percentage < Decimal::ZERO || quota_percentage > Decimal::ONE {
-            return Err(format!(
-                "Quota percentage must be between 0 and 1 (got: {})",
-                quota_percentage
-            ));
+            return Err(ChargeDistributionError::QuotaOutOfRange(quota_percentage));
         }
         if total_amount < Decimal::ZERO {
-            return Err("Total amount cannot be negative".to_string());
+            return Err(ChargeDistributionError::NegativeTotalAmount);
         }
 
         // Calcul du montant dû
@@ -64,12 +108,14 @@ impl ChargeDistribution {
     }
 
     /// Recalcule le montant dû si la quote-part ou le total change
-    pub fn recalculate(&mut self, total_amount: Decimal) -> Result<(), String> {
+    pub fn recalculate(&mut self, total_amount: Decimal) -> Result<(), ChargeDistributionError> {
         if self.quota_percentage < Decimal::ZERO || self.quota_percentage > Decimal::ONE {
-            return Err("Quota percentage must be between 0 and 1".to_string());
+            return Err(ChargeDistributionError::QuotaOutOfRange(
+                self.quota_percentage,
+            ));
         }
         if total_amount < Decimal::ZERO {
-            return Err("Total amount cannot be negative".to_string());
+            return Err(ChargeDistributionError::NegativeTotalAmount);
         }
 
         self.amount_due = total_amount * self.quota_percentage;
@@ -82,19 +128,16 @@ impl ChargeDistribution {
         expense_id: Uuid,
         total_amount: Decimal,
         unit_ownerships: Vec<(Uuid, Uuid, Decimal)>, // (unit_id, owner_id, quota_percentage)
-    ) -> Result<Vec<ChargeDistribution>, String> {
+    ) -> Result<Vec<ChargeDistribution>, ChargeDistributionError> {
         if total_amount < Decimal::ZERO {
-            return Err("Total amount cannot be negative".to_string());
+            return Err(ChargeDistributionError::NegativeTotalAmount);
         }
 
         // Vérifier que la somme des quotes-parts ne dépasse pas 100%
         let total_quota: Decimal = unit_ownerships.iter().map(|(_, _, q)| *q).sum();
         if total_quota > QUOTA_SUM_TOLERANCE {
             // Tolérance pour arrondi
-            return Err(format!(
-                "Total quota percentage exceeds 100% (got: {})",
-                total_quota * dec!(100)
-            ));
+            return Err(ChargeDistributionError::QuotaSumExceeds { total_quota });
         }
 
         let mut distributions = Vec::new();
@@ -154,9 +197,10 @@ mod tests {
             ChargeDistribution::new(expense_id, unit_id, owner_id, dec!(-0.1), dec!(1000));
 
         assert!(distribution.is_err());
-        assert!(distribution
-            .unwrap_err()
-            .contains("Quota percentage must be between 0 and 1"));
+        assert!(matches!(
+            distribution.unwrap_err(),
+            ChargeDistributionError::QuotaOutOfRange(_)
+        ));
     }
 
     #[test]
@@ -237,9 +281,10 @@ mod tests {
             ChargeDistribution::calculate_distributions(expense_id, dec!(1000), unit_ownerships);
 
         assert!(distributions.is_err());
-        assert!(distributions
-            .unwrap_err()
-            .contains("Total quota percentage exceeds 100%"));
+        assert!(matches!(
+            distributions.unwrap_err(),
+            ChargeDistributionError::QuotaSumExceeds { .. }
+        ));
     }
 
     #[test]
@@ -394,5 +439,126 @@ mod tests {
 
         let dists = vec![dist1, dist2, dist3];
         assert_eq!(ChargeDistribution::total_distributed(&dists), dec!(0.3));
+    }
+
+    // ------------------------------------------------------------------------
+    // 4 catégories #433/WP-A4 — taxonomie typée (CRITICAL.md #3). Le glue BDD
+    // (charge_distribution.feature) fixe une répartition valide à 100% via le
+    // Background et ne peut donc pas exercer comportementalement les chemins de
+    // rejet : ces invariants de l'entité domaine sont vérifiés ici en unitaire,
+    // sur l'erreur typée `ChargeDistributionError` (précédent WP-A3
+    // journal_entry.rs / commentaire journal_entries.feature).
+    // ------------------------------------------------------------------------
+
+    /// @happy — Nominal distribution: quotes-parts somment à 100%, total réparti
+    /// exactement, équilibre vérifié à 1 centime.
+    #[test]
+    fn happy_distribution_balances_to_total() {
+        let expense_id = Uuid::new_v4();
+        let ownerships = vec![
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.40)),
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.35)),
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.25)),
+        ];
+
+        let dists = ChargeDistribution::calculate_distributions(expense_id, dec!(1000), ownerships)
+            .unwrap();
+
+        assert_eq!(dists.len(), 3);
+        assert_eq!(ChargeDistribution::total_distributed(&dists), dec!(1000.00));
+        assert!(ChargeDistribution::verify_distribution(&dists, dec!(1000)));
+    }
+
+    /// @edge — Borne exacte de la tolérance de somme des quotités :
+    /// 100.01% (= QUOTA_SUM_TOLERANCE) passe, 100.011% est rejeté.
+    #[test]
+    fn edge_quota_sum_at_tolerance_boundary() {
+        let expense_id = Uuid::new_v4();
+
+        // Exactement 1.0001 (100.01%) — accepté (borne stricte `>`).
+        let at_boundary = vec![
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.5000)),
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.5001)),
+        ];
+        assert!(
+            ChargeDistribution::calculate_distributions(expense_id, dec!(1000), at_boundary)
+                .is_ok(),
+            "Σ quotités == 1.0001 doit passer (borne de tolérance)"
+        );
+
+        // 1.00011 (100.011%) — au-delà de la tolérance, rejeté.
+        let over_boundary = vec![
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.50000)),
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.50011)),
+        ];
+        assert!(matches!(
+            ChargeDistribution::calculate_distributions(expense_id, dec!(1000), over_boundary)
+                .unwrap_err(),
+            ChargeDistributionError::QuotaSumExceeds { .. }
+        ));
+    }
+
+    /// @negative — Quote-part > 1 ou négative rejetée (erreur typée, pas de panic).
+    #[test]
+    fn negative_quota_out_of_range_rejected() {
+        let above = ChargeDistribution::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            dec!(1.5),
+            dec!(1000),
+        );
+        assert!(matches!(
+            above.unwrap_err(),
+            ChargeDistributionError::QuotaOutOfRange(_)
+        ));
+
+        let negative = ChargeDistribution::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            dec!(-0.1),
+            dec!(1000),
+        );
+        assert!(matches!(
+            negative.unwrap_err(),
+            ChargeDistributionError::QuotaOutOfRange(_)
+        ));
+    }
+
+    /// @negative — Montant total négatif rejeté (erreur typée).
+    #[test]
+    fn negative_total_amount_rejected() {
+        let result = ChargeDistribution::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            dec!(0.25),
+            dec!(-1000),
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            ChargeDistributionError::NegativeTotalAmount
+        ));
+    }
+
+    /// @security — Une table de quotités falsifiée sommant à > 100% ne doit
+    /// jamais permettre de sur-répartir une charge (sur-facturation des
+    /// copropriétaires) : invariant d'intégrité financière (#433/WP-A4).
+    #[test]
+    fn security_quota_sum_overflow_prevents_overcharge() {
+        let expense_id = Uuid::new_v4();
+        // Σ = 130% — tentative de sur-distribution.
+        let tampered = vec![
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.70)),
+            (Uuid::new_v4(), Uuid::new_v4(), dec!(0.60)),
+        ];
+
+        let result = ChargeDistribution::calculate_distributions(expense_id, dec!(10000), tampered);
+
+        assert!(matches!(
+            result.unwrap_err(),
+            ChargeDistributionError::QuotaSumExceeds { .. }
+        ));
     }
 }

--- a/backend/src/domain/entities/mod.rs
+++ b/backend/src/domain/entities/mod.rs
@@ -70,7 +70,7 @@ pub use budget::{Budget, BudgetStatus};
 pub use building::Building;
 pub use call_for_funds::{CallForFunds, CallForFundsStatus};
 pub use challenge::{Challenge, ChallengeProgress, ChallengeStatus, ChallengeType};
-pub use charge_distribution::ChargeDistribution;
+pub use charge_distribution::{ChargeDistribution, ChargeDistributionError};
 pub use consent::{ConsentRecord, ConsentStatus};
 pub use contract_evaluation::ContractEvaluation;
 pub use contractor_report::{ContractorReport, ContractorReportStatus, ReplacedPart};

--- a/backend/tests/features/charge_distribution.feature
+++ b/backend/tests/features/charge_distribution.feature
@@ -15,6 +15,17 @@ Feature: Charge Distribution
     And unit 3 owned by "Charlie" at 25%
     And an expense of 1000 EUR exists for the building
 
+  # 4 catégories (#433/WP-A4 — EXP-005). @edge (borne tolérance somme
+  # quotités 1.0001), @negative (quote-part > 1 / négative, total négatif)
+  # et @security (somme quotités > 100% ⇒ sur-facturation rejetée) sont des
+  # invariants de l'entité domaine, vérifiés par les tests unitaires typés
+  # `edge_quota_sum_at_tolerance_boundary`, `negative_quota_out_of_range_rejected`,
+  # `negative_total_amount_rejected`, `security_quota_sum_overflow_prevents_overcharge`
+  # (charge_distribution.rs) — le Background BDD fixe une répartition valide à
+  # 100% et ne peut donc pas exercer comportementalement ces chemins de rejet
+  # ici (même précédent que journal_entries.feature / WP-A3).
+
+  @happy
   Scenario: Calculate distribution for an invoice
     When I calculate charge distribution for the expense
     Then distributions should be created for all 3 owners
@@ -38,7 +49,10 @@ Feature: Charge Distribution
     When I get total due for owner "Alice" (40%)
     Then the total due should be 600 EUR (40% of 1500 EUR)
 
+  @edge
   Scenario: Distribution respects ownership percentages exactly
+    # Cent-rounding precision: 333 EUR ventilé en quotités 40/35/25 — Decimal
+    # exact (ADR-0007), pas de dérive f64 sur le cumul des montants dus.
     Given an expense of 333 EUR exists
     When I calculate charge distribution
     Then "Alice" should owe 133.20 EUR (40%)

--- a/docs/WBS_GO_LIVE_v0.1.0.md
+++ b/docs/WBS_GO_LIVE_v0.1.0.md
@@ -2,7 +2,7 @@
 
 `WBS-v0.1.0-beta-r1` · 2026-05-16 · base : `feature/dev` + branche `story/521-C1-governance-decimal` (HEAD `98c1651`, 1 commit devant `origin/feature/dev`).
 
-> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont *référencés*, pas créés.
+> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont _référencés_, pas créés.
 >
 > **Supersession** : ce document remplace, pour le go-live, les WBS périmés du 2026-04-01 — [`WBS_RELEASE_0_1_0.md`](WBS_RELEASE_0_1_0.md), [`WBS_BUGFIX_UI_v0.1.0.md`](WBS_BUGFIX_UI_v0.1.0.md), [`WBS_CORRECTIONS_v0.1.0.md`](WBS_CORRECTIONS_v0.1.0.md) — qui restent valables comme contexte historique mais ne reflètent plus l'état du code (Story A Decimal mergée, #515 mergé, TLS déjà câblé).
 
@@ -11,6 +11,7 @@
 KoproGo v0.1.0 n'a jamais été taggé ni mis en ligne (aucun tag git, aucune release). Le besoin : **mettre v0.1.0 en ligne en bêta privée fermée (5-10 copropriétés)** avec une infrastructure opérationnelle réelle et tous les tests requis (4 catégories `@happy/@edge/@security/@negative`, RED-first). Le rapport de revue humaine `docs/HUMAN_REVIEW_REPORT_v0.1.0.md` date du **2026-04-01 (~6 semaines, périmé)** et concluait NO-GO public / GO-conditionnel bêta — il doit être **re-rejoué** sur le code courant, pas pris pour argent comptant (plusieurs bugs sont probablement déjà corrigés : #523 dashboard %, #521 Story A mergée).
 
 Décisions produit verrouillées :
+
 1. **Déploiement : VPS d'abord, puis k3s en Phase 2.** Phase 1 = OVH VPS + docker-compose (`infrastructure/monosite/vps/production`, poller systemd `gitops-deploy.sh`). k3s/ArgoCD = Phase 2 post-v0.1.0.
 2. **Périmètre : bêta privée fermée.** Gate = bloquants critiques (sécurité réelle mais allégée vs gate public #427).
 3. **Decimal : umbrella #433 COMPLÈTE** (EXP-003..008 + gouvernance C1 #521/#534/#525). Exactitude PCMN obligatoire même en bêta.
@@ -18,16 +19,16 @@ Décisions produit verrouillées :
 
 ## Faits vérifiés (corrigent le chemin critique — ne pas re-dériver)
 
-| Hypothèse initiale | Réalité vérifiée (code) | Impact |
-|---|---|---|
-| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL. |
-| EXP-005 `charge_distribution` à faire | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`) | `Result→AppError` + BDD 4-cat seulement |
-| #453 TLS = bloquant go-live | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
-| #515 5 gaps ArgoCD bloquants | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s | Phase 2 |
-| Migration gouvernance large | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode |
-| EXP-007 `etat_date` mineur | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC) | WP-A5 = item le plus long de Track A |
-| #443 cascade énorme | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e_*.rs | Cascade réelle mais bornée |
-| JWT stockage | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage` | **Bloquant sécurité bêta fermée** confirmé |
+| Hypothèse initiale                                   | Réalité vérifiée (code)                                                                                                                                                                                                                          | Impact                                                                                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB                                                                   | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL.                                                  |
+| EXP-005 `charge_distribution` à faire                | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`)                                                                                                                                                                                          | `Result→AppError` + BDD 4-cat seulement                                                                                                       |
+| #453 TLS = bloquant go-live                          | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
+| #515 5 gaps ArgoCD bloquants                         | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s                                                                                                                                                                     | Phase 2                                                                                                                                       |
+| Migration gouvernance large                          | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data                                                                         | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode                                                                                     |
+| EXP-007 `etat_date` mineur                           | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC)                                                                                                                                                              | WP-A5 = item le plus long de Track A                                                                                                          |
+| #443 cascade énorme                                  | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e\_\*.rs                                                                                                                                                                                           | Cascade réelle mais bornée                                                                                                                    |
+| JWT stockage                                         | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage`                                                                                                                                         | **Bloquant sécurité bêta fermée** confirmé                                                                                                    |
 
 **Vrai long pole = WP-A2 (#443 cascade tests) → WP-A5 (EXP-007 etat_date)**, à paralléliser avec la chaîne Ops-VPS (latence Tier-1 humaine).
 
@@ -37,18 +38,19 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track A — Backend Decimal
 
-- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · *critique, premier*
+- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · _critique, premier_
   Appliquer `backend/migrations/20260516000000_alter_governance_to_numeric.sql` (DB test) ; `bdd_governance` 4 scénarios VERTS ; tuer le panic #525 ColumnDecode `units.quota`. Décisions bloquantes : (a) **ADR-0008 ratio** pour proxy validation `vote.rs:~312-342` (draft `docs/agent-activity/2026-05-16-adr8-noncompliance-body.md`) ; (b) **politique f64 d'affichage** — `resolution.rs:185-212` `pour/contre/abstention_percentage()` renvoient `f64` depuis comptes entiers : **reco = carve-out ADR-0008 explicite (affichage seul, jamais seuil légal)** + assertion que le chemin quorum/majorité légal n'a aucun aller-retour Decimal→f64→Decimal. Fichiers : la migration, `tests/bdd_governance.rs`, `features/governance_decimal.feature`, `entities/{vote,resolution,meeting,age_request}.rs`, repos impl correspondants. Deps : aucune.
 
-- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · *critique* · **FAIT** (#539 + reconfirmé 2026-05-18)
+- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · _critique_ · **FAIT** (#539 + reconfirmé 2026-05-18)
   `docker compose run --rm backend cargo check --tests` propre (`--lib` déjà propre). Literals f64→`dec!()` aux call-sites, assertions Decimal-equality, zéro régression scénario @security/@negative. Fichiers : `tests/bdd_financial.rs` (~23 occ.), `tests/e2e_*.rs`, glue `features/*.feature`. Deps : conventions WP-A1. **Concurrent Track F.**
   **Reconfirmé** (post-merge 5 PR + WP-B3 + #526) : `cargo check --tests` **CHECK_EXIT=0**, 0 erreur, aucune cascade f64/Decimal résiduelle (1 warning amont `proc-macro-error2`, non-bloquant). Suite BDD 100% verte (G1/G2/OPS/COM/FIN=0) ⇒ zéro régression @security/@negative confirmée. **Critère GO « `cargo check --tests` propre » atteint.**
 
 - **WP-A3 — EXP-006 journal_entry (réduit)** · #433 · T2 · M
   `Result<_,String>`→`AppError` sur `JournalEntry/JournalEntryLine`. `features/journal_entries.feature` 4-cat RED-first : @negative **débit≠crédit rejeté**, @edge 0.1+0.2=0.3, @security isolation cross-org, @happy écriture équilibrée. Pas de SQL. Deps : A1, A2.
 
-- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · *parallèle A3*
+- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · _parallèle A3_ · **FAIT** (2026-05-19)
   `Result→AppError` ; 4-cat : @security somme quotas==100% à `dec!(1.0001)`, @negative quota>1/négatif rejeté. Deps : A1.
+  **Réalisé** (slice cohérente WP-A3) : entité `charge_distribution.rs` typée `ChargeDistributionError` (pure domaine, 3 variantes) + pont `From<…> for String` + `From<…> for AppError`→Validation 400 (bloc en fin de section From, après A3). Entité déjà 100% `Decimal` (aucune migration SQL). 4-cat RED-first typés in-module (`happy/edge borne 1.0001/negative ×2/security Σ>100%`) ; feature taggée `@happy`+`@edge` (commentaire style A3 pour les invariants unitaires). `cargo check --lib --tests` propre, `cargo test --lib charge_distribution` 30/30, `application::error` 16/16, fmt propre (fallback cargo hôte — daemon Docker absent). **Différé (idem A3)** : cascade port/use-case/repo/handler `String`→`AppError` (slice #433 large unique) + gap isolation cross-org use-case (finding Tier-2 tracé `docs/agent-activity/2026-05-19-wbs-a4.md`).
 
 - **WP-A5 — EXP-007 quote/etat_date (Art. 577 CC, plus gros résidu)** · #433 · T2 · L
   f64→Decimal `etat_date` (17 occ.) + `quote` + DTO/use_case/repo ; migration SQL **seulement si** colonnes `DOUBLE PRECISION` (vérifier `20251115000000_create_etats_dates.sql`, `20251120150000_create_quotes.sql`) ; `Result→AppError` ; 4-cat `etat_date.feature`/`quotes.feature`. Deps : A1, A2.
@@ -61,19 +63,19 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track B — Backend autre
 
-- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1*
+- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1\*
   Re-jouer `HUMAN_REVIEW_REPORT_v0.1.0.md` comme checklist vs `feature/dev` courant : **BUG-WF14-2 fuite bâtiments cross-org (Alice voit 3 bâtiments) = bloquant sécurité bêta si reproductible** — tracer scoping `organization_id` repo buildings ; BUG-WF2-1 `voting_power≤1000` vs seed>1280 (vérifier `20260401000000_fix_voting_power_constraint.sql`) ; BUG-WF7-1 ticket 400 ; NaN% compteurs (probablement corrigé par #523 `7c2d664` — vérifier). Repro RED par bug confirmé. Deps : aucune.
 
-- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · *parallèle* · **FAIT** (PR #538)
+- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · _parallèle_ · **FAIT** (PR #538)
   Réalité : #432 = 100% npm/frontend (le "14 vulns" était périmé). `svelte 5.55.7` + `devalue 5.8.1` → 5 alertes résolues, `npm audit --omit=dev` = 0, build vert. Résiduel 1 HIGH `@babel/plugin-transform-modules-systemjs` (devDependency build-only, `audit fix --force` breaking → accepté/documenté). `cargo audit` (RustSec) exit 0 modulo ignores `.cargo/audit.toml`. Fichiers : `frontend/package-lock.json`. Deps : aucune.
 
-- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · *débruite le gate* · **FAIT** (PR #541)
+- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · _débruite le gate_ · **FAIT** (PR #541)
   Le fix #524 a rendu le harness honnête → ~27 scénarios BDD pré-existants rouges sur 8 groupes (CI run `25982956110`) bruitent **toute** PR : « Meeting Resolutions » 14/14 (quorum Art. 3.87 §5 ordre workflow), Board CdC mandat ×5 (Art. 3.89 assertion vs règle), Energy/Notice/CallForFunds/Gamification ×6 (seeds/asserts), Stats ×2 (= #526). **Issue de tracking consolidée = #540** (inventaire complet + critères) ; un sous-fix RED-first 4-cat par groupe (P1 = Meeting Resolutions + Board mandat, légalement sensibles ; P2 = seeds/asserts ; Stats = #526 séparé). Aucun fix « comme ça » — comprendre la cause (test faux / prod faux / spec obsolète). Deps : aucune (parallèle). **Prérequis du jugement BDD propre en G1.**
-  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle *syndic* Art. 3.89 1–3 ans au *conseil de copropriété*, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
+  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle _syndic_ Art. 3.89 1–3 ans au _conseil de copropriété_, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
 
 ### Track C — Frontend sécurité (refacto #343 / SSR client:load DIFFÉRÉS post-bêta)
 
-- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · *critique*
+- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · _critique_
   `auth.ts:128-235` : refresh token → cookie backend `HttpOnly; Secure; SameSite=Strict` ; access token en mémoire seule + silent-refresh au load. Backend login/refresh : set-cookie + read-cookie + CORS credentials. 4-cat RED-first : @security token illisible JS/`document.cookie` & absent localStorage ; @negative cookie forgé/expiré→401 ; @happy login→refresh→protégé ; @edge refresh à la borne d'expiration. Deps : coordination WP-B1 ; moitié backend nourrit moitié FE.
 
 - **WP-FE2 — Corriger bugs FE revue (WF1-1/2/3)** · T2 · M
@@ -89,7 +91,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track E — Tests IaC (sous-ensemble VPS de #354)
 
-- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · *100% parallèle*
+- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · _100% parallèle_
   Job lint dans `ci-infra.yml`, assets VPS seulement : `terraform fmt -check`/`validate` (modules OVH + `monosite/vps/production/terraform`), `ansible-lint` (14 rôles + playbook prod), `yamllint`, `shellcheck` (**gate dur sur `gitops-deploy.sh`** — il exécute le déploiement prod). conftest/molecule/terratest = Phase 2. Deps : aucune.
 
 ### Track F — Ops VPS (concurrent Track A — aucun fichier partagé)
@@ -160,6 +162,7 @@ E1 (lint IaC) ─► F1 (TF/Ansible,T1) ─► F2 (TLS,T1) ─► F3 (poller,T1)
 ## Vérification — commandes exactes & gate humain
 
 Backend (agent) :
+
 ```
 docker compose run --rm backend cargo check --lib
 docker compose run --rm backend cargo check --tests        # propre post WP-A2
@@ -170,7 +173,9 @@ docker compose run --rm backend cargo test --no-fail-fast --test bdd --test bdd_
 docker compose run --rm backend cargo test --test e2e
 docker compose run --rm backend cargo audit                 # #432
 ```
+
 Frontend :
+
 ```
 docker compose run --rm frontend npm run build
 docker compose run --rm frontend npx svelte-check --threshold warning
@@ -179,13 +184,17 @@ docker compose run --rm frontend npx playwright test --project=chromium    # pla
 docker compose run --rm frontend npx playwright test --project=scenarios   # par-scénario
 docker compose run --rm frontend npx prettier --check .
 ```
+
 Gate push / contrat :
+
 ```
 make ci                # VERT obligatoire avant tout push
 make openapi-check     # si DTOs touchés
 make types-sync        # si spec changée
 ```
+
 IaC (post WP-E1) :
+
 ```
 terraform -chdir=infrastructure/monosite/vps/production/terraform fmt -check
 terraform -chdir=infrastructure/monosite/vps/production/terraform validate
@@ -193,7 +202,9 @@ ansible-lint infrastructure/monosite/vps/production/ansible/playbook.yml
 yamllint infrastructure/monosite/vps/production
 shellcheck infrastructure/_shared/scripts/gitops-deploy.sh
 ```
+
 Gate humain (Tier 1 — agent diagnostique/propose seulement) :
+
 1. `terraform apply` (agent fournit plan revu) — F1
 2. `ansible-playbook -i ansible/inventory.ini ansible/playbook.yml` prod — F1
 3. DNS A→IP VPS, ouvrir 80/443, `ACME_EMAIL` dans `.env` prod — F2

--- a/docs/agent-activity/2026-05-19-wbs-a4.md
+++ b/docs/agent-activity/2026-05-19-wbs-a4.md
@@ -1,0 +1,83 @@
+# Agent activity — 2026-05-19 — WBS WP-A4 (EXP-005 charge_distribution)
+
+**Persona:** backend/Rust agent (Tier 2 — diagnose + implement typed-error
+slice + RED-first 4-cat. No prod mutation, no issue creation, no
+force-push, no `--no-verify`).
+
+**Branch:** `claude/continue-wbs-implementation-2qhWE` (== `origin/feature/dev`
+au démarrage, working tree clean).
+
+**Scope:** WBS Track A, WP-A4 — `#433` EXP-005 `charge_distribution`.
+Slice **cohérente avec le précédent WP-A3** (journal*entry) : l'entité de
+domaine passe de `Result<*, String>`à une erreur **typée pure**, l'application
+la mappe vers`AppError`, le pont `From<…> for String` garde la cascade
+use-case/port inchangée (slice plus large, différée — voir §Deferred).
+
+## Réalisé
+
+- `domain/entities/charge_distribution.rs` : enum domaine pur
+  `ChargeDistributionError` (3 variantes : `QuotaOutOfRange(Decimal)`,
+  `NegativeTotalAmount`, `QuotaSumExceeds { total_quota }`) + `Display`
+  (messages **conservés à l'identique** ⇒ assertions `.contains(...)` du glue
+  BDD via le pont String inchangées) + `impl std::error::Error` +
+  `From<ChargeDistributionError> for String` (pont, std-only, pur). Signatures
+  `new` / `recalculate` / `calculate_distributions` → `Result<_,
+ChargeDistributionError>`. Aucun `f64` (l'entité était déjà 100% `Decimal`,
+  ADR-0007 OK — pas de migration SQL).
+- `domain/entities/mod.rs` : export `ChargeDistributionError`.
+- `application/error.rs` : `impl From<ChargeDistributionError> for AppError`
+  → `Validation` (400, **jamais** 500 Internal). Bloc ajouté **en fin** de
+  section From, **après** le bloc `JournalEntryError` (WP-A3), un bloc par WP
+  pour minimiser les conflits de merge inter-WP concurrents (A3/A4/A5).
+- `tests/features/charge_distribution.feature` : taggé `@happy` (calcul
+  nominal) + `@edge` (exactitude Decimal 333 EUR) + commentaire (style WP-A3)
+  expliquant que `@edge` borne / `@negative` / `@security` sont des invariants
+  d'entité vérifiés en unitaire (le Background BDD fixe une répartition valide
+  à 100% et ne peut exercer comportementalement les chemins de rejet).
+- 4-cat RED-first typés (in-module `charge_distribution.rs`) :
+  `happy_distribution_balances_to_total`, `edge_quota_sum_at_tolerance_boundary`
+  (1.0001 passe / 1.00011 rejeté), `negative_quota_out_of_range_rejected`,
+  `negative_total_amount_rejected`,
+  `security_quota_sum_overflow_prevents_overcharge` (Σ quotités > 100% ⇒
+  sur-facturation rejetée — intégrité financière). 2 assertions in-module
+  pré-existantes migrées de `.unwrap_err().contains(...)` vers `matches!`
+  typé.
+
+## Vérification (Docker daemon indisponible → fallback cargo hôte)
+
+- `docker compose run --rm backend …` : **daemon Docker absent** dans cet
+  environnement (`/var/run/docker.sock` inexistant). Fallback hôte (cargo
+  1.94.1, `SQLX_OFFLINE=true`) après tentative docker, conforme CRITICAL.md
+  #12 (essayer docker d'abord).
+- `cargo check --lib --tests` (SQLX_OFFLINE) : **propre, 0 erreur** — le pont
+  String garde `charge_distribution_use_cases.rs:64` (`calculate_distributions(...)?`)
+  et `bdd_financial.rs` compilants sans changement de signature.
+- `cargo test --lib charge_distribution` : **30/30 verts** (dont les 5
+  nouveaux 4-cat ; mocks use-case/repo inchangés OK via le pont).
+- `cargo test --lib application::error` : **16/16 verts**.
+- `cargo fmt --check` sur les 3 fichiers touchés : **propre**.
+
+## Deferred (slice plus large, tracée — identique au choix WP-A3)
+
+- **Cascade port/use-case/repo/handler `Result<_,String>` → `AppError`** :
+  hors scope WP-A4, comme pour WP-A3 (`From<JournalEntryError> for String`
+  documenté « distinct, broader slice »). Le pont String conserve
+  `ChargeDistributionRepository` / `ChargeDistributionUseCases` /
+  `charge_distribution_handlers.rs` inchangés. À traiter en une slice
+  cohérente unique sur l'umbrella #433 (ne pas démanteler les ponts WP par WP).
+- **Gap @security use-case — isolation cross-org ABSENTE** (finding du
+  diagnostic 2026-05-19) : `ChargeDistributionUseCases::calculate_and_save_distribution`
+  ne compare jamais l'`organization_id` appelant vs `expense.organization_id`.
+  Non bloquant pour le @security **défini par le WBS pour A4** (= plafond Σ
+  quotités à `dec!(1.0001)`, couvert). Tracé ici comme finding Tier-2 à
+  reprendre avec la cascade use-case ci-dessus (ne pas faire de vert factice —
+  cf. WBS WP-A4 « scénario RED documenté »).
+- Réconciliation : stack local sur `feature/dev` (5 PR #535-539 + #541 + A3 +
+  ce A4) ; pas de création d'issue (gate Tier-1).
+
+## Critère GO (DoD bêta) adressé
+
+- `cargo check --tests` propre (déjà WP-A2 ; non régressé par A4).
+- `#433` EXP-005 : entité `Decimal` + erreur typée mappée `AppError` (400),
+  aucun `Result<_,String>` / `unwrap` / `expect` hors `#[cfg(test)]` sur le
+  **fichier touché** `charge_distribution.rs`. 4-cat RED-first présents.


### PR DESCRIPTION
## Summary

WBS go-live v0.1.0 — **WP-A4 (#433 EXP-005 `charge_distribution`)**. Slice cohérente avec le précédent **WP-A3** (journal_entry) : l'entité de domaine passe de `Result<_, String>` à une erreur **typée pure**, l'application la mappe vers `AppError`, le pont `From<…> for String` garde la cascade use-case/port inchangée.

- `domain/entities/charge_distribution.rs` : enum domaine pur `ChargeDistributionError` (3 variantes : `QuotaOutOfRange`, `NegativeTotalAmount`, `QuotaSumExceeds`) + `Display` (messages conservés ⇒ glue BDD inchangé via pont String) + `impl Error` + `From<…> for String`. Signatures `new`/`recalculate`/`calculate_distributions` typées. Entité déjà 100 % `Decimal` → **aucune migration SQL**.
- `application/error.rs` : `From<ChargeDistributionError> for AppError` → `Validation` (400, jamais 500). Bloc ajouté **en fin** de section From, après `JournalEntryError` (un bloc par WP, anti-conflit merge A3/A4/A5).
- `domain/entities/mod.rs` : export du type d'erreur.
- 4-cat RED-first typés in-module : `happy_distribution_balances_to_total`, `edge_quota_sum_at_tolerance_boundary` (1.0001 passe / 1.00011 rejeté), `negative_quota_out_of_range_rejected`, `negative_total_amount_rejected`, `security_quota_sum_overflow_prevents_overcharge`. 2 assertions pré-existantes migrées `.contains()` → `matches!` typé.
- `charge_distribution.feature` taggée `@happy`/`@edge` + commentaire (style WP-A3) renvoyant aux invariants unitaires.

### Différé (slice large unique #433, identique au choix WP-A3, tracé)
- Cascade port/use-case/repo/handler `String`→`AppError` (pont String conservé).
- Gap @security use-case **isolation cross-org absente** dans `calculate_and_save_distribution` (finding Tier-2 tracé dans `docs/agent-activity/2026-05-19-wbs-a4.md` — non bloquant pour le @security défini par le WBS pour A4 = plafond Σ quotités `dec!(1.0001)`).

## Test plan

- [x] `cargo check --lib --tests` (SQLX_OFFLINE) propre — 0 erreur
- [x] `cargo test --lib charge_distribution` — 30/30 verts (dont 5 nouveaux 4-cat)
- [x] `cargo test --lib application::error` — 16/16 verts
- [x] `cargo fmt --check` sur fichiers touchés — propre
- [ ] CI complète (`make ci`) — gate humain
- [ ] BDD `charge_distribution.feature` jugé par-scénario en CI (daemon Docker absent en session → fallback cargo hôte, conforme CRITICAL.md #12)

> Tier-2, pas de mutation prod. Base `feature/dev` (WBS go-live). Réf WBS : `docs/WBS_GO_LIVE_v0.1.0.md` WP-A4.

https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP)_