### PR TITLE
feat(backend): #433 WP-A5 EXP-007 etat_date — f64 → Decimal + typed domain error

### DIFF
--- a/backend/src/application/dto/etat_date_dto.rs
+++ b/backend/src/application/dto/etat_date_dto.rs
@@ -21,11 +21,13 @@ pub struct CreateEtatDateRequest {
 /// Request pour mettre à jour les données financières d'un état daté
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateEtatDateFinancialRequest {
-    pub owner_balance: f64,
-    pub arrears_amount: f64,
-    pub monthly_provision_amount: f64,
-    pub total_balance: f64,
-    pub approved_works_unpaid: f64,
+    // MONÉTAIRE : Decimal exact (ADR-0007/0008), sérialisé string JSON
+    // comme les quote-parts (#433 / WP-A5 EXP-007).
+    pub owner_balance: rust_decimal::Decimal,
+    pub arrears_amount: rust_decimal::Decimal,
+    pub monthly_provision_amount: rust_decimal::Decimal,
+    pub total_balance: rust_decimal::Decimal,
+    pub approved_works_unpaid: rust_decimal::Decimal,
 }
 
 /// Request pour mettre à jour les données additionnelles (sections 7-16)
@@ -60,11 +62,11 @@ pub struct EtatDateResponse {
     pub ordinary_charges_quota: rust_decimal::Decimal,
     /// Quote-part charges extraordinaires — Decimal exact (ADR-0008), string JSON.
     pub extraordinary_charges_quota: rust_decimal::Decimal,
-    pub owner_balance: f64,
-    pub arrears_amount: f64,
-    pub monthly_provision_amount: f64,
-    pub total_balance: f64,
-    pub approved_works_unpaid: f64,
+    pub owner_balance: rust_decimal::Decimal,
+    pub arrears_amount: rust_decimal::Decimal,
+    pub monthly_provision_amount: rust_decimal::Decimal,
+    pub total_balance: rust_decimal::Decimal,
+    pub approved_works_unpaid: rust_decimal::Decimal,
     pub additional_data: serde_json::Value,
     pub pdf_file_path: Option<String>,
     pub created_at: DateTime<Utc>,

--- a/backend/src/application/error.rs
+++ b/backend/src/application/error.rs
@@ -191,6 +191,17 @@ impl From<crate::domain::entities::JournalEntryError> for AppError {
     }
 }
 
+impl From<crate::domain::entities::EtatDateError> for AppError {
+    /// Un état daté malformé (quote-part hors bornes, montant négatif
+    /// interdit, transition workflow invalide, champ obligatoire vide) est
+    /// une erreur d'entrée client → 400 validation, **jamais** 500 Internal
+    /// (le `From<String>` générique mappait à tort vers Internal) —
+    /// #433 / WP-A5 EXP-007.
+    fn from(e: crate::domain::entities::EtatDateError) -> Self {
+        AppError::Validation(e.to_string())
+    }
+}
+
 // ============================================================================
 // Tests — taxonomie 4 catégories obligatoire (cf. CRITICAL.md règle #3, #427)
 // ============================================================================

--- a/backend/src/application/use_cases/etat_date_use_cases.rs
+++ b/backend/src/application/use_cases/etat_date_use_cases.rs
@@ -773,21 +773,21 @@ mod tests {
         );
 
         let request = UpdateEtatDateFinancialRequest {
-            owner_balance: -1250.50,
-            arrears_amount: 800.0,
-            monthly_provision_amount: 150.0,
-            total_balance: -1250.50,
-            approved_works_unpaid: 3500.0,
+            owner_balance: dec!(-1250.50),
+            arrears_amount: dec!(800.0),
+            monthly_provision_amount: dec!(150.0),
+            total_balance: dec!(-1250.50),
+            approved_works_unpaid: dec!(3500.0),
         };
 
         let result = use_cases.update_financial_data(etat_id, request).await;
         assert!(result.is_ok());
         let response = result.unwrap();
-        assert_eq!(response.owner_balance, -1250.50);
-        assert_eq!(response.arrears_amount, 800.0);
-        assert_eq!(response.monthly_provision_amount, 150.0);
-        assert_eq!(response.total_balance, -1250.50);
-        assert_eq!(response.approved_works_unpaid, 3500.0);
+        assert_eq!(response.owner_balance, dec!(-1250.50));
+        assert_eq!(response.arrears_amount, dec!(800.0));
+        assert_eq!(response.monthly_provision_amount, dec!(150.0));
+        assert_eq!(response.total_balance, dec!(-1250.50));
+        assert_eq!(response.approved_works_unpaid, dec!(3500.0));
     }
 
     #[tokio::test]

--- a/backend/src/domain/entities/etat_date.rs
+++ b/backend/src/domain/entities/etat_date.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use f64;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
@@ -86,22 +85,25 @@ pub struct EtatDate {
     pub extraordinary_charges_quota: Decimal,
 
     // === Section 3: Situation financière du propriétaire ===
+    // MONÉTAIRE : Decimal exact (ADR-0007/0008). Document légal Art. 577-2
+    // CC — toute dérive d'arrondi f64 vicie l'état daté. Colonnes DB déjà
+    // `DECIMAL(12,2)` (#433 / WP-A5 EXP-007).
     /// Solde du propriétaire (positif = crédit, négatif = débit)
-    pub owner_balance: f64,
+    pub owner_balance: Decimal,
     /// Montant des arriérés (dettes)
-    pub arrears_amount: f64,
+    pub arrears_amount: Decimal,
 
     // === Section 4: Provisions pour charges ===
     /// Montant mensuel des provisions
-    pub monthly_provision_amount: f64,
+    pub monthly_provision_amount: Decimal,
 
     // === Section 5: Solde créditeur/débiteur ===
     /// Solde total (somme de tous les comptes)
-    pub total_balance: f64,
+    pub total_balance: Decimal,
 
     // === Section 6: Travaux votés non payés ===
     /// Montant total des travaux votés mais non encore payés
-    pub approved_works_unpaid: f64,
+    pub approved_works_unpaid: Decimal,
 
     // === Section 7-16: Données JSONB ===
     /// Données structurées pour les sections complexes
@@ -126,6 +128,65 @@ pub struct EtatDate {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Domain-typed validation error for États Datés (Art. 577-2 CC).
+///
+/// Pure domain type — no infra/application dependency (hexagonal purity).
+/// Suit le précédent `JournalEntryError` (journal_entry.rs) : l'entité
+/// renvoie son erreur typée, l'application la mappe vers `AppError`
+/// (#433 / WP-A5 EXP-007) → 400 validation, jamais 500 Internal.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EtatDateError {
+    /// Un champ texte obligatoire est vide (nom/email notaire, immeuble…).
+    EmptyField(&'static str),
+    /// Email notaire syntaxiquement invalide.
+    InvalidNotaryEmail,
+    /// Quote-part hors bornes [0, 100] %.
+    QuotaOutOfRange(&'static str),
+    /// Montant monétaire négatif là où c'est interdit (arriérés, provisions,
+    /// travaux non payés ≥ 0).
+    NegativeAmount(&'static str),
+    /// Transition de workflow interdite depuis le statut courant.
+    InvalidTransition {
+        from: EtatDateStatus,
+        to: &'static str,
+    },
+    /// Chemin du PDF généré vide.
+    EmptyPdfPath,
+    /// `additional_data` n'est pas un objet JSON.
+    AdditionalDataNotObject,
+}
+
+impl std::fmt::Display for EtatDateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyField(name) => write!(f, "{} cannot be empty", name),
+            Self::InvalidNotaryEmail => write!(f, "Invalid notary email"),
+            Self::QuotaOutOfRange(name) => {
+                write!(f, "{} must be between 0 and 100%", name)
+            }
+            Self::NegativeAmount(name) => write!(f, "{} cannot be negative", name),
+            Self::InvalidTransition { from, to } => {
+                write!(f, "Cannot mark as {}: current status is {:?}", to, from)
+            }
+            Self::EmptyPdfPath => write!(f, "PDF file path cannot be empty"),
+            Self::AdditionalDataNotObject => {
+                write!(f, "Additional data must be a JSON object")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EtatDateError {}
+
+/// Bridge : les use-cases/ports `Result<_, String>` compilent inchangés
+/// pendant que l'entité est typée (cascade String→AppError = slice plus
+/// large, hors scope WP-A5 — précédent WP-A3/A4). Pur, std-only.
+impl From<EtatDateError> for String {
+    fn from(e: EtatDateError) -> String {
+        e.to_string()
+    }
+}
+
 impl EtatDate {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -144,33 +205,35 @@ impl EtatDate {
         unit_area: Option<f64>,
         ordinary_charges_quota: Decimal,
         extraordinary_charges_quota: Decimal,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, EtatDateError> {
         // Validations
         if notary_name.trim().is_empty() {
-            return Err("Notary name cannot be empty".to_string());
+            return Err(EtatDateError::EmptyField("Notary name"));
         }
         if notary_email.trim().is_empty() {
-            return Err("Notary email cannot be empty".to_string());
+            return Err(EtatDateError::EmptyField("Notary email"));
         }
         if !notary_email.contains('@') {
-            return Err("Invalid notary email".to_string());
+            return Err(EtatDateError::InvalidNotaryEmail);
         }
         if building_name.trim().is_empty() {
-            return Err("Building name cannot be empty".to_string());
+            return Err(EtatDateError::EmptyField("Building name"));
         }
         if building_address.trim().is_empty() {
-            return Err("Building address cannot be empty".to_string());
+            return Err(EtatDateError::EmptyField("Building address"));
         }
         if unit_number.trim().is_empty() {
-            return Err("Unit number cannot be empty".to_string());
+            return Err(EtatDateError::EmptyField("Unit number"));
         }
 
         // Quote-parts doivent être entre 0 et 100%
         if ordinary_charges_quota < Decimal::ZERO || ordinary_charges_quota > dec!(100) {
-            return Err("Ordinary charges quota must be between 0 and 100%".to_string());
+            return Err(EtatDateError::QuotaOutOfRange("Ordinary charges quota"));
         }
         if extraordinary_charges_quota < Decimal::ZERO || extraordinary_charges_quota > dec!(100) {
-            return Err("Extraordinary charges quota must be between 0 and 100%".to_string());
+            return Err(EtatDateError::QuotaOutOfRange(
+                "Extraordinary charges quota",
+            ));
         }
 
         let now = Utc::now();
@@ -198,11 +261,11 @@ impl EtatDate {
             unit_area,
             ordinary_charges_quota,
             extraordinary_charges_quota,
-            owner_balance: 0.0,
-            arrears_amount: 0.0,
-            monthly_provision_amount: 0.0,
-            total_balance: 0.0,
-            approved_works_unpaid: 0.0,
+            owner_balance: Decimal::ZERO,
+            arrears_amount: Decimal::ZERO,
+            monthly_provision_amount: Decimal::ZERO,
+            total_balance: Decimal::ZERO,
+            approved_works_unpaid: Decimal::ZERO,
             additional_data: serde_json::json!({}),
             pdf_file_path: None,
             created_at: now,
@@ -236,24 +299,24 @@ impl EtatDate {
     }
 
     /// Marque l'état daté comme en cours de génération
-    pub fn mark_in_progress(&mut self) -> Result<(), String> {
+    pub fn mark_in_progress(&mut self) -> Result<(), EtatDateError> {
         match self.status {
             EtatDateStatus::Requested => {
                 self.status = EtatDateStatus::InProgress;
                 self.updated_at = Utc::now();
                 Ok(())
             }
-            _ => Err(format!(
-                "Cannot mark as in progress: current status is {:?}",
-                self.status
-            )),
+            _ => Err(EtatDateError::InvalidTransition {
+                from: self.status.clone(),
+                to: "in progress",
+            }),
         }
     }
 
     /// Marque l'état daté comme généré
-    pub fn mark_generated(&mut self, pdf_file_path: String) -> Result<(), String> {
+    pub fn mark_generated(&mut self, pdf_file_path: String) -> Result<(), EtatDateError> {
         if pdf_file_path.trim().is_empty() {
-            return Err("PDF file path cannot be empty".to_string());
+            return Err(EtatDateError::EmptyPdfPath);
         }
 
         match self.status {
@@ -264,15 +327,15 @@ impl EtatDate {
                 self.updated_at = Utc::now();
                 Ok(())
             }
-            _ => Err(format!(
-                "Cannot mark as generated: current status is {:?}",
-                self.status
-            )),
+            _ => Err(EtatDateError::InvalidTransition {
+                from: self.status.clone(),
+                to: "generated",
+            }),
         }
     }
 
     /// Marque l'état daté comme délivré au notaire
-    pub fn mark_delivered(&mut self) -> Result<(), String> {
+    pub fn mark_delivered(&mut self) -> Result<(), EtatDateError> {
         match self.status {
             EtatDateStatus::Generated => {
                 self.status = EtatDateStatus::Delivered;
@@ -280,10 +343,10 @@ impl EtatDate {
                 self.updated_at = Utc::now();
                 Ok(())
             }
-            _ => Err(format!(
-                "Cannot mark as delivered: current status is {:?}",
-                self.status
-            )),
+            _ => Err(EtatDateError::InvalidTransition {
+                from: self.status.clone(),
+                to: "delivered",
+            }),
         }
     }
 
@@ -318,21 +381,21 @@ impl EtatDate {
     /// Met à jour les données financières
     pub fn update_financial_data(
         &mut self,
-        owner_balance: f64,
-        arrears_amount: f64,
-        monthly_provision_amount: f64,
-        total_balance: f64,
-        approved_works_unpaid: f64,
-    ) -> Result<(), String> {
+        owner_balance: Decimal,
+        arrears_amount: Decimal,
+        monthly_provision_amount: Decimal,
+        total_balance: Decimal,
+        approved_works_unpaid: Decimal,
+    ) -> Result<(), EtatDateError> {
         // Validation: les arriérés ne peuvent pas être négatifs
-        if arrears_amount < 0.0 {
-            return Err("Arrears amount cannot be negative".to_string());
+        if arrears_amount < Decimal::ZERO {
+            return Err(EtatDateError::NegativeAmount("Arrears amount"));
         }
-        if monthly_provision_amount < 0.0 {
-            return Err("Monthly provision amount cannot be negative".to_string());
+        if monthly_provision_amount < Decimal::ZERO {
+            return Err(EtatDateError::NegativeAmount("Monthly provision amount"));
         }
-        if approved_works_unpaid < 0.0 {
-            return Err("Approved works unpaid cannot be negative".to_string());
+        if approved_works_unpaid < Decimal::ZERO {
+            return Err(EtatDateError::NegativeAmount("Approved works unpaid"));
         }
 
         self.owner_balance = owner_balance;
@@ -346,9 +409,9 @@ impl EtatDate {
     }
 
     /// Met à jour les données additionnelles (sections 7-16)
-    pub fn update_additional_data(&mut self, data: serde_json::Value) -> Result<(), String> {
+    pub fn update_additional_data(&mut self, data: serde_json::Value) -> Result<(), EtatDateError> {
         if !data.is_object() {
-            return Err("Additional data must be a JSON object".to_string());
+            return Err(EtatDateError::AdditionalDataNotObject);
         }
 
         self.additional_data = data;
@@ -418,8 +481,10 @@ mod tests {
             dec!(100),
         );
 
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "Invalid notary email");
+        assert!(matches!(
+            result.unwrap_err(),
+            EtatDateError::InvalidNotaryEmail
+        ));
     }
 
     #[test]
@@ -447,8 +512,10 @@ mod tests {
             dec!(100),
         );
 
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("between 0 and 100%"));
+        assert!(matches!(
+            result.unwrap_err(),
+            EtatDateError::QuotaOutOfRange(_)
+        ));
     }
 
     #[test]
@@ -553,16 +620,16 @@ mod tests {
         .unwrap();
 
         let result = ed.update_financial_data(
-            -500.00, // -500.00 EUR (débit)
-            100.0,   // 500.00 EUR arriérés
-            100.0,   // 150.00 EUR/mois
-            -500.00, // -500.00 EUR total
-            100.0,   // 2000.00 EUR travaux votés
+            dec!(-500.00), // débit
+            dec!(100.0),   // arriérés
+            dec!(100.0),   // provision/mois
+            dec!(-500.00), // total
+            dec!(100.0),   // travaux votés non payés
         );
 
         assert!(result.is_ok());
-        assert_eq!(ed.owner_balance, -500.00);
-        assert_eq!(ed.arrears_amount, 100.0);
+        assert_eq!(ed.owner_balance, dec!(-500.00));
+        assert_eq!(ed.arrears_amount, dec!(100.0));
     }
 
     #[test]
@@ -627,5 +694,136 @@ mod tests {
         ed.requested_date = Utc::now() - chrono::Duration::days(5);
 
         assert_eq!(ed.days_since_request(), 5);
+    }
+
+    // ------------------------------------------------------------------------
+    // 4 catégories #433/WP-A5 EXP-007 — erreur typée + exactitude Decimal
+    // (CRITICAL.md #3). Document légal Art. 577-2 CC : zéro dérive d'arrondi.
+    // ------------------------------------------------------------------------
+
+    fn sample() -> EtatDate {
+        EtatDate::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Utc::now(),
+            EtatDateLanguage::Fr,
+            "Maître Dupont".to_string(),
+            "dupont@notaire.be".to_string(),
+            None,
+            "Résidence Les Jardins".to_string(),
+            "Rue de la Loi 123".to_string(),
+            "101".to_string(),
+            None,
+            None,
+            dec!(50),
+            dec!(50),
+        )
+        .unwrap()
+    }
+
+    /// @happy — màj financière nominale : montants Decimal stockés exacts.
+    #[test]
+    fn happy_update_financial_data_decimal_exact() {
+        let mut ed = sample();
+        ed.update_financial_data(
+            dec!(-1234.56),
+            dec!(789.01),
+            dec!(150.00),
+            dec!(-445.55),
+            dec!(2000.00),
+        )
+        .unwrap();
+        assert_eq!(ed.owner_balance, dec!(-1234.56));
+        assert_eq!(ed.total_balance, dec!(-445.55));
+    }
+
+    /// @edge — exactitude Decimal sur cumul (0.1+0.2=0.3 ; f64 échoue) +
+    /// borne quota exactement 100% acceptée.
+    #[test]
+    fn edge_decimal_exactness_and_quota_boundary() {
+        let mut ed = sample();
+        ed.update_financial_data(
+            dec!(0.1) + dec!(0.2),
+            Decimal::ZERO,
+            Decimal::ZERO,
+            dec!(0.3),
+            Decimal::ZERO,
+        )
+        .unwrap();
+        assert_eq!(ed.owner_balance, dec!(0.3));
+        assert_eq!(ed.owner_balance, ed.total_balance);
+
+        // Quota exactement 100% (borne incluse) accepté.
+        let ok = EtatDate::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Utc::now(),
+            EtatDateLanguage::Nl,
+            "N".to_string(),
+            "n@x.be".to_string(),
+            None,
+            "B".to_string(),
+            "A".to_string(),
+            "1".to_string(),
+            None,
+            None,
+            dec!(100),
+            dec!(0),
+        );
+        assert!(ok.is_ok());
+    }
+
+    /// @negative — montant interdit négatif & transition invalide rejetés
+    /// (erreur typée, pas de panic).
+    #[test]
+    fn negative_amount_and_transition_rejected() {
+        let mut ed = sample();
+        assert!(matches!(
+            ed.update_financial_data(
+                Decimal::ZERO,
+                dec!(-1), // arriérés négatifs interdits
+                Decimal::ZERO,
+                Decimal::ZERO,
+                Decimal::ZERO,
+            )
+            .unwrap_err(),
+            EtatDateError::NegativeAmount(_)
+        ));
+
+        // Requested -> Delivered direct interdit.
+        assert!(matches!(
+            ed.mark_delivered().unwrap_err(),
+            EtatDateError::InvalidTransition { .. }
+        ));
+    }
+
+    /// @security — un état daté (acte légal Art. 577-2 CC) ne peut être créé
+    /// avec une quote-part falsifiée hors [0,100] % : intégrité du document
+    /// opposable au notaire/acquéreur.
+    #[test]
+    fn security_tampered_quota_rejected() {
+        let result = EtatDate::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Utc::now(),
+            EtatDateLanguage::Fr,
+            "Maître Dupont".to_string(),
+            "dupont@notaire.be".to_string(),
+            None,
+            "Résidence".to_string(),
+            "Rue".to_string(),
+            "101".to_string(),
+            None,
+            None,
+            dec!(250), // falsifié > 100%
+            dec!(50),
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            EtatDateError::QuotaOutOfRange(_)
+        ));
     }
 }

--- a/backend/src/domain/entities/mod.rs
+++ b/backend/src/domain/entities/mod.rs
@@ -81,7 +81,7 @@ pub use energy_bill_upload::EnergyBillUpload;
 pub use energy_campaign::{
     CampaignStatus, CampaignType, ContractType, EnergyCampaign, EnergyType, ProviderOffer,
 };
-pub use etat_date::{EtatDate, EtatDateLanguage, EtatDateStatus};
+pub use etat_date::{EtatDate, EtatDateError, EtatDateLanguage, EtatDateStatus};
 pub use expense::{ApprovalStatus, Expense, ExpenseCategory, PaymentStatus};
 pub use gdpr_art30::{ProcessingActivity, ProcessorAgreement};
 pub use gdpr_export::{

--- a/backend/src/infrastructure/database/repositories/etat_date_repository_impl.rs
+++ b/backend/src/infrastructure/database/repositories/etat_date_repository_impl.rs
@@ -110,8 +110,8 @@ impl EtatDateRepository for PostgresEtatDateRepository {
                 notary_name, notary_email, notary_phone,
                 building_name, building_address, unit_number, unit_floor, unit_area::FLOAT8 AS unit_area,
                 ordinary_charges_quota::NUMERIC(5,2) AS ordinary_charges_quota, extraordinary_charges_quota::NUMERIC(5,2) AS extraordinary_charges_quota,
-                owner_balance::FLOAT8 AS owner_balance, arrears_amount::FLOAT8 AS arrears_amount, monthly_provision_amount::FLOAT8 AS monthly_provision_amount,
-                total_balance::FLOAT8 AS total_balance, approved_works_unpaid::FLOAT8 AS approved_works_unpaid,
+                owner_balance, arrears_amount, monthly_provision_amount,
+                total_balance, approved_works_unpaid,
                 additional_data, pdf_file_path,
                 created_at, updated_at
             FROM etats_dates
@@ -139,8 +139,8 @@ impl EtatDateRepository for PostgresEtatDateRepository {
                 notary_name, notary_email, notary_phone,
                 building_name, building_address, unit_number, unit_floor, unit_area::FLOAT8 AS unit_area,
                 ordinary_charges_quota::NUMERIC(5,2) AS ordinary_charges_quota, extraordinary_charges_quota::NUMERIC(5,2) AS extraordinary_charges_quota,
-                owner_balance::FLOAT8 AS owner_balance, arrears_amount::FLOAT8 AS arrears_amount, monthly_provision_amount::FLOAT8 AS monthly_provision_amount,
-                total_balance::FLOAT8 AS total_balance, approved_works_unpaid::FLOAT8 AS approved_works_unpaid,
+                owner_balance, arrears_amount, monthly_provision_amount,
+                total_balance, approved_works_unpaid,
                 additional_data, pdf_file_path,
                 created_at, updated_at
             FROM etats_dates
@@ -165,8 +165,8 @@ impl EtatDateRepository for PostgresEtatDateRepository {
                 notary_name, notary_email, notary_phone,
                 building_name, building_address, unit_number, unit_floor, unit_area::FLOAT8 AS unit_area,
                 ordinary_charges_quota::NUMERIC(5,2) AS ordinary_charges_quota, extraordinary_charges_quota::NUMERIC(5,2) AS extraordinary_charges_quota,
-                owner_balance::FLOAT8 AS owner_balance, arrears_amount::FLOAT8 AS arrears_amount, monthly_provision_amount::FLOAT8 AS monthly_provision_amount,
-                total_balance::FLOAT8 AS total_balance, approved_works_unpaid::FLOAT8 AS approved_works_unpaid,
+                owner_balance, arrears_amount, monthly_provision_amount,
+                total_balance, approved_works_unpaid,
                 additional_data, pdf_file_path,
                 created_at, updated_at
             FROM etats_dates
@@ -195,8 +195,8 @@ impl EtatDateRepository for PostgresEtatDateRepository {
                 notary_name, notary_email, notary_phone,
                 building_name, building_address, unit_number, unit_floor, unit_area::FLOAT8 AS unit_area,
                 ordinary_charges_quota::NUMERIC(5,2) AS ordinary_charges_quota, extraordinary_charges_quota::NUMERIC(5,2) AS extraordinary_charges_quota,
-                owner_balance::FLOAT8 AS owner_balance, arrears_amount::FLOAT8 AS arrears_amount, monthly_provision_amount::FLOAT8 AS monthly_provision_amount,
-                total_balance::FLOAT8 AS total_balance, approved_works_unpaid::FLOAT8 AS approved_works_unpaid,
+                owner_balance, arrears_amount, monthly_provision_amount,
+                total_balance, approved_works_unpaid,
                 additional_data, pdf_file_path,
                 created_at, updated_at
             FROM etats_dates
@@ -232,8 +232,8 @@ impl EtatDateRepository for PostgresEtatDateRepository {
                 notary_name, notary_email, notary_phone,
                 building_name, building_address, unit_number, unit_floor, unit_area::FLOAT8 AS unit_area,
                 ordinary_charges_quota::NUMERIC(5,2) AS ordinary_charges_quota, extraordinary_charges_quota::NUMERIC(5,2) AS extraordinary_charges_quota,
-                owner_balance::FLOAT8 AS owner_balance, arrears_amount::FLOAT8 AS arrears_amount, monthly_provision_amount::FLOAT8 AS monthly_provision_amount,
-                total_balance::FLOAT8 AS total_balance, approved_works_unpaid::FLOAT8 AS approved_works_unpaid,
+                owner_balance, arrears_amount, monthly_provision_amount,
+                total_balance, approved_works_unpaid,
                 additional_data, pdf_file_path,
                 created_at, updated_at
             FROM etats_dates
@@ -333,8 +333,8 @@ impl EtatDateRepository for PostgresEtatDateRepository {
                 notary_name, notary_email, notary_phone,
                 building_name, building_address, unit_number, unit_floor, unit_area::FLOAT8 AS unit_area,
                 ordinary_charges_quota::NUMERIC(5,2) AS ordinary_charges_quota, extraordinary_charges_quota::NUMERIC(5,2) AS extraordinary_charges_quota,
-                owner_balance::FLOAT8 AS owner_balance, arrears_amount::FLOAT8 AS arrears_amount, monthly_provision_amount::FLOAT8 AS monthly_provision_amount,
-                total_balance::FLOAT8 AS total_balance, approved_works_unpaid::FLOAT8 AS approved_works_unpaid,
+                owner_balance, arrears_amount, monthly_provision_amount,
+                total_balance, approved_works_unpaid,
                 additional_data, pdf_file_path,
                 created_at, updated_at
             FROM etats_dates
@@ -365,8 +365,8 @@ impl EtatDateRepository for PostgresEtatDateRepository {
                 notary_name, notary_email, notary_phone,
                 building_name, building_address, unit_number, unit_floor, unit_area::FLOAT8 AS unit_area,
                 ordinary_charges_quota::NUMERIC(5,2) AS ordinary_charges_quota, extraordinary_charges_quota::NUMERIC(5,2) AS extraordinary_charges_quota,
-                owner_balance::FLOAT8 AS owner_balance, arrears_amount::FLOAT8 AS arrears_amount, monthly_provision_amount::FLOAT8 AS monthly_provision_amount,
-                total_balance::FLOAT8 AS total_balance, approved_works_unpaid::FLOAT8 AS approved_works_unpaid,
+                owner_balance, arrears_amount, monthly_provision_amount,
+                total_balance, approved_works_unpaid,
                 additional_data, pdf_file_path,
                 created_at, updated_at
             FROM etats_dates

--- a/backend/tests/bdd_governance.rs
+++ b/backend/tests/bdd_governance.rs
@@ -6067,30 +6067,32 @@ async fn when_update_financial_data(world: &mut GovernanceWorld, step: &Step) {
     let id = world.last_etat_date_id.unwrap();
     let table = step.table.as_ref().expect("table");
 
-    let mut owner_balance = 0.0;
-    let mut arrears = 0.0;
-    let mut monthly_provision = 0.0;
-    let mut total_balance = 0.0;
-    let mut approved_works = 0.0;
+    // WP-A5 : montants Decimal exacts (cents/100 sans dérive f64).
+    let cents = |v: &str| Decimal::from_str(v).unwrap_or(Decimal::ZERO) / Decimal::from(100);
+    let mut owner_balance = Decimal::ZERO;
+    let mut arrears = Decimal::ZERO;
+    let mut monthly_provision = Decimal::ZERO;
+    let mut total_balance = Decimal::ZERO;
+    let mut approved_works = Decimal::ZERO;
 
     for row in &table.rows {
         let key = row[0].trim();
         let val = row[1].trim();
         match key {
             "provisions_paid_amount_cents" => {
-                owner_balance = val.parse::<f64>().unwrap_or(0.0) / 100.0;
+                owner_balance = cents(val);
             }
             "outstanding_amount_cents" => {
-                arrears = val.parse::<f64>().unwrap_or(0.0) / 100.0;
+                arrears = cents(val);
             }
             "quota_ordinary" => {
-                monthly_provision = val.parse::<f64>().unwrap_or(0.0);
+                monthly_provision = Decimal::from_str(val).unwrap_or(Decimal::ZERO);
             }
             "pending_works_amount_cents" => {
-                approved_works = val.parse::<f64>().unwrap_or(0.0) / 100.0;
+                approved_works = cents(val);
             }
             "reserve_fund_amount_cents" => {
-                total_balance = val.parse::<f64>().unwrap_or(0.0) / 100.0;
+                total_balance = cents(val);
             }
             _ => {}
         }
@@ -6170,11 +6172,11 @@ async fn given_etat_date_with_sections(world: &mut GovernanceWorld) {
     let uc = world.etat_date_use_cases.as_ref().unwrap().clone();
     let id = world.last_etat_date_id.unwrap();
     let fin_req = UpdateEtatDateFinancialRequest {
-        owner_balance: 1500.0,
-        arrears_amount: 0.0,
-        monthly_provision_amount: 250.0,
-        total_balance: 50000.0,
-        approved_works_unpaid: 5000.0,
+        owner_balance: Decimal::from(1500),
+        arrears_amount: Decimal::ZERO,
+        monthly_provision_amount: Decimal::from(250),
+        total_balance: Decimal::from(50000),
+        approved_works_unpaid: Decimal::from(5000),
     };
     uc.update_financial_data(id, fin_req)
         .await

--- a/backend/tests/features/etat_date.feature
+++ b/backend/tests/features/etat_date.feature
@@ -15,6 +15,18 @@ Feature: État Daté Generation
     And a user "Syndic Vente" exists with email "syndic@vente.be" in organization "org-789"
     And the user is authenticated as Syndic
 
+  # 4 catégories (#433/WP-A5 EXP-007). Montants Decimal exact (ADR-0007/0008),
+  # acte légal Art. 577-2 CC. @negative (montant négatif interdit, transition
+  # workflow invalide, champ obligatoire vide) et @security (quote-part
+  # falsifiée hors [0,100] % ⇒ document opposable invalidé) sont des invariants
+  # de l'entité domaine, vérifiés par les tests unitaires typés
+  # `negative_amount_and_transition_rejected`,
+  # `security_tampered_quota_rejected`, `edge_decimal_exactness_and_quota_boundary`
+  # (etat_date.rs) — le glue BDD remplit des données valides et ne peut donc
+  # pas exercer comportementalement ces chemins de rejet ici (précédent
+  # journal_entries.feature / WP-A3, charge_distribution.feature / WP-A4).
+
+  @happy
   Scenario: Notary requests État Daté for property sale
     When I request an État Daté for unit "Apartment 101" with:
       | reference_date    | 2026-02-15                |
@@ -32,7 +44,9 @@ Feature: État Daté Generation
     Then the status should be "InProgress"
     And the in_progress_at timestamp should be set
 
+  @edge
   Scenario: Syndic fills 16 mandatory legal sections
+    # Montants en centimes → Decimal exact (cents/100 sans dérive f64).
     Given an État Daté in status "InProgress" exists
     When I update financial data with:
       | quota_ordinary              | 0.0250   |

--- a/docs/WBS_GO_LIVE_v0.1.0.md
+++ b/docs/WBS_GO_LIVE_v0.1.0.md
@@ -2,7 +2,7 @@
 
 `WBS-v0.1.0-beta-r1` · 2026-05-16 · base : `feature/dev` + branche `story/521-C1-governance-decimal` (HEAD `98c1651`, 1 commit devant `origin/feature/dev`).
 
-> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont *référencés*, pas créés.
+> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont _référencés_, pas créés.
 >
 > **Supersession** : ce document remplace, pour le go-live, les WBS périmés du 2026-04-01 — [`WBS_RELEASE_0_1_0.md`](WBS_RELEASE_0_1_0.md), [`WBS_BUGFIX_UI_v0.1.0.md`](WBS_BUGFIX_UI_v0.1.0.md), [`WBS_CORRECTIONS_v0.1.0.md`](WBS_CORRECTIONS_v0.1.0.md) — qui restent valables comme contexte historique mais ne reflètent plus l'état du code (Story A Decimal mergée, #515 mergé, TLS déjà câblé).
 
@@ -11,6 +11,7 @@
 KoproGo v0.1.0 n'a jamais été taggé ni mis en ligne (aucun tag git, aucune release). Le besoin : **mettre v0.1.0 en ligne en bêta privée fermée (5-10 copropriétés)** avec une infrastructure opérationnelle réelle et tous les tests requis (4 catégories `@happy/@edge/@security/@negative`, RED-first). Le rapport de revue humaine `docs/HUMAN_REVIEW_REPORT_v0.1.0.md` date du **2026-04-01 (~6 semaines, périmé)** et concluait NO-GO public / GO-conditionnel bêta — il doit être **re-rejoué** sur le code courant, pas pris pour argent comptant (plusieurs bugs sont probablement déjà corrigés : #523 dashboard %, #521 Story A mergée).
 
 Décisions produit verrouillées :
+
 1. **Déploiement : VPS d'abord, puis k3s en Phase 2.** Phase 1 = OVH VPS + docker-compose (`infrastructure/monosite/vps/production`, poller systemd `gitops-deploy.sh`). k3s/ArgoCD = Phase 2 post-v0.1.0.
 2. **Périmètre : bêta privée fermée.** Gate = bloquants critiques (sécurité réelle mais allégée vs gate public #427).
 3. **Decimal : umbrella #433 COMPLÈTE** (EXP-003..008 + gouvernance C1 #521/#534/#525). Exactitude PCMN obligatoire même en bêta.
@@ -18,16 +19,16 @@ Décisions produit verrouillées :
 
 ## Faits vérifiés (corrigent le chemin critique — ne pas re-dériver)
 
-| Hypothèse initiale | Réalité vérifiée (code) | Impact |
-|---|---|---|
-| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL. |
-| EXP-005 `charge_distribution` à faire | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`) | `Result→AppError` + BDD 4-cat seulement |
-| #453 TLS = bloquant go-live | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
-| #515 5 gaps ArgoCD bloquants | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s | Phase 2 |
-| Migration gouvernance large | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode |
-| EXP-007 `etat_date` mineur | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC) | WP-A5 = item le plus long de Track A |
-| #443 cascade énorme | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e_*.rs | Cascade réelle mais bornée |
-| JWT stockage | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage` | **Bloquant sécurité bêta fermée** confirmé |
+| Hypothèse initiale                                   | Réalité vérifiée (code)                                                                                                                                                                                                                          | Impact                                                                                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB                                                                   | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL.                                                  |
+| EXP-005 `charge_distribution` à faire                | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`)                                                                                                                                                                                          | `Result→AppError` + BDD 4-cat seulement                                                                                                       |
+| #453 TLS = bloquant go-live                          | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
+| #515 5 gaps ArgoCD bloquants                         | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s                                                                                                                                                                     | Phase 2                                                                                                                                       |
+| Migration gouvernance large                          | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data                                                                         | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode                                                                                     |
+| EXP-007 `etat_date` mineur                           | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC)                                                                                                                                                              | WP-A5 = item le plus long de Track A                                                                                                          |
+| #443 cascade énorme                                  | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e\_\*.rs                                                                                                                                                                                           | Cascade réelle mais bornée                                                                                                                    |
+| JWT stockage                                         | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage`                                                                                                                                         | **Bloquant sécurité bêta fermée** confirmé                                                                                                    |
 
 **Vrai long pole = WP-A2 (#443 cascade tests) → WP-A5 (EXP-007 etat_date)**, à paralléliser avec la chaîne Ops-VPS (latence Tier-1 humaine).
 
@@ -37,21 +38,22 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track A — Backend Decimal
 
-- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · *critique, premier*
+- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · _critique, premier_
   Appliquer `backend/migrations/20260516000000_alter_governance_to_numeric.sql` (DB test) ; `bdd_governance` 4 scénarios VERTS ; tuer le panic #525 ColumnDecode `units.quota`. Décisions bloquantes : (a) **ADR-0008 ratio** pour proxy validation `vote.rs:~312-342` (draft `docs/agent-activity/2026-05-16-adr8-noncompliance-body.md`) ; (b) **politique f64 d'affichage** — `resolution.rs:185-212` `pour/contre/abstention_percentage()` renvoient `f64` depuis comptes entiers : **reco = carve-out ADR-0008 explicite (affichage seul, jamais seuil légal)** + assertion que le chemin quorum/majorité légal n'a aucun aller-retour Decimal→f64→Decimal. Fichiers : la migration, `tests/bdd_governance.rs`, `features/governance_decimal.feature`, `entities/{vote,resolution,meeting,age_request}.rs`, repos impl correspondants. Deps : aucune.
 
-- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · *critique* · **FAIT** (#539 + reconfirmé 2026-05-18)
+- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · _critique_ · **FAIT** (#539 + reconfirmé 2026-05-18)
   `docker compose run --rm backend cargo check --tests` propre (`--lib` déjà propre). Literals f64→`dec!()` aux call-sites, assertions Decimal-equality, zéro régression scénario @security/@negative. Fichiers : `tests/bdd_financial.rs` (~23 occ.), `tests/e2e_*.rs`, glue `features/*.feature`. Deps : conventions WP-A1. **Concurrent Track F.**
   **Reconfirmé** (post-merge 5 PR + WP-B3 + #526) : `cargo check --tests` **CHECK_EXIT=0**, 0 erreur, aucune cascade f64/Decimal résiduelle (1 warning amont `proc-macro-error2`, non-bloquant). Suite BDD 100% verte (G1/G2/OPS/COM/FIN=0) ⇒ zéro régression @security/@negative confirmée. **Critère GO « `cargo check --tests` propre » atteint.**
 
 - **WP-A3 — EXP-006 journal_entry (réduit)** · #433 · T2 · M
   `Result<_,String>`→`AppError` sur `JournalEntry/JournalEntryLine`. `features/journal_entries.feature` 4-cat RED-first : @negative **débit≠crédit rejeté**, @edge 0.1+0.2=0.3, @security isolation cross-org, @happy écriture équilibrée. Pas de SQL. Deps : A1, A2.
 
-- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · *parallèle A3*
+- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · _parallèle A3_
   `Result→AppError` ; 4-cat : @security somme quotas==100% à `dec!(1.0001)`, @negative quota>1/négatif rejeté. Deps : A1.
 
-- **WP-A5 — EXP-007 quote/etat_date (Art. 577 CC, plus gros résidu)** · #433 · T2 · L
-  f64→Decimal `etat_date` (17 occ.) + `quote` + DTO/use_case/repo ; migration SQL **seulement si** colonnes `DOUBLE PRECISION` (vérifier `20251115000000_create_etats_dates.sql`, `20251120150000_create_quotes.sql`) ; `Result→AppError` ; 4-cat `etat_date.feature`/`quotes.feature`. Deps : A1, A2.
+- **WP-A5 — EXP-007 quote/etat_date (Art. 577 CC, plus gros résidu)** · #433 · T2 · L · **FAIT** (2026-05-19, branche `story/wbs-a5-etat-date`)
+  f64→Decimal `etat_date` (17 occ.) + `quote` + DTO/use*case/repo ; migration SQL **seulement si** colonnes `DOUBLE PRECISION` (vérifier `20251115000000_create_etats_dates.sql`, `20251120150000_create_quotes.sql`) ; `Result→AppError` ; 4-cat `etat_date.feature`/`quotes.feature`. Deps : A1, A2.
+  **Réalisé** : **aucune migration SQL** (colonnes déjà `DECIMAL(12,2)`). `etat_date.rs` — `use f64;` parasite retiré ; 5 champs monétaires f64→`Decimal` (`unit_area` conservé f64, ADR-0009) ; enum domaine pur `EtatDateError` (7 var.) + pont `From<*> for String`+`From<\_> for AppError`→Validation 400. DTO 5 champs→Decimal (non contract-visible : DTO sans `ToSchema`⇒ zéro drift openapi/api.d.ts). Repo : casts`::FLOAT8 AS`retirés sur 5 colonnes ×7 SELECT. bdd_governance steps → Decimal exact (cents/100). 4-cat RED-first in-module + feature taggée`@happy`/`@edge`(commentaire style A3/A4).`cargo check --lib --tests`propre,`cargo test --lib etat_date`24/24, fmt propre (fallback hôte — daemon Docker absent). Log`docs/agent-activity/2026-05-19-wbs-a5.md`. **Scopé etat_date** (vrai long-pole) ; `quote.rs`déjà Decimal-clean → typed-error`QuoteError`différé umbrella (idem A3/A4, non bloquant DoD car exactitude Decimal déjà satisfaite). **Différé** : cascade port/use-case/handler`String`→`AppError`.
 
 - **WP-A6 — EXP-008 owner_contribution/call_for_funds/gamification** · #433 · T2 · M
   Monétaire→Decimal+AppError+4-cat. Gamification/ratings = scores non-PCMN → carve-out ADR-0008, f64 conservé (@happy+@negative légers). Deps : A1, A2.
@@ -61,19 +63,19 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track B — Backend autre
 
-- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1*
+- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1\*
   Re-jouer `HUMAN_REVIEW_REPORT_v0.1.0.md` comme checklist vs `feature/dev` courant : **BUG-WF14-2 fuite bâtiments cross-org (Alice voit 3 bâtiments) = bloquant sécurité bêta si reproductible** — tracer scoping `organization_id` repo buildings ; BUG-WF2-1 `voting_power≤1000` vs seed>1280 (vérifier `20260401000000_fix_voting_power_constraint.sql`) ; BUG-WF7-1 ticket 400 ; NaN% compteurs (probablement corrigé par #523 `7c2d664` — vérifier). Repro RED par bug confirmé. Deps : aucune.
 
-- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · *parallèle* · **FAIT** (PR #538)
+- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · _parallèle_ · **FAIT** (PR #538)
   Réalité : #432 = 100% npm/frontend (le "14 vulns" était périmé). `svelte 5.55.7` + `devalue 5.8.1` → 5 alertes résolues, `npm audit --omit=dev` = 0, build vert. Résiduel 1 HIGH `@babel/plugin-transform-modules-systemjs` (devDependency build-only, `audit fix --force` breaking → accepté/documenté). `cargo audit` (RustSec) exit 0 modulo ignores `.cargo/audit.toml`. Fichiers : `frontend/package-lock.json`. Deps : aucune.
 
-- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · *débruite le gate* · **FAIT** (PR #541)
+- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · _débruite le gate_ · **FAIT** (PR #541)
   Le fix #524 a rendu le harness honnête → ~27 scénarios BDD pré-existants rouges sur 8 groupes (CI run `25982956110`) bruitent **toute** PR : « Meeting Resolutions » 14/14 (quorum Art. 3.87 §5 ordre workflow), Board CdC mandat ×5 (Art. 3.89 assertion vs règle), Energy/Notice/CallForFunds/Gamification ×6 (seeds/asserts), Stats ×2 (= #526). **Issue de tracking consolidée = #540** (inventaire complet + critères) ; un sous-fix RED-first 4-cat par groupe (P1 = Meeting Resolutions + Board mandat, légalement sensibles ; P2 = seeds/asserts ; Stats = #526 séparé). Aucun fix « comme ça » — comprendre la cause (test faux / prod faux / spec obsolète). Deps : aucune (parallèle). **Prérequis du jugement BDD propre en G1.**
-  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle *syndic* Art. 3.89 1–3 ans au *conseil de copropriété*, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
+  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle _syndic_ Art. 3.89 1–3 ans au _conseil de copropriété_, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
 
 ### Track C — Frontend sécurité (refacto #343 / SSR client:load DIFFÉRÉS post-bêta)
 
-- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · *critique*
+- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · _critique_
   `auth.ts:128-235` : refresh token → cookie backend `HttpOnly; Secure; SameSite=Strict` ; access token en mémoire seule + silent-refresh au load. Backend login/refresh : set-cookie + read-cookie + CORS credentials. 4-cat RED-first : @security token illisible JS/`document.cookie` & absent localStorage ; @negative cookie forgé/expiré→401 ; @happy login→refresh→protégé ; @edge refresh à la borne d'expiration. Deps : coordination WP-B1 ; moitié backend nourrit moitié FE.
 
 - **WP-FE2 — Corriger bugs FE revue (WF1-1/2/3)** · T2 · M
@@ -89,7 +91,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track E — Tests IaC (sous-ensemble VPS de #354)
 
-- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · *100% parallèle*
+- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · _100% parallèle_
   Job lint dans `ci-infra.yml`, assets VPS seulement : `terraform fmt -check`/`validate` (modules OVH + `monosite/vps/production/terraform`), `ansible-lint` (14 rôles + playbook prod), `yamllint`, `shellcheck` (**gate dur sur `gitops-deploy.sh`** — il exécute le déploiement prod). conftest/molecule/terratest = Phase 2. Deps : aucune.
 
 ### Track F — Ops VPS (concurrent Track A — aucun fichier partagé)
@@ -160,6 +162,7 @@ E1 (lint IaC) ─► F1 (TF/Ansible,T1) ─► F2 (TLS,T1) ─► F3 (poller,T1)
 ## Vérification — commandes exactes & gate humain
 
 Backend (agent) :
+
 ```
 docker compose run --rm backend cargo check --lib
 docker compose run --rm backend cargo check --tests        # propre post WP-A2
@@ -170,7 +173,9 @@ docker compose run --rm backend cargo test --no-fail-fast --test bdd --test bdd_
 docker compose run --rm backend cargo test --test e2e
 docker compose run --rm backend cargo audit                 # #432
 ```
+
 Frontend :
+
 ```
 docker compose run --rm frontend npm run build
 docker compose run --rm frontend npx svelte-check --threshold warning
@@ -179,13 +184,17 @@ docker compose run --rm frontend npx playwright test --project=chromium    # pla
 docker compose run --rm frontend npx playwright test --project=scenarios   # par-scénario
 docker compose run --rm frontend npx prettier --check .
 ```
+
 Gate push / contrat :
+
 ```
 make ci                # VERT obligatoire avant tout push
 make openapi-check     # si DTOs touchés
 make types-sync        # si spec changée
 ```
+
 IaC (post WP-E1) :
+
 ```
 terraform -chdir=infrastructure/monosite/vps/production/terraform fmt -check
 terraform -chdir=infrastructure/monosite/vps/production/terraform validate
@@ -193,7 +202,9 @@ ansible-lint infrastructure/monosite/vps/production/ansible/playbook.yml
 yamllint infrastructure/monosite/vps/production
 shellcheck infrastructure/_shared/scripts/gitops-deploy.sh
 ```
+
 Gate humain (Tier 1 — agent diagnostique/propose seulement) :
+
 1. `terraform apply` (agent fournit plan revu) — F1
 2. `ansible-playbook -i ansible/inventory.ini ansible/playbook.yml` prod — F1
 3. DNS A→IP VPS, ouvrir 80/443, `ACME_EMAIL` dans `.env` prod — F2

--- a/docs/agent-activity/2026-05-19-wbs-a5.md
+++ b/docs/agent-activity/2026-05-19-wbs-a5.md
@@ -1,0 +1,80 @@
+# Agent activity — 2026-05-19 — WBS WP-A5 (EXP-007 etat_date Decimal)
+
+**Persona :** backend/Rust agent (Tier 2 — implémente + 4-cat RED-first.
+Pas de mutation prod, pas de force-push, pas de `--no-verify`).
+
+**Branche :** `story/wbs-a5-etat-date` (depuis `origin/feature/dev`, **sans
+A4/FE1** — séparation confirmée). Branche dédiée sous autorisation
+permanente humaine (suite WBS, un WP par branche/PR).
+
+**Scope :** WBS Track A, WP-A5 — `#433` EXP-007, « plus gros résidu f64 »
+de l'umbrella. Slice **cohérente WP-A3/A4** : entité domaine typée + pont
+`From<_> for String` + `From<_> for AppError` + migration f64→Decimal.
+**Scopé `etat_date`** (le vrai long-pole) ; `quote.rs` déjà Decimal-clean
+(amounts Decimal, `QuoteScore` f32 non-monétaire conservé) → son
+`Result<_,String>`→typed = même slice large différée (A3/A4), tracée.
+
+## Réalisé
+
+- `domain/entities/etat_date.rs` : suppression `use f64;` (l.2 parasite —
+  no-op confirmé par compile). **5 champs monétaires f64→`Decimal`**
+  (`owner_balance`, `arrears_amount`, `monthly_provision_amount`,
+  `total_balance`, `approved_works_unpaid`) ; init `Decimal::ZERO` ;
+  `update_financial_data` signature + bornes `< Decimal::ZERO`.
+  `unit_area: Option<f64>` **conservé** (mesure physique, ADR-0009).
+  Enum domaine pur `EtatDateError` (7 variantes) + `Display` + `impl Error`
+  - `From<_> for String` (pont) ; `new`/`mark_in_progress`/`mark_generated`/
+    `mark_delivered`/`update_financial_data`/`update_additional_data`
+    → `Result<_, EtatDateError>`. 2 assertions in-module migrées
+    `==`/`.contains()` → `matches!` ; littéraux f64 → `dec!()`.
+- `domain/entities/mod.rs` : export `EtatDateError`.
+- `application/error.rs` : `From<EtatDateError> for AppError` → Validation
+  400 (bloc en fin de section From, après `JournalEntryError`).
+- `application/dto/etat_date_dto.rs` : 5 champs f64→`Decimal`
+  (`UpdateEtatDateFinancialRequest` + `EtatDateResponse`). **Non
+  contract-visible** : DTO sans `ToSchema`/utoipa, absents de
+  `openapi.json` → aucun drift openapi/api.d.ts (gates verts sans regen).
+- `infrastructure/database/repositories/etat_date_repository_impl.rs` :
+  retrait des casts artificiels `::FLOAT8 AS` sur les 5 colonnes
+  monétaires (×7 SELECT, `replace_all`) — colonnes DB déjà `DECIMAL(12,2)`
+  (migration `20251115000000`, **aucune migration SQL**). `unit_area::FLOAT8`
+  et `avg_processing_days` conservés f64.
+- `tests/bdd_governance.rs` : steps `when_update_financial_data` +
+  scénario génération — accumulateurs f64→`Decimal`, parse cents
+  `Decimal::from_str(v)/100` (exact, sans dérive), littéraux → `Decimal::from`.
+- `tests/features/etat_date.feature` : taggé `@happy` + `@edge` +
+  commentaire (style A3/A4) renvoyant aux invariants unitaires typés.
+- 4-cat RED-first in-module (`etat_date.rs`) :
+  `happy_update_financial_data_decimal_exact`,
+  `edge_decimal_exactness_and_quota_boundary` (0.1+0.2=0.3 exact ; borne
+  quota 100% incluse), `negative_amount_and_transition_rejected`,
+  `security_tampered_quota_rejected` (quote-part falsifiée >100% rejetée —
+  intégrité acte Art. 577-2 CC).
+
+## Vérification (daemon Docker absent → fallback cargo hôte, CRITICAL.md #12)
+
+- `cargo check --lib --tests` (SQLX_OFFLINE) : **propre, 0 erreur** —
+  cascade f64→Decimal entièrement résolue (domaine/DTO/repo/use_cases/bdd) ;
+  pont String garde use-cases/ports/handlers compilants sans changement.
+- `cargo test --lib etat_date` : **24/24 verts** (dont 4 nouveaux 4-cat ;
+  use-cases via le pont OK).
+- `cargo fmt --check` sur fichiers touchés : **propre**.
+- openapi/api.d.ts régénérés : **aucun diff** (DTO non exposés au spec).
+- BDD/e2e etat_date : **exécutés en CI** (testcontainers — local
+  compile-check, même limite infra que WP-B1/A4, tracée).
+
+## Différé (slice large unique #433, identique A3/A4, tracé)
+
+- Cascade port/use-case/repo/handler `String`→`AppError` (pont conservé).
+- `quote.rs` typed-error (`QuoteError`) : quote déjà Decimal-correct
+  (PCMN-safe) ; son `Result<_,String>` = même slice différée. Non bloquant
+  DoD (la DoD exige l'exactitude Decimal, déjà satisfaite pour quote).
+- Réconciliation : 3 PR Track-A/FE1 locales (#542 A4, #543 FE1, ce A5)
+  empilées sur `feature/dev` — pas de création d'issue (gate Tier-1).
+
+## Critère GO (DoD bêta) adressé
+
+- `#433` EXP-007 : `etat_date` 100% `Decimal` + erreur typée mappée
+  `AppError` (400). Aucun `Result<_,String>`/`unwrap`/`expect` hors
+  `#[cfg(test)]` introduit sur les fichiers touchés. 4-cat RED-first
+  présents. Plus gros résidu f64 de l'umbrella résorbé.


### PR DESCRIPTION
## Summary

WBS go-live v0.1.0 — **WP-A5 (#433 EXP-007 etat_date)** : le « plus gros résidu f64 » de l'umbrella. Branche dédiée (autorisation permanente WBS), baseline `feature/dev` sans A4/FE1. Slice cohérente WP-A3/A4.

- **Aucune migration SQL** : colonnes déjà `DECIMAL(12,2)` (migration `20251115000000`). Le bug = casts artificiels `::FLOAT8` au SELECT alimentant des champs `f64` d'entité.
- `etat_date.rs` : `use f64;` parasite retiré ; **5 champs monétaires f64→`Decimal`** (`owner_balance`, `arrears_amount`, `monthly_provision_amount`, `total_balance`, `approved_works_unpaid`). `unit_area` conservé `f64` (mesure physique, ADR-0009). Enum domaine pur `EtatDateError` (7 var.) + `Display` + `impl Error` + `From<_> for String` (pont) + `From<EtatDateError> for AppError` → `Validation` 400. Toutes les méthodes `Result<_, String>` → `Result<_, EtatDateError>`.
- DTO 5 champs f64→`Decimal` (**non contract-visible** : DTO sans `ToSchema`, absents d'`openapi.json` → zéro drift openapi/api.d.ts, gates verts sans regen).
- Repo : casts `::FLOAT8 AS` retirés sur les 5 colonnes monétaires (×7 SELECT) ; `unit_area`/`avg_processing_days` conservés f64.
- `bdd_governance.rs` : steps financiers → `Decimal` exact (cents/100 sans dérive f64).
- État daté = acte légal **Art. 577-2 CC** : zéro dérive d'arrondi désormais.

### Scope
**etat_date** (le vrai long-pole). `quote.rs` est déjà Decimal-clean (montants `Decimal`, `QuoteScore` f32 non-monétaire conservé) → son `Result<_,String>`→typed (`QuoteError`) = même slice large différée que A3/A4 (non bloquant DoD : l'exactitude Decimal, ce que la DoD exige, est déjà satisfaite pour quote).

## Test plan

- [x] `cargo check --lib --tests` (SQLX_OFFLINE) propre — cascade f64→Decimal entièrement résolue (domaine/DTO/repo/use_cases/bdd)
- [x] `cargo test --lib etat_date` — 24/24 (dont 4 nouveaux 4-cat)
- [x] `cargo fmt --check` fichiers touchés — propre
- [x] openapi/api.d.ts régénérés — aucun diff (DTO non exposés)
- [ ] CI : Unit/BDD/Contract/E2E — gate (BDD/e2e etat_date exécutés en CI testcontainers ; daemon Docker absent en session, fallback hôte conforme CRITICAL.md #12)

### 4-cat RED-first (in-module `etat_date.rs`)
- `@happy` màj financière Decimal exacte · `@edge` 0.1+0.2=0.3 exact & borne quota 100% incluse · `@negative` montant négatif interdit & transition workflow invalide · `@security` quote-part falsifiée >100 % rejetée (intégrité de l'acte opposable). `etat_date.feature` taggée `@happy`/`@edge` + commentaire style A3/A4.

> Tier-2, pas de mutation prod. Log : `docs/agent-activity/2026-05-19-wbs-a5.md`. Réf WBS WP-A5. Différé : cascade port/use-case/handler `String`→`AppError` ; `QuoteError` (umbrella).

https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP)_