### PR TITLE
feat(security): #343 WP-FE1 — JWT hors localStorage (refresh cookie HttpOnly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Install frontend dependencies
         run: |
@@ -409,7 +409,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Install frontend dependencies
         run: |
@@ -431,7 +431,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Install dependencies
         run: |
@@ -474,7 +474,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Install frontend dependencies
         run: |
@@ -508,6 +508,11 @@ jobs:
           LOGIN_RATE_LIMIT_MAX: 1000
           SMTP_ENABLED: false
           RUST_LOG: warn
+          # WP-FE1 : ce job lance le backend en HTTP direct (cargo run, pas
+          # docker-compose). Le défaut sûr COOKIE_SECURE=true poserait le
+          # cookie refresh `Secure`, rejeté par le navigateur sur http://
+          # → silent-refresh 401 → toute la suite auth E2E échoue.
+          COOKIE_SECURE: "false"
         run: |
           cd backend
           cargo install sqlx-cli --no-default-features --features postgres
@@ -599,7 +604,16 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test-unit, test-bdd, test-e2e, frontend-check, contract-types, vitest]
+    needs:
+      [
+        lint,
+        test-unit,
+        test-bdd,
+        test-e2e,
+        frontend-check,
+        contract-types,
+        vitest,
+      ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,6 +19,12 @@ SERVER_PORT=8080
 UPLOAD_DIR=./uploads
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4321
 
+# WP-FE1 — Refresh token cookie (HttpOnly; SameSite=Strict).
+# COOKIE_SECURE=true en PROD (HTTPS obligatoire — défaut sûr si non défini).
+# Mettre false UNIQUEMENT en dev/E2E sur http://localhost (sinon le
+# navigateur rejette le cookie hors HTTPS).
+COOKIE_SECURE=true
+
 # ========================================
 # Rate Limiting Configuration (Issue #78)
 # ========================================

--- a/backend/src/infrastructure/web/auth_cookie.rs
+++ b/backend/src/infrastructure/web/auth_cookie.rs
@@ -1,0 +1,106 @@
+//! Refresh-token cookie helpers (WP-FE1 — JWT hors localStorage).
+//!
+//! Le refresh token ne transite plus dans le corps JSON ni dans
+//! `localStorage` (vol de session via XSS). Il est porté par un cookie
+//! `HttpOnly; Secure; SameSite=Strict` scopé sur le chemin des endpoints
+//! d'authentification — illisible par JavaScript, non rejouable hors du
+//! même site. L'access token reste en mémoire JS (header `Bearer`,
+//! inchangé). Couche infra uniquement : les use-cases restent purs.
+
+use actix_web::cookie::{time::Duration, Cookie, SameSite};
+
+/// Nom du cookie portant le refresh token.
+pub const REFRESH_COOKIE_NAME: &str = "koprogo_refresh";
+
+/// Chemin de scoping : le cookie n'est envoyé qu'aux endpoints
+/// `/api/v1/auth/*` (refresh, logout) — surface minimale.
+pub const REFRESH_COOKIE_PATH: &str = "/api/v1/auth";
+
+/// Durée de vie alignée sur le `RefreshToken` domaine (7 jours,
+/// cf. `domain::entities::refresh_token::RefreshToken::new`).
+const REFRESH_COOKIE_MAX_AGE_DAYS: i64 = 7;
+
+/// `Secure` flag : `true` en prod (HTTPS obligatoire), `false` seulement
+/// en dev sur http (sinon le navigateur ignore le cookie). Piloté par
+/// `COOKIE_SECURE` (défaut sûr = `true`).
+fn cookie_secure() -> bool {
+    std::env::var("COOKIE_SECURE")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(true)
+}
+
+/// Cookie posant le refresh token (login / refresh-rotation / register /
+/// switch-role). `SameSite=Strict` : front et API servis sur le même site
+/// (Traefik domaine unique) — anti-CSRF natif.
+pub fn build_refresh_cookie(refresh_token: &str) -> Cookie<'static> {
+    Cookie::build(REFRESH_COOKIE_NAME, refresh_token.to_owned())
+        .http_only(true)
+        .secure(cookie_secure())
+        .same_site(SameSite::Strict)
+        .path(REFRESH_COOKIE_PATH)
+        .max_age(Duration::days(REFRESH_COOKIE_MAX_AGE_DAYS))
+        .finish()
+}
+
+/// Cookie d'expiration immédiate (logout) : même nom/chemin, `Max-Age=0`,
+/// valeur vidée. Le navigateur supprime le cookie.
+pub fn build_clearing_cookie() -> Cookie<'static> {
+    Cookie::build(REFRESH_COOKIE_NAME, "")
+        .http_only(true)
+        .secure(cookie_secure())
+        .same_site(SameSite::Strict)
+        .path(REFRESH_COOKIE_PATH)
+        .max_age(Duration::ZERO)
+        .finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// @happy — le cookie refresh est HttpOnly, SameSite=Strict, scopé auth.
+    #[test]
+    fn happy_refresh_cookie_has_security_attributes() {
+        let c = build_refresh_cookie("tok-abc");
+        assert_eq!(c.name(), REFRESH_COOKIE_NAME);
+        assert_eq!(c.value(), "tok-abc");
+        assert_eq!(c.http_only(), Some(true));
+        assert_eq!(c.same_site(), Some(SameSite::Strict));
+        assert_eq!(c.path(), Some(REFRESH_COOKIE_PATH));
+        assert_eq!(c.max_age(), Some(Duration::days(7)));
+    }
+
+    /// @security — par défaut (aucune env) le flag Secure est actif :
+    /// jamais de refresh token en clair sur une connexion non chiffrée.
+    #[test]
+    fn security_cookie_secure_defaults_true() {
+        std::env::remove_var("COOKIE_SECURE");
+        assert!(cookie_secure());
+        assert_eq!(build_refresh_cookie("x").secure(), Some(true));
+    }
+
+    /// @edge — opt-out explicite dev uniquement (`COOKIE_SECURE=false`)
+    /// pour http://localhost ; toute autre valeur reste sécurisée.
+    #[test]
+    fn edge_cookie_secure_opt_out_only_explicit_false() {
+        std::env::set_var("COOKIE_SECURE", "false");
+        assert!(!cookie_secure());
+        std::env::set_var("COOKIE_SECURE", "true");
+        assert!(cookie_secure());
+        std::env::set_var("COOKIE_SECURE", "yes-please");
+        assert!(cookie_secure());
+        std::env::remove_var("COOKIE_SECURE");
+    }
+
+    /// @negative — le cookie de logout invalide la session : valeur vidée,
+    /// Max-Age=0 (suppression navigateur), attributs sécurité conservés.
+    #[test]
+    fn negative_clearing_cookie_expires_immediately() {
+        let c = build_clearing_cookie();
+        assert_eq!(c.name(), REFRESH_COOKIE_NAME);
+        assert_eq!(c.value(), "");
+        assert_eq!(c.max_age(), Some(Duration::ZERO));
+        assert_eq!(c.http_only(), Some(true));
+        assert_eq!(c.path(), Some(REFRESH_COOKIE_PATH));
+    }
+}

--- a/backend/src/infrastructure/web/handlers/auth_handlers.rs
+++ b/backend/src/infrastructure/web/handlers/auth_handlers.rs
@@ -1,10 +1,40 @@
 use crate::application::dto::{
-    LoginRequest, RefreshTokenRequest, RegisterRequest, SwitchRoleRequest,
+    LoginRequest, LoginResponse, RefreshTokenRequest, RegisterRequest, SwitchRoleRequest,
+    UserResponse,
 };
 use crate::application::error::AppError;
-use crate::infrastructure::web::{AppState, AuthenticatedUser};
+use crate::infrastructure::web::{
+    build_clearing_cookie, build_refresh_cookie, AppState, AuthenticatedUser, REFRESH_COOKIE_NAME,
+};
 use actix_web::{get, post, web, HttpRequest, HttpResponse, Responder};
+use serde::Serialize;
 use validator::Validate;
+
+/// Corps de réponse d'authentification **sans** `refresh_token` (WP-FE1).
+///
+/// Le refresh token n'est plus exposé au JavaScript : il part exclusivement
+/// dans le cookie `HttpOnly` (cf. `auth_cookie`). On ne modifie pas le DTO
+/// interne `LoginResponse` (contrat use-case) — on projette ici la vue HTTP.
+#[derive(Serialize)]
+struct AuthBody {
+    token: String,
+    user: UserResponse,
+}
+
+impl From<LoginResponse> for AuthBody {
+    fn from(r: LoginResponse) -> Self {
+        Self {
+            token: r.token,
+            user: r.user,
+        }
+    }
+}
+
+/// Réponse 200 : pose le cookie refresh `HttpOnly` + corps sans refresh.
+fn auth_response_with_cookie(resp: LoginResponse) -> HttpResponse {
+    let cookie = build_refresh_cookie(&resp.refresh_token);
+    HttpResponse::Ok().cookie(cookie).json(AuthBody::from(resp))
+}
 
 #[utoipa::path(
     post,
@@ -29,7 +59,7 @@ pub async fn login(
         .map_err(|errors| AppError::Validation(errors.to_string()))?;
 
     let response = data.auth_use_cases.login(request.into_inner()).await?;
-    Ok(HttpResponse::Ok().json(response))
+    Ok(auth_response_with_cookie(response))
 }
 
 #[utoipa::path(
@@ -59,7 +89,12 @@ pub async fn register(
     }
 
     match data.auth_use_cases.register(request.into_inner()).await {
-        Ok(response) => HttpResponse::Created().json(response),
+        Ok(response) => {
+            let cookie = build_refresh_cookie(&response.refresh_token);
+            HttpResponse::Created()
+                .cookie(cookie)
+                .json(AuthBody::from(response))
+        }
         Err(e) => HttpResponse::BadRequest().json(serde_json::json!({
             "error": e
         })),
@@ -106,24 +141,35 @@ pub async fn get_current_user(
     path = "/auth/refresh",
     tag = "Auth",
     summary = "Refresh Token",
-    request_body = RefreshTokenRequest,
+    description = "Le refresh token est lu depuis le cookie HttpOnly \
+                   `koprogo_refresh` (WP-FE1) — aucun corps de requête. \
+                   La réponse rote le cookie et ne contient pas de \
+                   refresh_token.",
     responses(
-        (status = 201, description = "Resource created successfully"),
-        (status = 400, description = "Bad Request"),
-        (status = 404, description = "Not Found"),
+        (status = 200, description = "Access token rafraîchi"),
+        (status = 401, description = "Cookie refresh absent, expiré ou révoqué"),
         (status = 500, description = "Internal Server Error"),
     ),
 )]
 #[post("/auth/refresh")]
 pub async fn refresh_token(
     data: web::Data<AppState>,
-    request: web::Json<RefreshTokenRequest>,
+    req: HttpRequest,
 ) -> Result<HttpResponse, AppError> {
+    // Le refresh token vient EXCLUSIVEMENT du cookie HttpOnly : illisible
+    // par JS, donc non exfiltrable par XSS (WP-FE1). Absence = 401.
+    let refresh_token = req
+        .cookie(REFRESH_COOKIE_NAME)
+        .map(|c| c.value().to_owned())
+        .filter(|v| !v.is_empty())
+        .ok_or(AppError::Unauthorized)?;
+
     let response = data
         .auth_use_cases
-        .refresh_token(request.into_inner())
+        .refresh_token(RefreshTokenRequest { refresh_token })
         .await?;
-    Ok(HttpResponse::Ok().json(response))
+    // Rotation : le use-case révoque l'ancien refresh et en émet un neuf.
+    Ok(auth_response_with_cookie(response))
 }
 
 #[utoipa::path(
@@ -152,7 +198,39 @@ pub async fn switch_role(
         .switch_active_role(user.user_id, payload.role_id)
         .await
     {
-        Ok(response) => HttpResponse::Ok().json(response),
+        Ok(response) => auth_response_with_cookie(response),
         Err(e) => HttpResponse::BadRequest().json(serde_json::json!({ "error": e })),
     }
+}
+
+#[utoipa::path(
+    post,
+    path = "/auth/logout",
+    tag = "Auth",
+    summary = "Logout",
+    description = "Révoque tous les refresh tokens de l'utilisateur \
+                   (déconnexion serveur) et expire le cookie HttpOnly \
+                   `koprogo_refresh` (WP-FE1).",
+    responses(
+        (status = 200, description = "Déconnecté, cookie expiré"),
+        (status = 401, description = "Access token absent ou invalide"),
+        (status = 500, description = "Internal Server Error"),
+    ),
+)]
+#[post("/auth/logout")]
+pub async fn logout(
+    data: web::Data<AppState>,
+    user: AuthenticatedUser,
+) -> Result<HttpResponse, AppError> {
+    // Révocation serveur : tous les refresh de l'utilisateur sont
+    // invalidés (le cookie volé éventuel devient inutilisable), puis le
+    // cookie est expiré côté navigateur.
+    data.auth_use_cases
+        .revoke_all_refresh_tokens(user.user_id)
+        .await
+        .map_err(AppError::from)?;
+
+    Ok(HttpResponse::Ok()
+        .cookie(build_clearing_cookie())
+        .json(serde_json::json!({ "message": "logged out" })))
 }

--- a/backend/src/infrastructure/web/mod.rs
+++ b/backend/src/infrastructure/web/mod.rs
@@ -1,4 +1,5 @@
 pub mod app_state;
+pub mod auth_cookie;
 pub mod handlers;
 pub mod login_rate_limiter;
 pub mod middleware;
@@ -6,6 +7,7 @@ pub mod routes;
 pub mod security_headers;
 
 pub use app_state::AppState;
+pub use auth_cookie::{build_clearing_cookie, build_refresh_cookie, REFRESH_COOKIE_NAME};
 pub use login_rate_limiter::LoginRateLimiter;
 pub use middleware::{AuthenticatedUser, GdprRateLimit, GdprRateLimitConfig, OrganizationId};
 pub use routes::configure_routes;

--- a/backend/src/infrastructure/web/routes.rs
+++ b/backend/src/infrastructure/web/routes.rs
@@ -32,6 +32,7 @@ pub fn configure_routes(cfg: &mut web::ServiceConfig) {
             .service(register)
             .service(refresh_token)
             .service(switch_role)
+            .service(logout)
             .service(get_current_user)
             // Buildings
             .service(create_building)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -522,6 +522,11 @@ async fn main() -> std::io::Result<()> {
             cors = cors.allowed_origin(origin);
         }
         let cors = cors
+            // WP-FE1 : le cookie refresh HttpOnly exige des requêtes
+            // crédentialisées (fetch `credentials:"include"`). Origines
+            // explicites obligatoires (jamais `*`) — `validate_cors_origins`
+            // rejette déjà le wildcard, contrat compatible credentials.
+            .supports_credentials()
             .allowed_methods(vec!["GET", "POST", "PUT", "DELETE", "OPTIONS"])
             .allowed_headers(vec![
                 actix_web::http::header::AUTHORIZATION,

--- a/backend/tests/e2e_auth.rs
+++ b/backend/tests/e2e_auth.rs
@@ -2,7 +2,7 @@ mod common;
 
 use actix_web::http::header;
 use actix_web::{test, App};
-use koprogo_api::infrastructure::web::configure_routes;
+use koprogo_api::infrastructure::web::{configure_routes, AppState};
 use serde_json::json;
 use serial_test::serial;
 use uuid::Uuid;
@@ -409,5 +409,216 @@ async fn admin_can_manage_user_roles_via_http() {
             .as_str()
             .expect("active role in list"),
         "accountant"
+    );
+}
+
+// ============================================================================
+// WP-FE1 — Refresh token hors localStorage : cookie HttpOnly + corps sans
+// refresh_token. Taxonomie 4 catégories RED-first (CRITICAL.md #3, #427).
+// Exécutés en CI (testcontainers) ; localement compile-check (daemon Docker
+// indisponible — même limite infra que WP-B1, tracée).
+// ============================================================================
+
+async fn register_user(
+    app_state: &actix_web::web::Data<AppState>,
+    org_id: Uuid,
+) -> (String, String) {
+    let email = format!("fe1+{}@test.com", Uuid::new_v4());
+    let password = "Passw0rd!".to_string();
+    let reg = koprogo_api::application::dto::RegisterRequest {
+        email: email.clone(),
+        password: password.clone(),
+        first_name: "Fe1".to_string(),
+        last_name: "Cookie".to_string(),
+        role: "superadmin".to_string(),
+        organization_id: Some(org_id),
+    };
+    app_state
+        .auth_use_cases
+        .register(reg)
+        .await
+        .expect("register");
+    (email, password)
+}
+
+fn set_cookie_header(resp: &actix_web::dev::ServiceResponse) -> String {
+    resp.headers()
+        .get_all(header::SET_COOKIE)
+        .map(|h| h.to_str().unwrap_or_default().to_string())
+        .find(|c| c.starts_with("koprogo_refresh="))
+        .unwrap_or_default()
+}
+
+fn refresh_cookie_value(set_cookie: &str) -> String {
+    set_cookie
+        .strip_prefix("koprogo_refresh=")
+        .and_then(|s| s.split(';').next())
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[actix_web::test]
+#[serial]
+async fn fe1_happy_login_sets_httponly_cookie_and_strips_body() {
+    let (app_state, _container, org_id) = common::setup_test_db().await;
+    let (email, password) = register_user(&app_state, org_id).await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    let req = test::TestRequest::post()
+        .uri("/api/v1/auth/login")
+        .set_json(json!({ "email": email, "password": password }))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert!(resp.status().is_success());
+
+    let set_cookie = set_cookie_header(&resp);
+    assert!(
+        set_cookie.contains("HttpOnly"),
+        "refresh cookie must be HttpOnly: {set_cookie}"
+    );
+    assert!(
+        set_cookie.contains("SameSite=Strict"),
+        "refresh cookie must be SameSite=Strict: {set_cookie}"
+    );
+    assert!(
+        set_cookie.contains("Path=/api/v1/auth"),
+        "refresh cookie must be path-scoped: {set_cookie}"
+    );
+
+    let body: serde_json::Value = test::read_body_json(resp).await;
+    assert!(body.get("token").is_some(), "access token in body");
+    assert!(
+        body.get("refresh_token").is_none(),
+        "refresh_token MUST NOT be in the JSON body (WP-FE1)"
+    );
+}
+
+#[actix_web::test]
+#[serial]
+async fn fe1_security_refresh_via_cookie_rotates_and_body_has_no_refresh() {
+    let (app_state, _container, org_id) = common::setup_test_db().await;
+    let (email, password) = register_user(&app_state, org_id).await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    let login = test::TestRequest::post()
+        .uri("/api/v1/auth/login")
+        .set_json(json!({ "email": email, "password": password }))
+        .to_request();
+    let login_resp = test::call_service(&app, login).await;
+    let old_cookie = refresh_cookie_value(&set_cookie_header(&login_resp));
+    assert!(!old_cookie.is_empty());
+
+    let refresh = test::TestRequest::post()
+        .uri("/api/v1/auth/refresh")
+        .cookie(actix_web::cookie::Cookie::new(
+            "koprogo_refresh",
+            old_cookie.clone(),
+        ))
+        .to_request();
+    let refresh_resp = test::call_service(&app, refresh).await;
+    assert!(refresh_resp.status().is_success());
+
+    let new_set_cookie = set_cookie_header(&refresh_resp);
+    assert!(new_set_cookie.contains("HttpOnly"));
+    let new_cookie = refresh_cookie_value(&new_set_cookie);
+    assert_ne!(
+        old_cookie, new_cookie,
+        "refresh token must rotate on /auth/refresh"
+    );
+
+    let body: serde_json::Value = test::read_body_json(refresh_resp).await;
+    assert!(body.get("token").is_some());
+    assert!(
+        body.get("refresh_token").is_none(),
+        "refresh_token MUST NOT leak in /auth/refresh body"
+    );
+}
+
+#[actix_web::test]
+#[serial]
+async fn fe1_negative_refresh_without_or_forged_cookie_is_401() {
+    let (app_state, _container, _org_id) = common::setup_test_db().await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    // No cookie at all → 401
+    let no_cookie = test::TestRequest::post()
+        .uri("/api/v1/auth/refresh")
+        .to_request();
+    let resp = test::call_service(&app, no_cookie).await;
+    assert_eq!(resp.status(), 401, "missing refresh cookie must be 401");
+
+    // Forged cookie → 401 (token not found / invalid)
+    let forged = test::TestRequest::post()
+        .uri("/api/v1/auth/refresh")
+        .cookie(actix_web::cookie::Cookie::new(
+            "koprogo_refresh",
+            "forged-not-a-real-token",
+        ))
+        .to_request();
+    let resp = test::call_service(&app, forged).await;
+    assert_eq!(resp.status(), 401, "forged refresh cookie must be 401");
+}
+
+#[actix_web::test]
+#[serial]
+async fn fe1_edge_old_refresh_cookie_revoked_after_rotation() {
+    let (app_state, _container, org_id) = common::setup_test_db().await;
+    let (email, password) = register_user(&app_state, org_id).await;
+
+    let app = test::init_service(
+        App::new()
+            .app_data(app_state.clone())
+            .configure(configure_routes),
+    )
+    .await;
+
+    let login = test::TestRequest::post()
+        .uri("/api/v1/auth/login")
+        .set_json(json!({ "email": email, "password": password }))
+        .to_request();
+    let login_resp = test::call_service(&app, login).await;
+    let old_cookie = refresh_cookie_value(&set_cookie_header(&login_resp));
+
+    // First refresh succeeds and rotates.
+    let r1 = test::TestRequest::post()
+        .uri("/api/v1/auth/refresh")
+        .cookie(actix_web::cookie::Cookie::new(
+            "koprogo_refresh",
+            old_cookie.clone(),
+        ))
+        .to_request();
+    assert!(test::call_service(&app, r1).await.status().is_success());
+
+    // Reusing the OLD (now revoked) cookie must fail — replay protection.
+    let r2 = test::TestRequest::post()
+        .uri("/api/v1/auth/refresh")
+        .cookie(actix_web::cookie::Cookie::new(
+            "koprogo_refresh",
+            old_cookie,
+        ))
+        .to_request();
+    let resp = test::call_service(&app, r2).await;
+    assert_eq!(
+        resp.status(),
+        401,
+        "reused/rotated refresh token must be rejected (replay)"
     );
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,14 @@ services:
     container_name: koprogo-traefik
     command:
       - "--api.dashboard=true"
-      - "--api.insecure=true"  # Dashboard on :8081
+      - "--api.insecure=true" # Dashboard on :8081
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
       - "--log.level=INFO"
     ports:
-      - "80:80"      # HTTP
-      - "8081:8080"  # Traefik Dashboard
+      - "80:80" # HTTP
+      - "8081:8080" # Traefik Dashboard
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
@@ -33,7 +33,7 @@ services:
       POSTGRES_USER: koprogo
       POSTGRES_PASSWORD: koprogo123
     ports:
-      - "127.0.0.1:5432:5432"  # Localhost only - not exposed to network
+      - "127.0.0.1:5432:5432" # Localhost only - not exposed to network
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/migrations:/docker-entrypoint-initdb.d/migrations:ro
@@ -58,6 +58,9 @@ services:
       RUST_LOG: debug
       RUST_BACKTRACE: 1
       SQLX_OFFLINE: "true"
+      # WP-FE1 : dev/E2E sur http://localhost → cookie refresh sans flag
+      # Secure (sinon le navigateur le rejette hors HTTPS). PROD = true.
+      COOKIE_SECURE: "false"
       ENABLE_RATE_LIMITING: false
       LOGIN_RATE_LIMIT_MAX: "1000"
       LOGIN_RATE_LIMIT_WINDOW_SECS: "60"
@@ -102,7 +105,7 @@ services:
     volumes:
       # Hot reload: mount source code
       - ./frontend:/app
-      - /app/node_modules  # Prevent overwriting node_modules
+      - /app/node_modules # Prevent overwriting node_modules
     depends_on:
       - backend
       - minio
@@ -125,12 +128,16 @@ services:
       MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-minioadmin}
     # MinIO n'est exposé qu'en loopback. Utilisez un tunnel SSH si vous avez besoin d'y accéder à distance.
     ports:
-      - "127.0.0.1:9000:9000"  # S3 API (localhost uniquement)
-      - "127.0.0.1:9001:9001"  # Console (localhost uniquement)
+      - "127.0.0.1:9000:9000" # S3 API (localhost uniquement)
+      - "127.0.0.1:9001:9001" # Console (localhost uniquement)
     volumes:
       - minio_data:/data
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://127.0.0.1:9000/minio/health/live || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl -f http://127.0.0.1:9000/minio/health/live || exit 1",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/WBS_GO_LIVE_v0.1.0.md
+++ b/docs/WBS_GO_LIVE_v0.1.0.md
@@ -2,7 +2,7 @@
 
 `WBS-v0.1.0-beta-r1` · 2026-05-16 · base : `feature/dev` + branche `story/521-C1-governance-decimal` (HEAD `98c1651`, 1 commit devant `origin/feature/dev`).
 
-> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont *référencés*, pas créés.
+> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont _référencés_, pas créés.
 >
 > **Supersession** : ce document remplace, pour le go-live, les WBS périmés du 2026-04-01 — [`WBS_RELEASE_0_1_0.md`](WBS_RELEASE_0_1_0.md), [`WBS_BUGFIX_UI_v0.1.0.md`](WBS_BUGFIX_UI_v0.1.0.md), [`WBS_CORRECTIONS_v0.1.0.md`](WBS_CORRECTIONS_v0.1.0.md) — qui restent valables comme contexte historique mais ne reflètent plus l'état du code (Story A Decimal mergée, #515 mergé, TLS déjà câblé).
 
@@ -11,6 +11,7 @@
 KoproGo v0.1.0 n'a jamais été taggé ni mis en ligne (aucun tag git, aucune release). Le besoin : **mettre v0.1.0 en ligne en bêta privée fermée (5-10 copropriétés)** avec une infrastructure opérationnelle réelle et tous les tests requis (4 catégories `@happy/@edge/@security/@negative`, RED-first). Le rapport de revue humaine `docs/HUMAN_REVIEW_REPORT_v0.1.0.md` date du **2026-04-01 (~6 semaines, périmé)** et concluait NO-GO public / GO-conditionnel bêta — il doit être **re-rejoué** sur le code courant, pas pris pour argent comptant (plusieurs bugs sont probablement déjà corrigés : #523 dashboard %, #521 Story A mergée).
 
 Décisions produit verrouillées :
+
 1. **Déploiement : VPS d'abord, puis k3s en Phase 2.** Phase 1 = OVH VPS + docker-compose (`infrastructure/monosite/vps/production`, poller systemd `gitops-deploy.sh`). k3s/ArgoCD = Phase 2 post-v0.1.0.
 2. **Périmètre : bêta privée fermée.** Gate = bloquants critiques (sécurité réelle mais allégée vs gate public #427).
 3. **Decimal : umbrella #433 COMPLÈTE** (EXP-003..008 + gouvernance C1 #521/#534/#525). Exactitude PCMN obligatoire même en bêta.
@@ -18,16 +19,16 @@ Décisions produit verrouillées :
 
 ## Faits vérifiés (corrigent le chemin critique — ne pas re-dériver)
 
-| Hypothèse initiale | Réalité vérifiée (code) | Impact |
-|---|---|---|
-| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL. |
-| EXP-005 `charge_distribution` à faire | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`) | `Result→AppError` + BDD 4-cat seulement |
-| #453 TLS = bloquant go-live | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
-| #515 5 gaps ArgoCD bloquants | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s | Phase 2 |
-| Migration gouvernance large | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode |
-| EXP-007 `etat_date` mineur | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC) | WP-A5 = item le plus long de Track A |
-| #443 cascade énorme | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e_*.rs | Cascade réelle mais bornée |
-| JWT stockage | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage` | **Bloquant sécurité bêta fermée** confirmé |
+| Hypothèse initiale                                   | Réalité vérifiée (code)                                                                                                                                                                                                                          | Impact                                                                                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB                                                                   | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL.                                                  |
+| EXP-005 `charge_distribution` à faire                | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`)                                                                                                                                                                                          | `Result→AppError` + BDD 4-cat seulement                                                                                                       |
+| #453 TLS = bloquant go-live                          | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
+| #515 5 gaps ArgoCD bloquants                         | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s                                                                                                                                                                     | Phase 2                                                                                                                                       |
+| Migration gouvernance large                          | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data                                                                         | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode                                                                                     |
+| EXP-007 `etat_date` mineur                           | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC)                                                                                                                                                              | WP-A5 = item le plus long de Track A                                                                                                          |
+| #443 cascade énorme                                  | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e\_\*.rs                                                                                                                                                                                           | Cascade réelle mais bornée                                                                                                                    |
+| JWT stockage                                         | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage`                                                                                                                                         | **Bloquant sécurité bêta fermée** confirmé                                                                                                    |
 
 **Vrai long pole = WP-A2 (#443 cascade tests) → WP-A5 (EXP-007 etat_date)**, à paralléliser avec la chaîne Ops-VPS (latence Tier-1 humaine).
 
@@ -37,17 +38,17 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track A — Backend Decimal
 
-- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · *critique, premier*
+- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · _critique, premier_
   Appliquer `backend/migrations/20260516000000_alter_governance_to_numeric.sql` (DB test) ; `bdd_governance` 4 scénarios VERTS ; tuer le panic #525 ColumnDecode `units.quota`. Décisions bloquantes : (a) **ADR-0008 ratio** pour proxy validation `vote.rs:~312-342` (draft `docs/agent-activity/2026-05-16-adr8-noncompliance-body.md`) ; (b) **politique f64 d'affichage** — `resolution.rs:185-212` `pour/contre/abstention_percentage()` renvoient `f64` depuis comptes entiers : **reco = carve-out ADR-0008 explicite (affichage seul, jamais seuil légal)** + assertion que le chemin quorum/majorité légal n'a aucun aller-retour Decimal→f64→Decimal. Fichiers : la migration, `tests/bdd_governance.rs`, `features/governance_decimal.feature`, `entities/{vote,resolution,meeting,age_request}.rs`, repos impl correspondants. Deps : aucune.
 
-- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · *critique* · **FAIT** (#539 + reconfirmé 2026-05-18)
+- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · _critique_ · **FAIT** (#539 + reconfirmé 2026-05-18)
   `docker compose run --rm backend cargo check --tests` propre (`--lib` déjà propre). Literals f64→`dec!()` aux call-sites, assertions Decimal-equality, zéro régression scénario @security/@negative. Fichiers : `tests/bdd_financial.rs` (~23 occ.), `tests/e2e_*.rs`, glue `features/*.feature`. Deps : conventions WP-A1. **Concurrent Track F.**
   **Reconfirmé** (post-merge 5 PR + WP-B3 + #526) : `cargo check --tests` **CHECK_EXIT=0**, 0 erreur, aucune cascade f64/Decimal résiduelle (1 warning amont `proc-macro-error2`, non-bloquant). Suite BDD 100% verte (G1/G2/OPS/COM/FIN=0) ⇒ zéro régression @security/@negative confirmée. **Critère GO « `cargo check --tests` propre » atteint.**
 
 - **WP-A3 — EXP-006 journal_entry (réduit)** · #433 · T2 · M
   `Result<_,String>`→`AppError` sur `JournalEntry/JournalEntryLine`. `features/journal_entries.feature` 4-cat RED-first : @negative **débit≠crédit rejeté**, @edge 0.1+0.2=0.3, @security isolation cross-org, @happy écriture équilibrée. Pas de SQL. Deps : A1, A2.
 
-- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · *parallèle A3*
+- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · _parallèle A3_
   `Result→AppError` ; 4-cat : @security somme quotas==100% à `dec!(1.0001)`, @negative quota>1/négatif rejeté. Deps : A1.
 
 - **WP-A5 — EXP-007 quote/etat_date (Art. 577 CC, plus gros résidu)** · #433 · T2 · L
@@ -61,20 +62,21 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track B — Backend autre
 
-- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1*
+- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1\*
   Re-jouer `HUMAN_REVIEW_REPORT_v0.1.0.md` comme checklist vs `feature/dev` courant : **BUG-WF14-2 fuite bâtiments cross-org (Alice voit 3 bâtiments) = bloquant sécurité bêta si reproductible** — tracer scoping `organization_id` repo buildings ; BUG-WF2-1 `voting_power≤1000` vs seed>1280 (vérifier `20260401000000_fix_voting_power_constraint.sql`) ; BUG-WF7-1 ticket 400 ; NaN% compteurs (probablement corrigé par #523 `7c2d664` — vérifier). Repro RED par bug confirmé. Deps : aucune.
 
-- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · *parallèle* · **FAIT** (PR #538)
+- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · _parallèle_ · **FAIT** (PR #538)
   Réalité : #432 = 100% npm/frontend (le "14 vulns" était périmé). `svelte 5.55.7` + `devalue 5.8.1` → 5 alertes résolues, `npm audit --omit=dev` = 0, build vert. Résiduel 1 HIGH `@babel/plugin-transform-modules-systemjs` (devDependency build-only, `audit fix --force` breaking → accepté/documenté). `cargo audit` (RustSec) exit 0 modulo ignores `.cargo/audit.toml`. Fichiers : `frontend/package-lock.json`. Deps : aucune.
 
-- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · *débruite le gate* · **FAIT** (PR #541)
+- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · _débruite le gate_ · **FAIT** (PR #541)
   Le fix #524 a rendu le harness honnête → ~27 scénarios BDD pré-existants rouges sur 8 groupes (CI run `25982956110`) bruitent **toute** PR : « Meeting Resolutions » 14/14 (quorum Art. 3.87 §5 ordre workflow), Board CdC mandat ×5 (Art. 3.89 assertion vs règle), Energy/Notice/CallForFunds/Gamification ×6 (seeds/asserts), Stats ×2 (= #526). **Issue de tracking consolidée = #540** (inventaire complet + critères) ; un sous-fix RED-first 4-cat par groupe (P1 = Meeting Resolutions + Board mandat, légalement sensibles ; P2 = seeds/asserts ; Stats = #526 séparé). Aucun fix « comme ça » — comprendre la cause (test faux / prod faux / spec obsolète). Deps : aucune (parallèle). **Prérequis du jugement BDD propre en G1.**
-  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle *syndic* Art. 3.89 1–3 ans au *conseil de copropriété*, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
+  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle _syndic_ Art. 3.89 1–3 ans au _conseil de copropriété_, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
 
 ### Track C — Frontend sécurité (refacto #343 / SSR client:load DIFFÉRÉS post-bêta)
 
-- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · *critique*
+- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · _critique_ · **FAIT** (2026-05-19, branche `story/wbs-fe1-jwt-cookie`)
   `auth.ts:128-235` : refresh token → cookie backend `HttpOnly; Secure; SameSite=Strict` ; access token en mémoire seule + silent-refresh au load. Backend login/refresh : set-cookie + read-cookie + CORS credentials. 4-cat RED-first : @security token illisible JS/`document.cookie` & absent localStorage ; @negative cookie forgé/expiré→401 ; @happy login→refresh→protégé ; @edge refresh à la borne d'expiration. Deps : coordination WP-B1 ; moitié backend nourrit moitié FE.
+  **Réalisé** : `auth_cookie.rs` (cookie `HttpOnly; Secure(COOKIE_SECURE); SameSite=Strict; Path=/api/v1/auth; 7j`) + `auth_handlers` (corps sans `refresh_token` via `AuthBody`, DTO `LoginResponse` intact ; `refresh` cookie-only → 401 si absent ; rotation ; `POST /auth/logout` révoque+expire) ; CORS `.supports_credentials()` (R2 inexistant : `validate_cors_origins` rejette déjà `*`). Frontend : `accessToken.ts` mémoire seule, `auth.ts` réécrit (zéro token localStorage, silent-refresh cookie, logout serveur), `api.ts` Bearer mémoire, Login/Register `credentials:"include"`. `injectAuth` Playwright réécrit (cookie réel + silent-refresh, ripple ~specs absorbé — **lève dépendance WP-D1**) + `AuthCookie.spec.ts` 4-cat. openapi.json + api.d.ts régénérés (gate Contract). `COOKIE_SECURE=false` dev/E2E (`docker-compose.yml`/`.env.example`). Vérif : `cargo check --lib --tests` propre, `auth_cookie` 4/4, `astro check` 0 erreur, prettier propre (fallback hôte — daemon Docker absent). Log Tier-2 `docs/agent-activity/2026-05-19-wbs-fe1.md`. **Différé** : use-cases auth `Result<_,String>` (hexagonal-clean, hors scope) ; `SameSite=Strict` à re-décider si sous-domaines séparés Phase 2.
 
 - **WP-FE2 — Corriger bugs FE revue (WF1-1/2/3)** · T2 · M
   Bouton "Nouvelle réunion" `/meetings` (syndic) ; POST `/convocations` envoie `building_id` ; lister convocations créées via API. Re-vérifier vs courant. 4-cat Playwright (@happy créer+envoyer via UI, @negative building_id manquant → erreur visible pas 400 silencieux). Deps : WP-B1.
@@ -89,7 +91,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track E — Tests IaC (sous-ensemble VPS de #354)
 
-- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · *100% parallèle*
+- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · _100% parallèle_
   Job lint dans `ci-infra.yml`, assets VPS seulement : `terraform fmt -check`/`validate` (modules OVH + `monosite/vps/production/terraform`), `ansible-lint` (14 rôles + playbook prod), `yamllint`, `shellcheck` (**gate dur sur `gitops-deploy.sh`** — il exécute le déploiement prod). conftest/molecule/terratest = Phase 2. Deps : aucune.
 
 ### Track F — Ops VPS (concurrent Track A — aucun fichier partagé)
@@ -160,6 +162,7 @@ E1 (lint IaC) ─► F1 (TF/Ansible,T1) ─► F2 (TLS,T1) ─► F3 (poller,T1)
 ## Vérification — commandes exactes & gate humain
 
 Backend (agent) :
+
 ```
 docker compose run --rm backend cargo check --lib
 docker compose run --rm backend cargo check --tests        # propre post WP-A2
@@ -170,7 +173,9 @@ docker compose run --rm backend cargo test --no-fail-fast --test bdd --test bdd_
 docker compose run --rm backend cargo test --test e2e
 docker compose run --rm backend cargo audit                 # #432
 ```
+
 Frontend :
+
 ```
 docker compose run --rm frontend npm run build
 docker compose run --rm frontend npx svelte-check --threshold warning
@@ -179,13 +184,17 @@ docker compose run --rm frontend npx playwright test --project=chromium    # pla
 docker compose run --rm frontend npx playwright test --project=scenarios   # par-scénario
 docker compose run --rm frontend npx prettier --check .
 ```
+
 Gate push / contrat :
+
 ```
 make ci                # VERT obligatoire avant tout push
 make openapi-check     # si DTOs touchés
 make types-sync        # si spec changée
 ```
+
 IaC (post WP-E1) :
+
 ```
 terraform -chdir=infrastructure/monosite/vps/production/terraform fmt -check
 terraform -chdir=infrastructure/monosite/vps/production/terraform validate
@@ -193,7 +202,9 @@ ansible-lint infrastructure/monosite/vps/production/ansible/playbook.yml
 yamllint infrastructure/monosite/vps/production
 shellcheck infrastructure/_shared/scripts/gitops-deploy.sh
 ```
+
 Gate humain (Tier 1 — agent diagnostique/propose seulement) :
+
 1. `terraform apply` (agent fournit plan revu) — F1
 2. `ansible-playbook -i ansible/inventory.ini ansible/playbook.yml` prod — F1
 3. DNS A→IP VPS, ouvrir 80/443, `ACME_EMAIL` dans `.env` prod — F2

--- a/docs/agent-activity/2026-05-19-wbs-fe1.md
+++ b/docs/agent-activity/2026-05-19-wbs-fe1.md
@@ -94,3 +94,28 @@ Path=/api/v1/auth; Max-Age=7j` aligné `RefreshToken` domaine) +
   (était propre à l'autre checkout) — rien à supprimer ici.
 - Use-cases auth (`Result<_, String>` résiduel) non touchés (hors scope
   FE1, hexagonal-clean — pont inchangé).
+
+## Suivi CI — fix Playwright (échec #543 « Playwright E2E Tests »)
+
+Symptôme : seul le job `Playwright E2E Tests` rouge sur #543 (tous les
+autres verts, dont E2E backend/BDD). Logs CI non récupérables (pas
+d'outil/auth) → diagnostic par analyse du code.
+
+**Cause racine** (course rotation refresh ↔ double `init()`) : le step CI
+lance `--project=chromium` (exclut `smoke/` ⇒ pas `AuthCookie.spec.ts`,
+mais les ~30 specs via `loginAsSyndic*`→`injectAuth`). L'ancien
+`injectAuth` faisait `goto("/login")` (LoginForm `authStore.init()` ⇒
+silent-refresh #1 qui **rote** le cookie A→B) **puis** `goto(dashboard)`
+(RouteGuard `init()` ⇒ refresh #2). Si la nav quitte /login avant commit
+du Set-Cookie B, refresh #2 envoie A déjà révoqué par la rotation → 401 →
+redirection /login → échec en cascade. L'ancien injectAuth (token statique
+localStorage, pas de rotation) n'avait pas ce problème.
+
+**Fix (test-only, sécurité inchangée)** : `injectAuth` ne visite plus
+`/login` ; `koprogo_user` posé via `page.addInitScript` (avant tout script
+de page, sur chaque document) ; **une seule** navigation dashboard ⇒ un
+seul `authStore.init()` ⇒ un seul silent-refresh, plus de course de
+rotation. La rotation anti-rejeu (voulue, testée par
+`fe1_edge_old_refresh_cookie_revoked_after_rotation`) reste intacte.
+Vérif : `prettier --check` propre, `astro check` 0 erreur. Re-push #543
+(autorisé humain) → CI re-tourne.

--- a/docs/agent-activity/2026-05-19-wbs-fe1.md
+++ b/docs/agent-activity/2026-05-19-wbs-fe1.md
@@ -1,0 +1,96 @@
+# Agent activity — 2026-05-19 — WBS WP-FE1 (JWT hors localStorage)
+
+**Persona :** sécurité/full-stack agent (Tier 2 — implémente + 4-cat
+RED-first. Pas de mutation prod, pas de force-push, pas de `--no-verify`).
+
+**Branche :** `story/wbs-fe1-jwt-cookie` (depuis `origin/feature/dev`,
+**sans WP-A4** — séparation confirmée `git merge-base`). Branche dédiée
+**autorisée explicitement par l'humain** (PR #542/WP-A4 occupant la branche
+unique ; question posée via AskUserQuestion).
+
+**Scope :** WBS Track C, WP-FE1 — BLOQUANT SÉCURITÉ (vol session XSS).
+Décisions humaines verrouillées : (1) PR unique FE1 complet ; (2) même
+site, `SameSite=Strict; Secure` (pas d'attribut Domain) ; (3) retrait
+`refresh_token` du corps JSON (+ régen openapi/api.d.ts).
+
+## Réalisé
+
+### Backend (couche infra uniquement — use-cases purs inchangés)
+
+- `infrastructure/web/auth_cookie.rs` (nouveau) : `build_refresh_cookie`
+  (`HttpOnly; Secure(COOKIE_SECURE, défaut true); SameSite=Strict;
+Path=/api/v1/auth; Max-Age=7j` aligné `RefreshToken` domaine) +
+  `build_clearing_cookie` (Max-Age 0). 4 tests 4-cat in-module.
+- `auth_handlers.rs` : projection HTTP `AuthBody { token, user }` (DTO
+  interne `LoginResponse` **non modifié**) — `refresh_token` retiré du
+  corps de `login`/`register`/`switch-role`, posé en cookie. `refresh`
+  lit le refresh **exclusivement** depuis le cookie (plus de
+  `web::Json<RefreshTokenRequest>`) → 401 si absent ; rotation cookie.
+  Nouveau `POST /auth/logout` (AuthenticatedUser → `revoke_all_refresh_tokens`
+  - cookie expiré).
+- `routes.rs` : `logout` enregistré. `main.rs` : CORS
+  `.supports_credentials()` (origines explicites déjà imposées —
+  `validate_cors_origins` rejette `*`, donc R2 du diagnostic **inexistant**).
+- `tests/e2e_auth.rs` : 4-cat RED-first cookie (@happy set-cookie HttpOnly
+  - corps sans refresh ; @security refresh via cookie rote + corps sans
+    refresh ; @negative refresh sans/forgé cookie → 401 ; @edge ancien
+    cookie révoqué post-rotation = anti-rejeu).
+- `docs/api/openapi.json` régénéré (binaire hôte) : `RefreshTokenRequest`
+  request-body retiré de `/auth/refresh`, `/auth/logout` ajouté.
+
+### Frontend
+
+- `lib/accessToken.ts` (nouveau) : access token **mémoire seule**
+  (module dédié, zéro cycle d'import auth.ts↔api.ts). Jamais
+  localStorage/sessionStorage/cookie JS.
+- `stores/auth.ts` : suppression totale `koprogo_token`/`koprogo_refresh_token`
+  localStorage. `init()` = silent-refresh via cookie ; `login(user,token)`
+  (refresh arg supprimé) ; `refreshAccessToken()` sans arg
+  (`credentials:"include"`, corps sans refresh) ; `logout()` appelle
+  `/auth/logout` + `clearSession()` ; `validateSession()` retombe sur le
+  silent-refresh cookie ; interval périodique cookie-based.
+  `koprogo_user` conservé = cache d'affichage NON sensible (R4).
+- `lib/api.ts` : Bearer depuis `getAccessToken()` (mémoire) ; 401 →
+  `clearAccessToken()`.
+- `LoginForm`/`RegisterForm` : `credentials:"include"`, plus de
+  `refresh_token` du corps, `authStore.login(user, token)`.
+- `AdminDashboard.svelte` : log debug aligné (token mémoire).
+- `types/api.d.ts` régénéré (openapi-typescript) — `RefreshTokenRequest`
+  retiré, gate Contract Types Check cohérent.
+
+### Tests E2E / config
+
+- `tests/e2e/helpers/auth.ts` : `injectAuth` réécrit — plus d'injection
+  token localStorage ; le cookie HttpOnly réel (register/login via
+  `page.request`, cookie jar partagé) + silent-refresh à la nav font foi.
+  Chokepoint unique → ripple ~specs absorbé sans toucher chaque spec.
+- `tests/e2e/smoke/AuthCookie.spec.ts` (nouveau) : 4-cat (@security token
+  absent localStorage + cookie illisible JS ; @edge attributs cookie ;
+  @happy reload conserve session ; @negative sans cookie → /login).
+- `docker-compose.yml` + `.env.example` : `COOKIE_SECURE=false` dev/E2E
+  (http://localhost ; prod = true par défaut sûr).
+
+## Vérification (daemon Docker absent → fallback cargo/npm hôte, CRITICAL.md #12)
+
+- `cargo check --lib --tests` (SQLX_OFFLINE) : **propre, 0 erreur**.
+- `cargo test --lib auth_cookie` : **4/4 verts**.
+- `astro sync && astro check` : **0 erreur** (239 fichiers ; warnings =
+  unused-var pré-existants tests, hors FE1).
+- `openapi-typescript` régénéré sans divergence ; `prettier` propre sur
+  tous les fichiers touchés.
+- e2e backend cookie + Playwright AuthCookie : **exécutés en CI** (live
+  stack / testcontainers) — local = compile/type-check seulement (même
+  limite infra que WP-B1, tracée).
+
+## Notes / coordination
+
+- **WP-D1** (un-skip Playwright) : `injectAuth` livre déjà le nouveau flux
+  cookie attendu (dépendance levée).
+- `SameSite=Strict` validé pour topo prod « même site » (Traefik domaine
+  unique, API en `/api/v1`). Si bascule sous-domaines séparés (Phase 2) →
+  re-décision `Lax`+`COOKIE_DOMAIN` (tracé).
+- Fichier parasite signalé par le diagnostic
+  (`auth_dto.rs.tmp.153245.1763509305518`) : **absent** sur cette branche
+  (était propre à l'autre checkout) — rien à supprimer ici.
+- Use-cases auth (`Result<_, String>` résiduel) non touchés (hors scope
+  FE1, hexagonal-clean — pont inchangé).

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -256,26 +256,14 @@
           "Auth"
         ],
         "summary": "Refresh Token",
+        "description": "Le refresh token est lu depuis le cookie HttpOnly `koprogo_refresh` (WP-FE1) — aucun corps de requête. La réponse rote le cookie et ne contient pas de refresh_token.",
         "operationId": "refresh_token",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RefreshTokenRequest"
-              }
-            }
-          },
-          "required": true
-        },
         "responses": {
-          "201": {
-            "description": "Resource created successfully"
+          "200": {
+            "description": "Access token rafraîchi"
           },
-          "400": {
-            "description": "Bad Request"
-          },
-          "404": {
-            "description": "Not Found"
+          "401": {
+            "description": "Cookie refresh absent, expiré ou révoqué"
           },
           "500": {
             "description": "Internal Server Error"
@@ -4671,17 +4659,6 @@
           "Weekly",
           "Monthly"
         ]
-      },
-      "RefreshTokenRequest": {
-        "type": "object",
-        "required": [
-          "refresh_token"
-        ],
-        "properties": {
-          "refresh_token": {
-            "type": "string"
-          }
-        }
       },
       "RefundPaymentRequest": {
         "type": "object",

--- a/frontend/src/components/LoginForm.svelte
+++ b/frontend/src/components/LoginForm.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   // Svelte 5 runes mode
-  import { _, isLoading } from '../lib/i18n';
-  import { authStore, mapUserFromBackend } from '../stores/auth';
-  import { UserRole } from '../lib/types';
-  import type { User } from '../lib/types';
-  import { apiEndpoint } from '../lib/config';
+  import { _, isLoading } from "../lib/i18n";
+  import { authStore, mapUserFromBackend } from "../stores/auth";
+  import { UserRole } from "../lib/types";
+  import type { User } from "../lib/types";
+  import { apiEndpoint } from "../lib/config";
 
-  let email = $state('');
-  let password = $state('');
-  let error = $state('');
+  let email = $state("");
+  let password = $state("");
+  let error = $state("");
   let loading = $state(false);
 
   $effect(() => {
@@ -18,53 +18,60 @@
 
   const handleLogin = async (e: Event) => {
     e.preventDefault();
-    error = '';
+    error = "";
     loading = true;
 
     try {
       // Real API call
-      const response = await fetch(apiEndpoint('/auth/login'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch(apiEndpoint("/auth/login"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // WP-FE1 : credentials inclus pour que le Set-Cookie refresh
+        // HttpOnly soit stocké par le navigateur.
+        credentials: "include",
         body: JSON.stringify({ email, password }),
       });
 
       if (response.ok) {
         const data = await response.json();
-        const { token, refresh_token, user } = data;
+        // WP-FE1 : plus de refresh_token dans le corps — il est dans le
+        // cookie HttpOnly. Seul l'access token (mémoire) transite ici.
+        const { token, user } = data;
 
         // Map backend user format to frontend format
         const mappedUser: User = mapUserFromBackend(user);
 
-        // Login with token, refresh token and initialize sync
-        await authStore.login(mappedUser, token, refresh_token);
+        // Access token en mémoire ; refresh = cookie posé par le backend
+        await authStore.login(mappedUser, token);
 
         // Redirect based on role
         const redirectMap: Record<string, string> = {
-          [UserRole.SUPERADMIN]: '/admin',
-          [UserRole.SYNDIC]: '/syndic',
-          [UserRole.ACCOUNTANT]: '/accountant',
-          [UserRole.OWNER]: '/owner',
+          [UserRole.SUPERADMIN]: "/admin",
+          [UserRole.SYNDIC]: "/syndic",
+          [UserRole.ACCOUNTANT]: "/accountant",
+          [UserRole.OWNER]: "/owner",
         };
 
         // Check for ?redirect= query param (set by RouteGuard)
         const urlParams = new URLSearchParams(window.location.search);
-        const redirectTo = urlParams.get('redirect');
-        const targetUrl = redirectTo || redirectMap[mappedUser.role] || '/';
+        const redirectTo = urlParams.get("redirect");
+        const targetUrl = redirectTo || redirectMap[mappedUser.role] || "/";
 
         // Petit délai pour laisser localStorage se propager avant navigation
         setTimeout(() => {
           window.location.href = targetUrl;
         }, 100);
       } else if (response.status === 429) {
-        error = $_('auth.tooManyAttempts') || 'Trop de tentatives de connexion. Réessayez dans 15 minutes.';
+        error =
+          $_("auth.tooManyAttempts") ||
+          "Trop de tentatives de connexion. Réessayez dans 15 minutes.";
       } else {
         const errorData = await response.json().catch(() => ({}));
-        error = errorData.error || $_('auth.loginError');
+        error = errorData.error || $_("auth.loginError");
       }
     } catch (e) {
-      console.error('Login error:', e);
-      error = $_('auth.connectionError');
+      console.error("Login error:", e);
+      error = $_("auth.connectionError");
     } finally {
       loading = false;
     }
@@ -73,77 +80,82 @@
 
 {#if $isLoading}
   <div class="flex justify-center py-8">
-    <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+    <div
+      class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"
+    ></div>
   </div>
 {:else}
-<form onsubmit={handleLogin} class="space-y-6" data-testid="login-form">
-  {#if error}
-    <div
-      class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg"
-      role="alert"
-      data-testid="login-error"
-    >
-      {error}
-    </div>
-  {/if}
+  <form onsubmit={handleLogin} class="space-y-6" data-testid="login-form">
+    {#if error}
+      <div
+        class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg"
+        role="alert"
+        data-testid="login-error"
+      >
+        {error}
+      </div>
+    {/if}
 
-  <div>
-    <label for="email" class="block text-sm font-medium text-gray-700 mb-2">
-      {$_('auth.email')}
-    </label>
-    <input
-      id="email"
-      type="email"
-      bind:value={email}
-      required
-      class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-      placeholder={$_('auth.emailPlaceholder')}
-      autocomplete="email"
-      data-testid="login-email"
-    />
-  </div>
-
-  <div>
-    <label for="password" class="block text-sm font-medium text-gray-700 mb-2">
-      {$_('auth.password')}
-    </label>
-    <input
-      id="password"
-      type="password"
-      bind:value={password}
-      required
-      class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
-      placeholder="••••••••"
-      autocomplete="current-password"
-      data-testid="login-password"
-    />
-  </div>
-
-  <div class="flex items-center justify-between">
-    <label class="flex items-center">
+    <div>
+      <label for="email" class="block text-sm font-medium text-gray-700 mb-2">
+        {$_("auth.email")}
+      </label>
       <input
-        type="checkbox"
-        class="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
-        data-testid="login-remember"
+        id="email"
+        type="email"
+        bind:value={email}
+        required
+        class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        placeholder={$_("auth.emailPlaceholder")}
+        autocomplete="email"
+        data-testid="login-email"
       />
-      <span class="ml-2 text-sm text-gray-600">{$_('auth.rememberMe')}</span>
-    </label>
-    <a
-      href="/forgot-password"
-      class="text-sm text-primary-600 hover:text-primary-700"
-      data-testid="login-forgot-password"
-    >
-      {$_('auth.forgotPassword')}
-    </a>
-  </div>
+    </div>
 
-  <button
-    type="submit"
-    disabled={loading}
-    class="w-full bg-primary-600 text-white py-3 rounded-lg hover:bg-primary-700 transition font-medium disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-    data-testid="login-submit"
-  >
-    {loading ? $_('auth.loggingIn') : $_('auth.login')}
-  </button>
-</form>
+    <div>
+      <label
+        for="password"
+        class="block text-sm font-medium text-gray-700 mb-2"
+      >
+        {$_("auth.password")}
+      </label>
+      <input
+        id="password"
+        type="password"
+        bind:value={password}
+        required
+        class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        placeholder="••••••••"
+        autocomplete="current-password"
+        data-testid="login-password"
+      />
+    </div>
+
+    <div class="flex items-center justify-between">
+      <label class="flex items-center">
+        <input
+          type="checkbox"
+          class="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+          data-testid="login-remember"
+        />
+        <span class="ml-2 text-sm text-gray-600">{$_("auth.rememberMe")}</span>
+      </label>
+      <a
+        href="/forgot-password"
+        class="text-sm text-primary-600 hover:text-primary-700"
+        data-testid="login-forgot-password"
+      >
+        {$_("auth.forgotPassword")}
+      </a>
+    </div>
+
+    <button
+      type="submit"
+      disabled={loading}
+      class="w-full bg-primary-600 text-white py-3 rounded-lg hover:bg-primary-700 transition font-medium disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+      data-testid="login-submit"
+    >
+      {loading ? $_("auth.loggingIn") : $_("auth.login")}
+    </button>
+  </form>
 {/if}

--- a/frontend/src/components/RegisterForm.svelte
+++ b/frontend/src/components/RegisterForm.svelte
@@ -1,40 +1,40 @@
 <script lang="ts">
-  import { authStore, mapUserFromBackend } from '../stores/auth';
-  import { toast } from '../stores/toast';
-  import { UserRole } from '../lib/types';
-  import type { User } from '../lib/types';
-  import { apiEndpoint } from '../lib/config';
-  import FormInput from './ui/FormInput.svelte';
-  import FormSelect from './ui/FormSelect.svelte';
-  import Button from './ui/Button.svelte';
-  import { _ } from '../lib/i18n';
+  import { authStore, mapUserFromBackend } from "../stores/auth";
+  import { toast } from "../stores/toast";
+  import { UserRole } from "../lib/types";
+  import type { User } from "../lib/types";
+  import { apiEndpoint } from "../lib/config";
+  import FormInput from "./ui/FormInput.svelte";
+  import FormSelect from "./ui/FormSelect.svelte";
+  import Button from "./ui/Button.svelte";
+  import { _ } from "../lib/i18n";
   import { withErrorHandling } from "../lib/utils/error.utils";
 
   let formData = {
-    email: '',
-    password: '',
-    confirmPassword: '',
-    first_name: '',
-    last_name: '',
+    email: "",
+    password: "",
+    confirmPassword: "",
+    first_name: "",
+    last_name: "",
     role: UserRole.OWNER,
-    organizationId: '',
+    organizationId: "",
   };
 
   let errors = {
-    email: '',
-    password: '',
-    confirmPassword: '',
-    first_name: '',
-    last_name: '',
+    email: "",
+    password: "",
+    confirmPassword: "",
+    first_name: "",
+    last_name: "",
   };
 
   let loading = false;
   let showOrgField = false;
 
   $: roleOptions = [
-    { value: UserRole.OWNER, label: $_('auth.roles.owner') },
-    { value: UserRole.SYNDIC, label: $_('auth.roles.syndic') },
-    { value: UserRole.ACCOUNTANT, label: $_('auth.roles.accountant') },
+    { value: UserRole.OWNER, label: $_("auth.roles.owner") },
+    { value: UserRole.SYNDIC, label: $_("auth.roles.syndic") },
+    { value: UserRole.ACCOUNTANT, label: $_("auth.roles.accountant") },
   ];
 
   $: showOrgField = formData.role !== UserRole.OWNER;
@@ -42,50 +42,50 @@
   const validateForm = (): boolean => {
     let isValid = true;
     errors = {
-      email: '',
-      password: '',
-      confirmPassword: '',
-      first_name: '',
-      last_name: '',
+      email: "",
+      password: "",
+      confirmPassword: "",
+      first_name: "",
+      last_name: "",
     };
 
     // Email validation
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!formData.email) {
-      errors.email = $_('validation.emailRequired');
+      errors.email = $_("validation.emailRequired");
       isValid = false;
     } else if (!emailRegex.test(formData.email)) {
-      errors.email = $_('validation.emailInvalid');
+      errors.email = $_("validation.emailInvalid");
       isValid = false;
     }
 
     // Password validation
     if (!formData.password) {
-      errors.password = $_('validation.passwordRequired');
+      errors.password = $_("validation.passwordRequired");
       isValid = false;
     } else if (formData.password.length < 6) {
-      errors.password = $_('validation.passwordMinLength');
+      errors.password = $_("validation.passwordMinLength");
       isValid = false;
     }
 
     // Confirm password validation
     if (!formData.confirmPassword) {
-      errors.confirmPassword = $_('validation.confirmPasswordRequired');
+      errors.confirmPassword = $_("validation.confirmPasswordRequired");
       isValid = false;
     } else if (formData.password !== formData.confirmPassword) {
-      errors.confirmPassword = $_('validation.passwordMismatch');
+      errors.confirmPassword = $_("validation.passwordMismatch");
       isValid = false;
     }
 
     // First name validation
     if (!formData.first_name || formData.first_name.trim().length < 2) {
-      errors.first_name = $_('validation.firstNameMinLength');
+      errors.first_name = $_("validation.firstNameMinLength");
       isValid = false;
     }
 
     // Last name validation
     if (!formData.last_name || formData.last_name.trim().length < 2) {
-      errors.last_name = $_('validation.lastNameMinLength');
+      errors.last_name = $_("validation.lastNameMinLength");
       isValid = false;
     }
 
@@ -115,52 +115,52 @@
         requestBody.organization_id = formData.organizationId;
       }
 
-      const response = await fetch(apiEndpoint('/auth/register'), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const response = await fetch(apiEndpoint("/auth/register"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // WP-FE1 : credentials inclus pour stocker le cookie refresh HttpOnly.
+        credentials: "include",
         body: JSON.stringify(requestBody),
       });
 
       if (response.ok) {
         const data = await response.json();
-        const { token, refresh_token, user } = data;
+        // WP-FE1 : refresh_token retiré du corps (cookie HttpOnly).
+        const { token, user } = data;
 
         // Map backend user format to frontend format
         const mappedUser: User = mapUserFromBackend(user);
 
-        // Login with token, refresh token and initialize sync
-        await authStore.login(mappedUser, token, refresh_token);
+        // Access token en mémoire ; refresh = cookie posé par le backend
+        await authStore.login(mappedUser, token);
 
-        toast.show($_('auth.registerSuccess'), 'success');
+        toast.show($_("auth.registerSuccess"), "success");
 
         // Redirect based on role
         const redirectMap = {
-          [UserRole.SUPERADMIN]: '/admin',
-          [UserRole.SYNDIC]: '/syndic',
-          [UserRole.ACCOUNTANT]: '/accountant',
-          [UserRole.OWNER]: '/owner',
+          [UserRole.SUPERADMIN]: "/admin",
+          [UserRole.SYNDIC]: "/syndic",
+          [UserRole.ACCOUNTANT]: "/accountant",
+          [UserRole.OWNER]: "/owner",
         };
 
         setTimeout(() => {
-          window.location.href = redirectMap[mappedUser.role] || '/';
+          window.location.href = redirectMap[mappedUser.role] || "/";
         }, 1000);
       } else {
         const errorData = await response.json();
-        const errorMessage = errorData.error || $_('auth.registerError');
+        const errorMessage = errorData.error || $_("auth.registerError");
 
         // Check for specific validation errors
-        if (errorMessage.includes('email')) {
-          errors.email = $_('auth.emailAlreadyUsed');
+        if (errorMessage.includes("email")) {
+          errors.email = $_("auth.emailAlreadyUsed");
         } else {
-          toast.show(errorMessage, 'error');
+          toast.show(errorMessage, "error");
         }
       }
     } catch (e) {
-      console.error('Registration error:', e);
-      toast.show(
-        $_('auth.registerConnectionError'),
-        'error'
-      );
+      console.error("Registration error:", e);
+      toast.show($_("auth.registerConnectionError"), "error");
     } finally {
       loading = false;
     }
@@ -171,7 +171,7 @@
   <div class="grid grid-cols-2 gap-4">
     <FormInput
       id="first_name"
-      label={$_('auth.firstName')}
+      label={$_("auth.firstName")}
       type="text"
       bind:value={formData.first_name}
       error={errors.first_name}
@@ -182,7 +182,7 @@
 
     <FormInput
       id="last_name"
-      label={$_('auth.lastName')}
+      label={$_("auth.lastName")}
       type="text"
       bind:value={formData.last_name}
       error={errors.last_name}
@@ -194,7 +194,7 @@
 
   <FormInput
     id="email"
-    label={$_('auth.email')}
+    label={$_("auth.email")}
     type="email"
     bind:value={formData.email}
     error={errors.email}
@@ -206,20 +206,20 @@
 
   <FormInput
     id="password"
-    label={$_('auth.password')}
+    label={$_("auth.password")}
     type="password"
     bind:value={formData.password}
     error={errors.password}
     required
     placeholder="••••••••"
-    hint={$_('auth.passwordHint')}
+    hint={$_("auth.passwordHint")}
     autocomplete="new-password"
     data-testid="register-password"
   />
 
   <FormInput
     id="confirmPassword"
-    label={$_('auth.confirmPassword')}
+    label={$_("auth.confirmPassword")}
     type="password"
     bind:value={formData.confirmPassword}
     error={errors.confirmPassword}
@@ -231,7 +231,7 @@
 
   <FormSelect
     id="role"
-    label={$_('auth.accountType')}
+    label={$_("auth.accountType")}
     bind:value={formData.role}
     options={roleOptions}
     required
@@ -241,10 +241,10 @@
   {#if showOrgField}
     <FormInput
       id="organizationId"
-      label={$_('auth.organizationId')}
+      label={$_("auth.organizationId")}
       type="text"
       bind:value={formData.organizationId}
-      hint={$_('auth.organizationHint')}
+      hint={$_("auth.organizationHint")}
       placeholder="550e8400-e29b-41d4-a716-446655440000"
       data-testid="register-org-id"
     />
@@ -258,10 +258,10 @@
     size="lg"
     data-testid="register-submit"
   >
-    {loading ? $_('auth.creatingAccount') : $_('auth.createAccount')}
+    {loading ? $_("auth.creatingAccount") : $_("auth.createAccount")}
   </Button>
 
   <p class="text-xs text-gray-500 text-center mt-4">
-    {$_('auth.termsNotice')}
+    {$_("auth.termsNotice")}
   </p>
 </form>

--- a/frontend/src/components/dashboards/AdminDashboard.svelte
+++ b/frontend/src/components/dashboards/AdminDashboard.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   // Svelte 5 runes mode
-  import { _ } from '../../lib/i18n';
-  import { authStore } from '../../stores/auth';
-  import { apiEndpoint } from '../../lib/config';
-  import { api } from '../../lib/api';
+  import { _ } from "../../lib/i18n";
+  import { authStore } from "../../stores/auth";
+  import { apiEndpoint } from "../../lib/config";
+  import { api } from "../../lib/api";
   import { withErrorHandling } from "../../lib/utils/error.utils";
 
   interface Stats {
@@ -28,11 +28,11 @@
     totalMeetings: 0,
   });
   let loading = $state(true);
-  let statsError = $state('');
+  let statsError = $state("");
   let seedLoading = $state(false);
   let clearLoading = $state(false);
-  let seedMessage = $state('');
-  let seedError = $state('');
+  let seedMessage = $state("");
+  let seedError = $state("");
 
   let user = $derived($authStore.user);
 
@@ -42,18 +42,19 @@
 
   async function loadStats() {
     loading = true;
-    statsError = '';
+    statsError = "";
     const data = await withErrorHandling({
-      action: () => api.get<{
-        total_organizations: number;
-        total_users: number;
-        total_buildings: number;
-        active_subscriptions: number;
-        total_owners: number;
-        total_units: number;
-        total_expenses: number;
-        total_meetings: number;
-      }>('/stats/dashboard'),
+      action: () =>
+        api.get<{
+          total_organizations: number;
+          total_users: number;
+          total_buildings: number;
+          active_subscriptions: number;
+          total_owners: number;
+          total_units: number;
+          total_expenses: number;
+          total_meetings: number;
+        }>("/stats/dashboard"),
     });
     if (data) {
       stats = {
@@ -67,88 +68,93 @@
         totalMeetings: data.total_meetings,
       };
     } else {
-      statsError = $_('common.error.loadStats');
+      statsError = $_("common.error.loadStats");
     }
     loading = false;
   }
 
   const handleSeedDemoData = async () => {
     seedLoading = true;
-    seedMessage = '';
-    seedError = '';
+    seedMessage = "";
+    seedError = "";
 
     // DEBUG: Log token state
-    console.log('=== DEBUG: Seed Demo Data ===');
-    console.log('Auth Store State:', $authStore);
-    console.log('Token:', $authStore.token);
-    console.log('Is Authenticated:', $authStore.isAuthenticated);
-    if (typeof window !== 'undefined') {
-      console.log('LocalStorage Token:', localStorage.getItem('koprogo_token'));
-      console.log('LocalStorage User:', localStorage.getItem('koprogo_user'));
+    console.log("=== DEBUG: Seed Demo Data ===");
+    console.log("Auth Store State:", $authStore);
+    console.log("Token:", $authStore.token);
+    console.log("Is Authenticated:", $authStore.isAuthenticated);
+    if (typeof window !== "undefined") {
+      // WP-FE1 : access token en mémoire (jamais localStorage) ;
+      // refresh = cookie HttpOnly (illisible par JS).
+      console.log("In-memory access token present:", $authStore.token !== null);
+      console.log("LocalStorage User:", localStorage.getItem("koprogo_user"));
     }
-    console.log('API Endpoint:', apiEndpoint('/seed/demo'));
-    console.log('============================');
+    console.log("API Endpoint:", apiEndpoint("/seed/demo"));
+    console.log("============================");
 
     try {
-      const response = await fetch(apiEndpoint('/seed/demo'), {
-        method: 'POST',
+      const response = await fetch(apiEndpoint("/seed/demo"), {
+        method: "POST",
         headers: {
-          'Authorization': `Bearer ${$authStore.token}`,
+          Authorization: `Bearer ${$authStore.token}`,
         },
       });
 
       const data = await response.json();
 
       if (response.ok) {
-        seedMessage = data.message || $_('dashboards.admin.seed.successMessage');
+        seedMessage =
+          data.message || $_("dashboards.admin.seed.successMessage");
         // Reload stats after seeding
         await loadStats();
-        setTimeout(() => seedMessage = '', 5000);
+        setTimeout(() => (seedMessage = ""), 5000);
       } else {
-        seedError = data.error || $_('dashboards.admin.seed.errorMessage');
-        setTimeout(() => seedError = '', 5000);
+        seedError = data.error || $_("dashboards.admin.seed.errorMessage");
+        setTimeout(() => (seedError = ""), 5000);
       }
     } catch (error) {
-      console.error('Seed error:', error);
-      seedError = $_('common.error.serverConnection');
-      setTimeout(() => seedError = '', 5000);
+      console.error("Seed error:", error);
+      seedError = $_("common.error.serverConnection");
+      setTimeout(() => (seedError = ""), 5000);
     } finally {
       seedLoading = false;
     }
   };
 
   const handleClearDemoData = async () => {
-    if (!confirm($_('dashboards.admin.seed.confirmDelete'))) {
+    if (!confirm($_("dashboards.admin.seed.confirmDelete"))) {
       return;
     }
 
     clearLoading = true;
-    seedMessage = '';
-    seedError = '';
+    seedMessage = "";
+    seedError = "";
 
     try {
-      const response = await fetch(apiEndpoint('/seed/clear'), {
-        method: 'POST',
+      const response = await fetch(apiEndpoint("/seed/clear"), {
+        method: "POST",
         headers: {
-          'Authorization': `Bearer ${$authStore.token}`,
+          Authorization: `Bearer ${$authStore.token}`,
         },
       });
 
       const data = await response.json();
 
       if (response.ok) {
-        seedMessage = data.message || $_('dashboards.admin.seed.deleteSuccessMessage');
+        seedMessage =
+          data.message || $_("dashboards.admin.seed.deleteSuccessMessage");
         // Reload stats after clearing
         await loadStats();
-        setTimeout(() => seedMessage = '', 5000);
+        setTimeout(() => (seedMessage = ""), 5000);
       } else {
-        seedError = data.error || $_('dashboards.admin.seed.deleteErrorMessage');
-        setTimeout(() => seedError = '', 5000);
+        seedError =
+          data.error || $_("dashboards.admin.seed.deleteErrorMessage");
+        setTimeout(() => (seedError = ""), 5000);
       }
     } catch (error) {
-      console.error('Clear error:', error);
-      seedError = $_('common.error.serverConnection');
-      setTimeout(() => seedError = '', 5000);
+      console.error("Clear error:", error);
+      seedError = $_("common.error.serverConnection");
+      setTimeout(() => (seedError = ""), 5000);
     } finally {
       clearLoading = false;
     }
@@ -159,16 +165,18 @@
   <!-- Header -->
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-gray-900 mb-2">
-      {$_('common.welcome')}, {user?.first_name} 👋
+      {$_("common.welcome")}, {user?.first_name} 👋
     </h1>
     <p class="text-gray-600">
-      {$_('dashboards.admin.title')} - {$_('dashboards.admin.subtitle')}
+      {$_("dashboards.admin.title")} - {$_("dashboards.admin.subtitle")}
     </p>
   </div>
 
   <!-- Stats Cards -->
   {#if statsError}
-    <div class="mb-6 p-4 bg-red-50 border border-red-200 text-red-700 rounded-lg">
+    <div
+      class="mb-6 p-4 bg-red-50 border border-red-200 text-red-700 rounded-lg"
+    >
       ⚠️ {statsError}
     </div>
   {/if}
@@ -176,105 +184,145 @@
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.organizations')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.organizations")}</span
+        >
         <span class="text-2xl">🏛️</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
-        <p class="text-3xl font-bold text-gray-900">{stats.totalOrganizations}</p>
-        <p class="text-sm text-gray-500 mt-1">{stats.activeSubscriptions} {$_('dashboards.admin.stats.active')}</p>
+        <p class="text-3xl font-bold text-gray-900">
+          {stats.totalOrganizations}
+        </p>
+        <p class="text-sm text-gray-500 mt-1">
+          {stats.activeSubscriptions}
+          {$_("dashboards.admin.stats.active")}
+        </p>
       {/if}
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.users')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.users")}</span
+        >
         <span class="text-2xl">👥</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
         <p class="text-3xl font-bold text-gray-900">{stats.totalUsers}</p>
-        <p class="text-sm text-gray-500 mt-1">{$_('dashboards.admin.stats.allOrganizations')}</p>
+        <p class="text-sm text-gray-500 mt-1">
+          {$_("dashboards.admin.stats.allOrganizations")}
+        </p>
       {/if}
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.buildings')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.buildings")}</span
+        >
         <span class="text-2xl">🏢</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
         <p class="text-3xl font-bold text-gray-900">{stats.totalBuildings}</p>
-        <p class="text-sm text-gray-500 mt-1">{stats.totalUnits} {$_('dashboards.admin.stats.units')}</p>
+        <p class="text-sm text-gray-500 mt-1">
+          {stats.totalUnits}
+          {$_("dashboards.admin.stats.units")}
+        </p>
       {/if}
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.owners')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.owners")}</span
+        >
         <span class="text-2xl">👨‍👩‍👧</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
         <p class="text-3xl font-bold text-gray-900">{stats.totalOwners}</p>
-        <p class="text-sm text-gray-500 mt-1">{$_('dashboards.admin.stats.database')}</p>
+        <p class="text-sm text-gray-500 mt-1">
+          {$_("dashboards.admin.stats.database")}
+        </p>
       {/if}
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.lots')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.lots")}</span
+        >
         <span class="text-2xl">🏠</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
         <p class="text-3xl font-bold text-gray-900">{stats.totalUnits}</p>
-        <p class="text-sm text-gray-500 mt-1">{$_('dashboards.admin.stats.allBuildings')}</p>
+        <p class="text-sm text-gray-500 mt-1">
+          {$_("dashboards.admin.stats.allBuildings")}
+        </p>
       {/if}
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.expenses')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.expenses")}</span
+        >
         <span class="text-2xl">💶</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
         <p class="text-3xl font-bold text-gray-900">{stats.totalExpenses}</p>
-        <p class="text-sm text-gray-500 mt-1">{$_('dashboards.admin.stats.totalRecorded')}</p>
+        <p class="text-sm text-gray-500 mt-1">
+          {$_("dashboards.admin.stats.totalRecorded")}
+        </p>
       {/if}
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.meetings')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.meetings")}</span
+        >
         <span class="text-2xl">📅</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
         <p class="text-3xl font-bold text-gray-900">{stats.totalMeetings}</p>
-        <p class="text-sm text-gray-500 mt-1">{$_('dashboards.admin.stats.plannedMeetings')}</p>
+        <p class="text-sm text-gray-500 mt-1">
+          {$_("dashboards.admin.stats.plannedMeetings")}
+        </p>
       {/if}
     </div>
 
     <div class="bg-white rounded-lg shadow p-6">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-gray-600 text-sm font-medium">{$_('dashboards.admin.stats.subscriptions')}</span>
+        <span class="text-gray-600 text-sm font-medium"
+          >{$_("dashboards.admin.stats.subscriptions")}</span
+        >
         <span class="text-2xl">✅</span>
       </div>
       {#if loading}
         <div class="h-8 bg-gray-200 animate-pulse rounded"></div>
       {:else}
-        <p class="text-3xl font-bold text-gray-900">{stats.activeSubscriptions}</p>
-        <p class="text-sm text-gray-500 mt-1">{$_('dashboards.admin.stats.outOf')} {stats.totalOrganizations} {$_('dashboards.admin.stats.orgs')}</p>
+        <p class="text-3xl font-bold text-gray-900">
+          {stats.activeSubscriptions}
+        </p>
+        <p class="text-sm text-gray-500 mt-1">
+          {$_("dashboards.admin.stats.outOf")}
+          {stats.totalOrganizations}
+          {$_("dashboards.admin.stats.orgs")}
+        </p>
       {/if}
     </div>
   </div>
@@ -284,26 +332,34 @@
     <div class="p-6 border-b border-gray-200">
       <div class="flex justify-between items-start">
         <div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('dashboards.admin.seed.title')}</h2>
-          <p class="text-sm text-gray-600 mt-1">{$_('dashboards.admin.seed.subtitle')}</p>
+          <h2 class="text-lg font-semibold text-gray-900">
+            {$_("dashboards.admin.seed.title")}
+          </h2>
+          <p class="text-sm text-gray-600 mt-1">
+            {$_("dashboards.admin.seed.subtitle")}
+          </p>
         </div>
         <a
           href="/admin/seed"
           class="inline-flex items-center gap-2 px-4 py-2 bg-blue-50 text-blue-700 rounded-lg hover:bg-blue-100 transition text-sm font-medium"
         >
           <span>⚙️</span>
-          {$_('dashboards.admin.seed.advancedManagement')}
+          {$_("dashboards.admin.seed.advancedManagement")}
         </a>
       </div>
     </div>
     <div class="p-6">
       {#if seedMessage}
-        <div class="mb-4 p-4 bg-green-50 border border-green-200 text-green-700 rounded-lg">
+        <div
+          class="mb-4 p-4 bg-green-50 border border-green-200 text-green-700 rounded-lg"
+        >
           ✓ {seedMessage}
         </div>
       {/if}
       {#if seedError}
-        <div class="mb-4 p-4 bg-red-50 border border-red-200 text-red-700 rounded-lg">
+        <div
+          class="mb-4 p-4 bg-red-50 border border-red-200 text-red-700 rounded-lg"
+        >
           ✗ {seedError}
         </div>
       {/if}
@@ -311,8 +367,12 @@
       <!-- Info Banner -->
       <div class="mb-6 p-4 bg-blue-50 border-l-4 border-blue-500 rounded">
         <p class="text-sm text-blue-900">
-          <strong>ℹ️ {$_('dashboards.admin.seed.infoBanner')}</strong> {$_('dashboards.admin.seed.infoDetails')}
-          <code class="bg-blue-100 px-1 rounded font-mono text-xs">is_seed_data=true</code> {$_('dashboards.admin.seed.infoProtection')}
+          <strong>ℹ️ {$_("dashboards.admin.seed.infoBanner")}</strong>
+          {$_("dashboards.admin.seed.infoDetails")}
+          <code class="bg-blue-100 px-1 rounded font-mono text-xs"
+            >is_seed_data=true</code
+          >
+          {$_("dashboards.admin.seed.infoProtection")}
         </p>
       </div>
 
@@ -322,22 +382,26 @@
           <div class="flex items-center gap-3 mb-4">
             <span class="text-4xl">🌱</span>
             <div>
-              <h3 class="font-semibold text-lg text-green-900">{$_('dashboards.admin.seed.generateTitle')}</h3>
-              <p class="text-xs text-green-700">{$_('dashboards.admin.seed.generateSubtitle')}</p>
+              <h3 class="font-semibold text-lg text-green-900">
+                {$_("dashboards.admin.seed.generateTitle")}
+              </h3>
+              <p class="text-xs text-green-700">
+                {$_("dashboards.admin.seed.generateSubtitle")}
+              </p>
             </div>
           </div>
           <ul class="text-sm text-gray-700 mb-4 space-y-2">
             <li class="flex items-start gap-2">
               <span class="text-green-600 font-bold">✓</span>
-              <span>{$_('dashboards.admin.seed.list1')}</span>
+              <span>{$_("dashboards.admin.seed.list1")}</span>
             </li>
             <li class="flex items-start gap-2">
               <span class="text-green-600 font-bold">✓</span>
-              <span>{$_('dashboards.admin.seed.list2')}</span>
+              <span>{$_("dashboards.admin.seed.list2")}</span>
             </li>
             <li class="flex items-start gap-2">
               <span class="text-green-600 font-bold">✓</span>
-              <span>{$_('dashboards.admin.seed.list3')}</span>
+              <span>{$_("dashboards.admin.seed.list3")}</span>
             </li>
           </ul>
           <button
@@ -345,7 +409,9 @@
             disabled={seedLoading || clearLoading}
             class="w-full bg-green-600 text-white py-3 rounded-lg hover:bg-green-700 transition font-semibold disabled:opacity-50 disabled:cursor-not-allowed shadow-md"
           >
-            {seedLoading ? '⏳ ' + $_('dashboards.admin.seed.generating') : '🚀 ' + $_('dashboards.admin.seed.generateButton')}
+            {seedLoading
+              ? "⏳ " + $_("dashboards.admin.seed.generating")
+              : "🚀 " + $_("dashboards.admin.seed.generateButton")}
           </button>
         </div>
 
@@ -354,22 +420,34 @@
           <div class="flex items-center gap-3 mb-4">
             <span class="text-4xl">🗑️</span>
             <div>
-              <h3 class="font-semibold text-lg text-red-900">{$_('dashboards.admin.seed.deleteTitle')}</h3>
-              <p class="text-xs text-red-700">{$_('dashboards.admin.seed.deleteSubtitle')}</p>
+              <h3 class="font-semibold text-lg text-red-900">
+                {$_("dashboards.admin.seed.deleteTitle")}
+              </h3>
+              <p class="text-xs text-red-700">
+                {$_("dashboards.admin.seed.deleteSubtitle")}
+              </p>
             </div>
           </div>
           <ul class="text-sm text-gray-700 mb-4 space-y-2">
             <li class="flex items-start gap-2">
               <span class="text-blue-600 font-bold">🛡️</span>
-              <span><strong>{$_('dashboards.admin.seed.preserveLabel')}</strong> {$_('dashboards.admin.seed.preserveProduction')}</span>
+              <span
+                ><strong>{$_("dashboards.admin.seed.preserveLabel")}</strong>
+                {$_("dashboards.admin.seed.preserveProduction")}</span
+              >
             </li>
             <li class="flex items-start gap-2">
               <span class="text-red-600 font-bold">🗑️</span>
-              <span>{$_('dashboards.admin.seed.deleteOnly')} <code class="bg-red-100 px-1 rounded text-xs">is_seed_data=true</code></span>
+              <span
+                >{$_("dashboards.admin.seed.deleteOnly")}
+                <code class="bg-red-100 px-1 rounded text-xs"
+                  >is_seed_data=true</code
+                ></span
+              >
             </li>
             <li class="flex items-start gap-2">
               <span class="text-blue-600 font-bold">🔒</span>
-              <span>{$_('dashboards.admin.seed.superAdminPreserved')}</span>
+              <span>{$_("dashboards.admin.seed.superAdminPreserved")}</span>
             </li>
           </ul>
           <button
@@ -377,7 +455,9 @@
             disabled={seedLoading || clearLoading}
             class="w-full bg-red-600 text-white py-3 rounded-lg hover:bg-red-700 transition font-semibold disabled:opacity-50 disabled:cursor-not-allowed shadow-md"
           >
-            {clearLoading ? '⏳ ' + $_('dashboards.admin.seed.deleting') : '🗑️ ' + $_('dashboards.admin.seed.deleteButton')}
+            {clearLoading
+              ? "⏳ " + $_("dashboards.admin.seed.deleting")
+              : "🗑️ " + $_("dashboards.admin.seed.deleteButton")}
           </button>
         </div>
       </div>
@@ -385,9 +465,14 @@
       <!-- Link to advanced management -->
       <div class="mt-6 p-4 bg-gray-50 border border-gray-200 rounded-lg">
         <p class="text-sm text-gray-600">
-          💡 <strong>{$_('dashboards.admin.seed.needDetails')}</strong> {$_('dashboards.admin.seed.consultPage')}
-          <a href="/admin/seed" class="text-blue-600 hover:text-blue-800 underline font-medium">{$_('dashboards.admin.seed.advancedPageLink')}</a>
-          {$_('dashboards.admin.seed.toSeeDetails')}
+          💡 <strong>{$_("dashboards.admin.seed.needDetails")}</strong>
+          {$_("dashboards.admin.seed.consultPage")}
+          <a
+            href="/admin/seed"
+            class="text-blue-600 hover:text-blue-800 underline font-medium"
+            >{$_("dashboards.admin.seed.advancedPageLink")}</a
+          >
+          {$_("dashboards.admin.seed.toSeeDetails")}
         </p>
       </div>
     </div>
@@ -398,32 +483,50 @@
     <!-- Recent Activity -->
     <div class="bg-white rounded-lg shadow">
       <div class="p-6 border-b border-gray-200">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('dashboards.admin.recentActivity')}</h2>
+        <h2 class="text-lg font-semibold text-gray-900">
+          {$_("dashboards.admin.recentActivity")}
+        </h2>
       </div>
       <div class="p-6">
         <div class="space-y-4">
           <div class="flex items-start space-x-3">
             <span class="text-2xl">🏛️</span>
             <div class="flex-1">
-              <p class="text-sm font-medium text-gray-900">{$_('dashboards.admin.activity.newOrganization')}</p>
-              <p class="text-sm text-gray-600">Copropriété Les Jardins - Paris 15e</p>
-              <p class="text-xs text-gray-400 mt-1">{$_('dashboards.admin.activity.twoHoursAgo')}</p>
+              <p class="text-sm font-medium text-gray-900">
+                {$_("dashboards.admin.activity.newOrganization")}
+              </p>
+              <p class="text-sm text-gray-600">
+                Copropriété Les Jardins - Paris 15e
+              </p>
+              <p class="text-xs text-gray-400 mt-1">
+                {$_("dashboards.admin.activity.twoHoursAgo")}
+              </p>
             </div>
           </div>
           <div class="flex items-start space-x-3">
             <span class="text-2xl">👤</span>
             <div class="flex-1">
-              <p class="text-sm font-medium text-gray-900">{$_('dashboards.admin.activity.newUser')}</p>
-              <p class="text-sm text-gray-600">jean.dupont@example.com (Syndic)</p>
-              <p class="text-xs text-gray-400 mt-1">{$_('dashboards.admin.activity.fiveHoursAgo')}</p>
+              <p class="text-sm font-medium text-gray-900">
+                {$_("dashboards.admin.activity.newUser")}
+              </p>
+              <p class="text-sm text-gray-600">
+                jean.dupont@example.com (Syndic)
+              </p>
+              <p class="text-xs text-gray-400 mt-1">
+                {$_("dashboards.admin.activity.fiveHoursAgo")}
+              </p>
             </div>
           </div>
           <div class="flex items-start space-x-3">
             <span class="text-2xl">🏢</span>
             <div class="flex-1">
-              <p class="text-sm font-medium text-gray-900">{$_('dashboards.admin.activity.buildingAdded')}</p>
+              <p class="text-sm font-medium text-gray-900">
+                {$_("dashboards.admin.activity.buildingAdded")}
+              </p>
               <p class="text-sm text-gray-600">Résidence Le Parc - Lyon 3e</p>
-              <p class="text-xs text-gray-400 mt-1">{$_('dashboards.admin.activity.yesterday')}</p>
+              <p class="text-xs text-gray-400 mt-1">
+                {$_("dashboards.admin.activity.yesterday")}
+              </p>
             </div>
           </div>
         </div>
@@ -433,7 +536,9 @@
     <!-- Quick Links -->
     <div class="bg-white rounded-lg shadow">
       <div class="p-6 border-b border-gray-200">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('dashboards.admin.quickActions')}</h2>
+        <h2 class="text-lg font-semibold text-gray-900">
+          {$_("dashboards.admin.quickActions")}
+        </h2>
       </div>
       <div class="p-6">
         <div class="grid grid-cols-2 gap-4">
@@ -441,43 +546,67 @@
             href="/admin/organizations"
             class="flex flex-col items-center justify-center p-6 border-2 border-gray-200 rounded-lg hover:border-primary-500 hover:bg-primary-50 transition group"
           >
-            <span class="text-4xl mb-2 group-hover:scale-110 transition">🏛️</span>
-            <span class="text-sm font-medium text-gray-700">{$_('navigation.organizations')}</span>
+            <span class="text-4xl mb-2 group-hover:scale-110 transition"
+              >🏛️</span
+            >
+            <span class="text-sm font-medium text-gray-700"
+              >{$_("navigation.organizations")}</span
+            >
           </a>
           <a
             href="/admin/users"
             class="flex flex-col items-center justify-center p-6 border-2 border-gray-200 rounded-lg hover:border-primary-500 hover:bg-primary-50 transition group"
           >
-            <span class="text-4xl mb-2 group-hover:scale-110 transition">👥</span>
-            <span class="text-sm font-medium text-gray-700">{$_('navigation.users')}</span>
+            <span class="text-4xl mb-2 group-hover:scale-110 transition"
+              >👥</span
+            >
+            <span class="text-sm font-medium text-gray-700"
+              >{$_("navigation.users")}</span
+            >
           </a>
           <a
             href="/buildings"
             class="flex flex-col items-center justify-center p-6 border-2 border-gray-200 rounded-lg hover:border-primary-500 hover:bg-primary-50 transition group"
           >
-            <span class="text-4xl mb-2 group-hover:scale-110 transition">🏢</span>
-            <span class="text-sm font-medium text-gray-700">{$_('navigation.buildings')}</span>
+            <span class="text-4xl mb-2 group-hover:scale-110 transition"
+              >🏢</span
+            >
+            <span class="text-sm font-medium text-gray-700"
+              >{$_("navigation.buildings")}</span
+            >
           </a>
           <a
             href="/admin/subscriptions"
             class="flex flex-col items-center justify-center p-6 border-2 border-gray-200 rounded-lg hover:border-primary-500 hover:bg-primary-50 transition group"
           >
-            <span class="text-4xl mb-2 group-hover:scale-110 transition">💳</span>
-            <span class="text-sm font-medium text-gray-700">{$_('navigation.subscriptions')}</span>
+            <span class="text-4xl mb-2 group-hover:scale-110 transition"
+              >💳</span
+            >
+            <span class="text-sm font-medium text-gray-700"
+              >{$_("navigation.subscriptions")}</span
+            >
           </a>
           <a
             href="/admin/seed"
             class="flex flex-col items-center justify-center p-6 border-2 border-green-200 rounded-lg hover:border-green-500 hover:bg-green-50 transition group"
           >
-            <span class="text-4xl mb-2 group-hover:scale-110 transition">🌱</span>
-            <span class="text-sm font-medium text-gray-700">{$_('navigation.seedData')}</span>
+            <span class="text-4xl mb-2 group-hover:scale-110 transition"
+              >🌱</span
+            >
+            <span class="text-sm font-medium text-gray-700"
+              >{$_("navigation.seedData")}</span
+            >
           </a>
           <a
             href="/admin/user-owner-links"
             class="flex flex-col items-center justify-center p-6 border-2 border-blue-200 rounded-lg hover:border-blue-500 hover:bg-blue-50 transition group"
           >
-            <span class="text-4xl mb-2 group-hover:scale-110 transition">🔗</span>
-            <span class="text-sm font-medium text-gray-700">{$_('navigation.userOwnerLinks')}</span>
+            <span class="text-4xl mb-2 group-hover:scale-110 transition"
+              >🔗</span
+            >
+            <span class="text-sm font-medium text-gray-700"
+              >{$_("navigation.userOwnerLinks")}</span
+            >
           </a>
         </div>
       </div>

--- a/frontend/src/lib/accessToken.ts
+++ b/frontend/src/lib/accessToken.ts
@@ -1,0 +1,25 @@
+/**
+ * In-memory access token holder (WP-FE1 — JWT hors localStorage).
+ *
+ * L'access token (JWT court, 15 min) vit UNIQUEMENT en mémoire JS : jamais
+ * `localStorage`/`sessionStorage`/cookie lisible. Un vol XSS ne peut donc
+ * pas exfiltrer une session rejouable longue durée. Le refresh token, lui,
+ * est dans un cookie `HttpOnly` posé par le backend (illisible par JS).
+ *
+ * Module dédié pour éviter tout cycle d'import entre `stores/auth.ts`
+ * (écrit le token) et `lib/api.ts` (le lit pour le header Bearer).
+ */
+
+let accessToken: string | null = null;
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export function setAccessToken(token: string | null): void {
+  accessToken = token;
+}
+
+export function clearAccessToken(): void {
+  accessToken = null;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { get } from "svelte/store";
 import { locale } from "svelte-i18n";
 import { toast } from "../stores/toast";
+import { getAccessToken, clearAccessToken } from "./accessToken";
 import type { Document, DocumentUploadPayload } from "./types";
 
 /**
@@ -32,10 +33,8 @@ function buildHeaders(
 
   headers.set("Accept-Language", getCurrentLanguage());
 
-  const token =
-    typeof window !== "undefined"
-      ? localStorage.getItem("koprogo_token")
-      : null;
+  // WP-FE1 : access token en mémoire (jamais localStorage).
+  const token = getAccessToken();
 
   if (token) {
     headers.set("Authorization", `Bearer ${token}`);
@@ -120,8 +119,8 @@ export async function apiFetch<T = any>(
     } else if (response.status === 401) {
       // Clear stale token and dedupe toast across parallel 401s
       if (typeof window !== "undefined") {
-        const hadToken = localStorage.getItem("koprogo_token");
-        localStorage.removeItem("koprogo_token");
+        const hadToken = getAccessToken() !== null;
+        clearAccessToken();
         if (hadToken && !(window as any).__koprogo_session_expired_shown__) {
           (window as any).__koprogo_session_expired_shown__ = true;
           toast.warning("Session expirée. Veuillez vous reconnecter.");

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -4,14 +4,21 @@ import { UserRole } from "../lib/types";
 import { syncService } from "../lib/sync";
 import { localDB } from "../lib/db";
 import { apiEndpoint } from "../lib/config";
+import {
+  getAccessToken,
+  setAccessToken,
+  clearAccessToken,
+} from "../lib/accessToken";
 
 // Auth store
 interface AuthState {
   user: User | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  // Access token reflété ici pour la réactivité UI. Source de vérité =
+  // mémoire (`lib/accessToken`). JAMAIS persisté (WP-FE1). Le refresh
+  // token n'est plus côté JS : cookie HttpOnly géré par le backend.
   token: string | null;
-  refreshToken: string | null;
 }
 
 // Refresh token 5 minutes before expiry (access token expires in 15 minutes)
@@ -132,29 +139,22 @@ const createAuthStore = () => {
     isAuthenticated: false,
     isLoading: true,
     token: null,
-    refreshToken: null,
   };
 
+  // WP-FE1 : aucun token en localStorage. `koprogo_user` est un cache
+  // d'affichage NON sensible (peinture instantanée), jamais une preuve
+  // d'authentification : `init()` fait un silent-refresh via le cookie
+  // HttpOnly pour obtenir un access token frais et confirmer la session.
   if (typeof window !== "undefined") {
     const storedUser = localStorage.getItem("koprogo_user");
-    const storedToken = localStorage.getItem("koprogo_token");
-    const storedRefreshToken = localStorage.getItem("koprogo_refresh_token");
-
-    if (storedUser && storedToken && storedRefreshToken) {
+    if (storedUser) {
       try {
-        const user = ensureUserShape(JSON.parse(storedUser));
-        initialState = {
-          user,
-          isAuthenticated: true,
-          isLoading: true, // still loading until init() completes async ops
-          token: storedToken,
-          refreshToken: storedRefreshToken,
-        };
+        initialState.user = ensureUserShape(JSON.parse(storedUser));
+        // isAuthenticated reste false tant que le silent-refresh n'a pas
+        // (re)produit un access token : pas de session sans token.
       } catch {
-        // Invalid stored data, keep defaults
+        // Invalid cached user, ignore
       }
-    } else {
-      initialState.isLoading = false;
     }
   }
 
@@ -166,9 +166,10 @@ const createAuthStore = () => {
     }
 
     refreshTimer = window.setInterval(async () => {
-      const refreshToken = localStorage.getItem("koprogo_refresh_token");
-      if (refreshToken) {
-        await authStore.refreshAccessToken(refreshToken);
+      // Silent-refresh périodique via le cookie HttpOnly (aucun token JS).
+      const ok = await authStore.refreshAccessToken();
+      if (!ok && typeof window !== "undefined") {
+        window.location.href = "/login";
       }
     }, TOKEN_REFRESH_INTERVAL);
   };
@@ -183,67 +184,44 @@ const createAuthStore = () => {
   const authStore = {
     subscribe,
 
-    // Initialize async operations (localDB, sync, token refresh).
-    // User data is already pre-populated from localStorage at store creation.
+    // Initialize: silent-refresh via le cookie HttpOnly pour (re)produire
+    // un access token en mémoire après un reload (aucun token persisté).
     init: async () => {
-      if (typeof window !== "undefined") {
-        const storedToken = localStorage.getItem("koprogo_token");
-        const storedRefreshToken = localStorage.getItem(
-          "koprogo_refresh_token",
-        );
+      if (typeof window === "undefined") {
+        return;
+      }
 
-        if (initialState.user && storedToken && storedRefreshToken) {
-          try {
-            // Initialize local database
-            await localDB.init();
-
-            // Initialize sync service with token
-            await syncService.initialize(storedToken);
-
-            // Mark loading complete
-            update((state) => ({ ...state, isLoading: false }));
-
-            // Start auto-refresh
-            startTokenRefresh();
-          } catch (error) {
-            console.error("Failed to initialize auth:", error);
-            set({
-              user: null,
-              isAuthenticated: false,
-              isLoading: false,
-              token: null,
-              refreshToken: null,
-            });
+      const refreshed = await authStore.refreshAccessToken();
+      if (refreshed) {
+        try {
+          await localDB.init();
+          const token = getAccessToken();
+          if (token) {
+            await syncService.initialize(token);
           }
-        } else {
-          set({
-            user: null,
-            isAuthenticated: false,
-            isLoading: false,
-            token: null,
-            refreshToken: null,
-          });
+          startTokenRefresh();
+          update((state) => ({ ...state, isLoading: false }));
+        } catch (error) {
+          console.error("Failed to initialize auth:", error);
+          await authStore.clearSession();
         }
+      } else {
+        // Pas de cookie valide → session absente (pas une erreur).
+        await authStore.clearSession();
       }
     },
 
-    // Login
-    login: async (user: User, token: string, refreshToken: string) => {
+    // Login: access token en mémoire ; le refresh token est déjà posé
+    // par le backend dans un cookie HttpOnly (réponse de /auth/login).
+    login: async (user: User, token: string) => {
+      setAccessToken(token);
+
       if (typeof window !== "undefined") {
+        // Cache d'affichage non sensible uniquement (pas de credential).
         localStorage.setItem("koprogo_user", JSON.stringify(user));
-        localStorage.setItem("koprogo_token", token);
-        localStorage.setItem("koprogo_refresh_token", refreshToken);
-
-        // Initialize local database
         await localDB.init();
-
-        // Save user to local DB
         await localDB.saveUser(user);
-
-        // Initialize sync service
         await syncService.initialize(token);
-
-        // Start auto-refresh
         startTokenRefresh();
       }
 
@@ -252,30 +230,42 @@ const createAuthStore = () => {
         isAuthenticated: true,
         isLoading: false,
         token,
-        refreshToken,
       });
     },
 
-    // Logout
-    logout: async () => {
+    // Clear session côté client (mémoire + cache user + sync + state).
+    // N'appelle PAS le backend (utilisé quand le cookie est déjà invalide).
+    clearSession: async () => {
       stopTokenRefresh();
-
+      clearAccessToken();
       if (typeof window !== "undefined") {
         localStorage.removeItem("koprogo_user");
-        localStorage.removeItem("koprogo_token");
-        localStorage.removeItem("koprogo_refresh_token");
-
-        // Clear local data
         await syncService.clearLocalData();
       }
-
       set({
         user: null,
         isAuthenticated: false,
         isLoading: false,
         token: null,
-        refreshToken: null,
       });
+    },
+
+    // Logout: révocation serveur (expire le cookie + invalide les refresh)
+    // puis nettoyage client. Best-effort sur le réseau.
+    logout: async () => {
+      const token = getAccessToken();
+      if (typeof window !== "undefined" && token) {
+        try {
+          await fetch(apiEndpoint("/auth/logout"), {
+            method: "POST",
+            credentials: "include",
+            headers: { Authorization: `Bearer ${token}` },
+          });
+        } catch {
+          // best-effort : on nettoie le client quoi qu'il arrive
+        }
+      }
+      await authStore.clearSession();
     },
 
     // Update user
@@ -288,70 +278,52 @@ const createAuthStore = () => {
     },
 
     // Get token
-    getToken: () => {
-      if (typeof window !== "undefined") {
-        return localStorage.getItem("koprogo_token");
-      }
-      return null;
-    },
+    // Access token courant (mémoire seule, WP-FE1).
+    getToken: () => getAccessToken(),
 
-    // Refresh access token
-    refreshAccessToken: async (refreshToken: string): Promise<boolean> => {
+    // Silent-refresh : POST /auth/refresh sans corps ; le refresh token
+    // est lu côté serveur dans le cookie HttpOnly (credentials:"include").
+    // Aucun token n'est jamais lu/écrit en localStorage.
+    refreshAccessToken: async (): Promise<boolean> => {
       try {
         const response = await fetch(apiEndpoint("/auth/refresh"), {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ refresh_token: refreshToken }),
+          credentials: "include",
         });
 
         if (response.ok) {
           const data = await response.json();
-          const {
-            token: newToken,
-            refresh_token: newRefreshToken,
-            user: userPayload,
-          } = data;
+          // WP-FE1 : la réponse ne contient PLUS de refresh_token (cookie
+          // roté côté backend). Seul l'access token revient au JS.
+          const { token: newToken, user: userPayload } = data;
 
-          // Update stored tokens
-          if (typeof window !== "undefined") {
-            localStorage.setItem("koprogo_token", newToken);
-            localStorage.setItem("koprogo_refresh_token", newRefreshToken);
+          setAccessToken(newToken);
 
-            // Update sync service token
-            await syncService.setToken(newToken);
-          }
-
-          // Map backend user format to frontend format
           const mappedUser: User = mapBackendUser(userPayload);
 
           if (typeof window !== "undefined") {
             localStorage.setItem("koprogo_user", JSON.stringify(mappedUser));
+            await syncService.setToken(newToken);
+            await localDB.saveUser(mappedUser);
           }
-          await localDB.saveUser(mappedUser);
 
           update((state) => ({
             ...state,
             token: newToken,
-            refreshToken: newRefreshToken,
             user: mappedUser,
+            isAuthenticated: true,
           }));
 
           return true;
-        } else {
-          // Token refresh failed, logout user
-          console.error("Token refresh failed");
-          await authStore.logout();
-          if (typeof window !== "undefined") {
-            window.location.href = "/login";
-          }
-          return false;
         }
+
+        // Cookie absent/expiré/révoqué → session client nettoyée.
+        // (Pas d'appel backend logout : le cookie est déjà invalide.)
+        await authStore.clearSession();
+        return false;
       } catch (error) {
         console.error("Token refresh error:", error);
-        await authStore.logout();
-        if (typeof window !== "undefined") {
-          window.location.href = "/login";
-        }
+        await authStore.clearSession();
         return false;
       }
     },
@@ -371,6 +343,8 @@ const createAuthStore = () => {
       try {
         const response = await fetch(apiEndpoint("/auth/switch-role"), {
           method: "POST",
+          // credentials:"include" → le cookie refresh roté est stocké.
+          credentials: "include",
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
@@ -385,17 +359,14 @@ const createAuthStore = () => {
         }
 
         const data = await response.json();
-        const {
-          token: newToken,
-          refresh_token: newRefreshToken,
-          user: userPayload,
-        } = data;
+        // WP-FE1 : pas de refresh_token dans le corps (cookie HttpOnly).
+        const { token: newToken, user: userPayload } = data;
+
+        setAccessToken(newToken);
 
         const mappedUser: User = mapBackendUser(userPayload);
 
         if (typeof window !== "undefined") {
-          localStorage.setItem("koprogo_token", newToken);
-          localStorage.setItem("koprogo_refresh_token", newRefreshToken);
           localStorage.setItem("koprogo_user", JSON.stringify(mappedUser));
         }
 
@@ -407,7 +378,6 @@ const createAuthStore = () => {
         update((state) => ({
           ...state,
           token: newToken,
-          refreshToken: newRefreshToken,
           user: mappedUser,
         }));
 
@@ -420,9 +390,18 @@ const createAuthStore = () => {
 
     // Validate current session
     validateSession: async (): Promise<boolean> => {
-      const token = authStore.getToken();
+      let token = authStore.getToken();
       if (!token) {
-        return false;
+        // Pas d'access token en mémoire (reload) : tenter le silent-refresh
+        // via le cookie HttpOnly avant de conclure à l'absence de session.
+        const refreshed = await authStore.refreshAccessToken();
+        if (!refreshed) {
+          return false;
+        }
+        token = authStore.getToken();
+        if (!token) {
+          return false;
+        }
       }
 
       try {
@@ -464,15 +443,13 @@ const createAuthStore = () => {
         }
 
         if (response.status === 401) {
-          const refreshToken = localStorage.getItem("koprogo_refresh_token");
-          if (refreshToken) {
-            const refreshed = await authStore.refreshAccessToken(refreshToken);
-            if (refreshed) {
-              return true;
-            }
+          // Access token expiré : tenter un silent-refresh via le cookie.
+          const refreshed = await authStore.refreshAccessToken();
+          if (refreshed) {
+            return true;
           }
 
-          await authStore.logout();
+          await authStore.clearSession();
           return false;
         }
 

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -247,7 +247,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Refresh Token */
+    /**
+     * Refresh Token
+     * @description Le refresh token est lu depuis le cookie HttpOnly `koprogo_refresh` (WP-FE1) — aucun corps de requête. La réponse rote le cookie et ne contient pas de refresh_token.
+     */
     post: operations["refresh_token"];
     delete?: never;
     options?: never;
@@ -2085,9 +2088,6 @@ export interface components {
      * @enum {string}
      */
     RecurringPattern: "None" | "Daily" | "Weekly" | "Monthly";
-    RefreshTokenRequest: {
-      refresh_token: string;
-    };
     /** @description Refund payment request DTO */
     RefundPaymentRequest: {
       /** Format: int64 */
@@ -2538,28 +2538,17 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["RefreshTokenRequest"];
-      };
-    };
+    requestBody?: never;
     responses: {
-      /** @description Resource created successfully */
-      201: {
+      /** @description Access token rafraîchi */
+      200: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
       };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Not Found */
-      404: {
+      /** @description Cookie refresh absent, expiré ou révoqué */
+      401: {
         headers: {
           [name: string]: unknown;
         };

--- a/frontend/tests/e2e/helpers/auth.ts
+++ b/frontend/tests/e2e/helpers/auth.ts
@@ -55,6 +55,13 @@ interface OwnerContext extends SyndicContext {
  * `koprogo_user` reste injecté : cache d'AFFICHAGE non sensible (peinture
  * instantanée), jamais une preuve d'authentification.
  *
+ * **Anti-course de rotation** : on ne visite PAS `/login` au préalable
+ * (LoginForm déclenche son propre `authStore.init()` ⇒ refresh #1 qui
+ * **rote** le cookie ; une 2ᵉ nav vers le dashboard ⇒ refresh #2 avec le
+ * cookie déjà révoqué → 401 → /login). `koprogo_user` est posé via
+ * `addInitScript` (avant tout script de page) et une **unique** navigation
+ * dashboard déclenche **un seul** silent-refresh (RouteGuard).
+ *
  * Pré-requis env (E2E sur http://localhost) : `COOKIE_SECURE=false`
  * (sinon le navigateur refuse le cookie sur une origine non https).
  */
@@ -63,36 +70,36 @@ async function injectAuth(
   _token: string,
   user: { email: string; first_name: string; last_name: string; role: string },
 ) {
-  // Origine établie pour localStorage (cache d'affichage seulement).
-  await page.goto("/login", { waitUntil: "domcontentloaded" });
+  const roleObj = {
+    id: "injected-role-1",
+    role: user.role,
+    organization_id: null,
+    is_primary: true,
+  };
+  const cachedUser = JSON.stringify({
+    id: "injected-user",
+    email: user.email,
+    first_name: user.first_name,
+    last_name: user.last_name,
+    role: user.role,
+    roles: [roleObj],
+    active_role: roleObj,
+  });
 
-  await page.evaluate(
-    ({ user }) => {
-      const roleObj = {
-        id: "injected-role-1",
-        role: user.role,
-        organization_id: null,
-        is_primary: true,
-      };
-      localStorage.setItem(
-        "koprogo_user",
-        JSON.stringify({
-          id: "injected-user",
-          email: user.email,
-          first_name: user.first_name,
-          last_name: user.last_name,
-          role: user.role,
-          roles: [roleObj],
-          active_role: roleObj,
-        }),
-      );
-    },
-    { user },
-  );
+  // Posé AVANT tout script de page, sur chaque document du contexte —
+  // évite la pré-visite de /login (et son refresh prématuré).
+  await page.addInitScript((value) => {
+    try {
+      localStorage.setItem("koprogo_user", value);
+    } catch {
+      /* localStorage indisponible avant origine — ignoré */
+    }
+  }, cachedUser);
 
-  // Navigation dashboard → authStore.init() silent-refresh via le cookie
-  // HttpOnly (déjà dans le contexte). networkidle laisse le refresh
-  // résoudre l'access token en mémoire avant les assertions du test.
+  // UNE seule navigation dashboard → RouteGuard `authStore.init()` →
+  // un seul silent-refresh via le cookie HttpOnly (déjà dans le contexte
+  // via le register/login réel de l'appelant). networkidle laisse le
+  // refresh résoudre l'access token en mémoire avant les assertions.
   const dashboardPath =
     user.role === "owner"
       ? "/owner"

--- a/frontend/tests/e2e/helpers/auth.ts
+++ b/frontend/tests/e2e/helpers/auth.ts
@@ -43,20 +43,31 @@ interface OwnerContext extends SyndicContext {
 }
 
 /**
- * Inject auth token into browser localStorage without UI login.
- * Navigates to a page first (needed for localStorage domain), then injects.
+ * Establish an authenticated browser session WITHOUT UI login (WP-FE1).
+ *
+ * Plus de token en localStorage : l'access token vit en mémoire, le
+ * refresh token est un cookie `HttpOnly` posé par le backend lors du
+ * `register`/`login` réel effectué par l'appelant via `page.request`
+ * (le cookie jar est partagé avec le contexte navigateur). En naviguant
+ * vers le dashboard, `authStore.init()` fait un silent-refresh via ce
+ * cookie et obtient un access token frais — exactement le flux prod.
+ *
+ * `koprogo_user` reste injecté : cache d'AFFICHAGE non sensible (peinture
+ * instantanée), jamais une preuve d'authentification.
+ *
+ * Pré-requis env (E2E sur http://localhost) : `COOKIE_SECURE=false`
+ * (sinon le navigateur refuse le cookie sur une origine non https).
  */
 async function injectAuth(
   page: Page,
-  token: string,
+  _token: string,
   user: { email: string; first_name: string; last_name: string; role: string },
 ) {
-  // Navigate to base URL to set localStorage on the right domain
+  // Origine établie pour localStorage (cache d'affichage seulement).
   await page.goto("/login", { waitUntil: "domcontentloaded" });
 
   await page.evaluate(
-    ({ token, user }) => {
-      localStorage.setItem("koprogo_token", token);
+    ({ user }) => {
       const roleObj = {
         id: "injected-role-1",
         role: user.role,
@@ -75,19 +86,20 @@ async function injectAuth(
           active_role: roleObj,
         }),
       );
-      localStorage.setItem("koprogo_refresh_token", token);
     },
-    { token, user },
+    { user },
   );
 
-  // Navigate to syndic dashboard to complete "login"
+  // Navigation dashboard → authStore.init() silent-refresh via le cookie
+  // HttpOnly (déjà dans le contexte). networkidle laisse le refresh
+  // résoudre l'access token en mémoire avant les assertions du test.
   const dashboardPath =
     user.role === "owner"
       ? "/owner"
       : user.role === "superadmin"
         ? "/admin"
         : "/syndic";
-  await page.goto(dashboardPath, { waitUntil: "domcontentloaded" });
+  await page.goto(dashboardPath, { waitUntil: "networkidle" });
 }
 
 /**

--- a/frontend/tests/e2e/smoke/AuthCookie.spec.ts
+++ b/frontend/tests/e2e/smoke/AuthCookie.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * WP-FE1 — JWT hors localStorage (vol de session XSS).
+ *
+ * Vérifie de bout en bout que :
+ *  - l'access token n'est JAMAIS en localStorage (mémoire seule) ;
+ *  - le refresh token est un cookie HttpOnly (illisible par `document.cookie`),
+ *    scopé `/api/v1/auth` ;
+ *  - le silent-refresh via ce cookie restaure la session après reload ;
+ *  - sans cookie valide, pas de session (redirection /login).
+ *
+ * Taxonomie 4 catégories (CRITICAL.md #3). Stack live http://localhost
+ * (Traefik) ; `COOKIE_SECURE=false` en dev/E2E (cf. docker-compose.yml).
+ */
+
+const ADMIN_EMAIL = "admin@koprogo.com";
+const ADMIN_PASSWORD = "admin123";
+
+async function uiLogin(page: import("@playwright/test").Page) {
+  await page.goto("/login", { waitUntil: "domcontentloaded" });
+  await page.fill('input[type="email"]', ADMIN_EMAIL);
+  await page.fill('input[type="password"]', ADMIN_PASSWORD);
+  await page.click('button[type="submit"]');
+  // LoginForm redirige hors /login après authStore.login()
+  await page.waitForURL((url) => !url.pathname.startsWith("/login"), {
+    timeout: 15000,
+  });
+}
+
+test.describe("WP-FE1 — refresh token cookie HttpOnly", () => {
+  test("@security access token absent de localStorage, refresh illisible JS", async ({
+    page,
+  }) => {
+    await uiLogin(page);
+
+    const lsToken = await page.evaluate(() =>
+      localStorage.getItem("koprogo_token"),
+    );
+    const lsRefresh = await page.evaluate(() =>
+      localStorage.getItem("koprogo_refresh_token"),
+    );
+    expect(lsToken, "access token MUST NOT be in localStorage").toBeNull();
+    expect(lsRefresh, "refresh token MUST NOT be in localStorage").toBeNull();
+
+    // Le cookie refresh est HttpOnly → invisible depuis document.cookie.
+    const jsCookies = await page.evaluate(() => document.cookie);
+    expect(jsCookies).not.toContain("koprogo_refresh");
+  });
+
+  test("@edge cookie refresh HttpOnly + scopé /api/v1/auth dans le contexte", async ({
+    page,
+  }) => {
+    await uiLogin(page);
+
+    const cookies = await page.context().cookies();
+    const refresh = cookies.find((c) => c.name === "koprogo_refresh");
+    expect(refresh, "refresh cookie must be set").toBeTruthy();
+    expect(refresh!.httpOnly, "refresh cookie must be HttpOnly").toBe(true);
+    expect(refresh!.sameSite).toBe("Strict");
+    expect(refresh!.path).toBe("/api/v1/auth");
+    expect(refresh!.value.length).toBeGreaterThan(0);
+  });
+
+  test("@happy reload conserve la session via silent-refresh cookie", async ({
+    page,
+  }) => {
+    await uiLogin(page);
+    const afterLogin = page.url();
+
+    // Reload : l'access token mémoire est perdu ; init() doit le restaurer
+    // via le cookie HttpOnly (silent-refresh) sans repasser par /login.
+    await page.reload({ waitUntil: "networkidle" });
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 15000 })
+      .not.toMatch(/^\/login/);
+    expect(new URL(page.url()).pathname).toBe(new URL(afterLogin).pathname);
+  });
+
+  test("@negative sans cookie refresh → pas de session (redir /login)", async ({
+    page,
+  }) => {
+    await uiLogin(page);
+
+    // Supprime le cookie refresh : le silent-refresh doit échouer (401)
+    // et la session être nettoyée.
+    await page.context().clearCookies();
+    await page.goto("/syndic", { waitUntil: "networkidle" });
+    await expect
+      .poll(() => new URL(page.url()).pathname, { timeout: 15000 })
+      .toMatch(/^\/login/);
+  });
+});


### PR DESCRIPTION
## Summary

WBS go-live v0.1.0 — **WP-FE1 (#343) : JWT hors localStorage** (BLOQUANT SÉCURITÉ, vol de session XSS). Branche dédiée autorisée (PR séparée de #542/WP-A4 ; baseline `feature/dev` sans A4).

Décisions humaines verrouillées : PR unique FE1 complet · même site `SameSite=Strict; Secure` (pas de Domain) · `refresh_token` retiré du corps JSON (+ régen openapi/api.d.ts).

### Backend (couche infra uniquement — use-cases purs intacts)
- `auth_cookie.rs` : cookie `HttpOnly; Secure(COOKIE_SECURE, défaut true); SameSite=Strict; Path=/api/v1/auth; Max-Age=7j` + cookie de purge.
- `auth_handlers.rs` : projection HTTP `AuthBody { token, user }` (DTO `LoginResponse` **non modifié**) → `refresh_token` retiré du corps de `login`/`register`/`switch-role`, posé en cookie. `refresh` lit le refresh **exclusivement** depuis le cookie (plus de `web::Json`) → **401 si absent**, rotation. Nouveau `POST /auth/logout` (révoque tous les refresh + expire le cookie).
- `main.rs` CORS `.supports_credentials()` (R2 du diagnostic **inexistant** : `validate_cors_origins` rejette déjà `*`).
- `docs/api/openapi.json` régénéré (`RefreshTokenRequest` request-body retiré, `/auth/logout` ajouté).

### Frontend
- `lib/accessToken.ts` : access token **mémoire seule** (module dédié, zéro cycle d'import).
- `stores/auth.ts` réécrit : zéro token localStorage, `init()` silent-refresh via cookie, `login(user, token)`, `logout()` serveur, `validateSession()` retombe sur le cookie. `koprogo_user` conservé = cache d'affichage non sensible.
- `lib/api.ts` Bearer depuis la mémoire ; `LoginForm`/`RegisterForm` `credentials:"include"` + corps sans refresh.
- `types/api.d.ts` régénéré (gate Contract Types Check cohérent).

### Tests E2E / config
- `tests/e2e/helpers/auth.ts` : `injectAuth` réécrit (cookie HttpOnly réel + silent-refresh ; chokepoint unique → ripple ~specs absorbé — **lève la dépendance WP-D1**).
- `tests/e2e/smoke/AuthCookie.spec.ts` (nouveau) : 4-cat.
- `docker-compose.yml` + `.env.example` : `COOKIE_SECURE=false` dev/E2E (prod = true).

## Test plan

- [x] `cargo check --lib --tests` (SQLX_OFFLINE) propre
- [x] `cargo test --lib auth_cookie` — 4/4 (4-cat in-module)
- [x] `astro sync && astro check` — 0 erreur (239 fichiers)
- [x] `openapi-typescript` régénéré ; `prettier` propre sur fichiers touchés
- [ ] CI : Unit/BDD/Contract/E2E/Playwright (`AuthCookie.spec.ts` + smoke ripple) — gate
- [ ] e2e backend cookie 4-cat (`e2e_auth.rs`) exécutés en CI (testcontainers — daemon Docker absent en session, fallback hôte conforme CRITICAL.md #12)

### 4-cat RED-first
- `e2e_auth.rs` : @happy set-cookie HttpOnly + corps sans refresh · @security refresh via cookie rote + corps sans refresh · @negative refresh sans/forgé cookie → 401 · @edge ancien cookie révoqué post-rotation (anti-rejeu).
- `auth_cookie.rs` in-module + `AuthCookie.spec.ts` (Playwright).

> Tier-2, pas de mutation prod. Log : `docs/agent-activity/2026-05-19-wbs-fe1.md`. Réf WBS WP-FE1. Différé : use-cases auth `Result<_,String>` (hexagonal-clean, hors scope) ; `SameSite=Strict` à re-décider si sous-domaines séparés Phase 2.

https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP)_