### PR TITLE
feat(backend): #433 WP-A6 EXP-008 contributions/calls — typed domain errors

### DIFF
--- a/backend/src/application/error.rs
+++ b/backend/src/application/error.rs
@@ -191,6 +191,24 @@ impl From<crate::domain::entities::JournalEntryError> for AppError {
     }
 }
 
+impl From<crate::domain::entities::OwnerContributionError> for AppError {
+    /// Une contribution malformée (montant négatif, description vide) est
+    /// une erreur d'entrée client → 400 validation, **jamais** 500 Internal
+    /// (#433 / WP-A6 EXP-008).
+    fn from(e: crate::domain::entities::OwnerContributionError) -> Self {
+        AppError::Validation(e.to_string())
+    }
+}
+
+impl From<crate::domain::entities::CallForFundsError> for AppError {
+    /// Un appel de fonds malformé (montant ≤ 0, titre/description vide,
+    /// échéance ≤ appel) est une erreur d'entrée client → 400 validation,
+    /// **jamais** 500 Internal (#433 / WP-A6 EXP-008).
+    fn from(e: crate::domain::entities::CallForFundsError) -> Self {
+        AppError::Validation(e.to_string())
+    }
+}
+
 // ============================================================================
 // Tests — taxonomie 4 catégories obligatoire (cf. CRITICAL.md règle #3, #427)
 // ============================================================================

--- a/backend/src/domain/entities/call_for_funds.rs
+++ b/backend/src/domain/entities/call_for_funds.rs
@@ -66,6 +66,46 @@ pub struct CallForFunds {
     pub created_by: Option<Uuid>,
 }
 
+/// Domain-typed validation error for calls for funds (appel de fonds).
+///
+/// Pure domain type — no infra/application dependency (hexagonal purity).
+/// Précédent `JournalEntryError`/`ChargeDistributionError` (#433 / WP-A6
+/// EXP-008) → 400 validation, jamais 500 Internal.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CallForFundsError {
+    /// Montant total non strictement positif.
+    NonPositiveTotalAmount,
+    /// Titre vide.
+    EmptyTitle,
+    /// Description vide.
+    EmptyDescription,
+    /// Date d'échéance ≤ date d'appel (fenêtre de paiement invalide).
+    DueDateNotAfterCallDate,
+}
+
+impl std::fmt::Display for CallForFundsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonPositiveTotalAmount => write!(f, "Total amount must be positive"),
+            Self::EmptyTitle => write!(f, "Title cannot be empty"),
+            Self::EmptyDescription => write!(f, "Description cannot be empty"),
+            Self::DueDateNotAfterCallDate => {
+                write!(f, "Due date must be after call date")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CallForFundsError {}
+
+/// Bridge : use-cases/ports `Result<_, String>` inchangés (cascade
+/// String→AppError = slice large différée, précédent WP-A3/A4/A5).
+impl From<CallForFundsError> for String {
+    fn from(e: CallForFundsError) -> String {
+        e.to_string()
+    }
+}
+
 impl CallForFunds {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -78,25 +118,25 @@ impl CallForFunds {
         call_date: DateTime<Utc>,
         due_date: DateTime<Utc>,
         account_code: Option<String>,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, CallForFundsError> {
         // Validate total amount is positive
         if total_amount <= Decimal::ZERO {
-            return Err("Total amount must be positive".to_string());
+            return Err(CallForFundsError::NonPositiveTotalAmount);
         }
 
         // Validate title
         if title.trim().is_empty() {
-            return Err("Title cannot be empty".to_string());
+            return Err(CallForFundsError::EmptyTitle);
         }
 
         // Validate description
         if description.trim().is_empty() {
-            return Err("Description cannot be empty".to_string());
+            return Err(CallForFundsError::EmptyDescription);
         }
 
         // Validate dates
         if due_date <= call_date {
-            return Err("Due date must be after call date".to_string());
+            return Err(CallForFundsError::DueDateNotAfterCallDate);
         }
 
         Ok(Self {
@@ -191,8 +231,10 @@ mod tests {
             None,
         );
 
-        assert!(call.is_err());
-        assert!(call.unwrap_err().contains("must be positive"));
+        assert!(matches!(
+            call.unwrap_err(),
+            CallForFundsError::NonPositiveTotalAmount
+        ));
     }
 
     #[test]
@@ -212,8 +254,10 @@ mod tests {
             None,
         );
 
-        assert!(call.is_err());
-        assert!(call.unwrap_err().contains("Due date must be after"));
+        assert!(matches!(
+            call.unwrap_err(),
+            CallForFundsError::DueDateNotAfterCallDate
+        ));
     }
 
     #[test]
@@ -262,5 +306,70 @@ mod tests {
         .unwrap();
 
         assert!(call.is_overdue());
+    }
+
+    // ------------------------------------------------------------------------
+    // 4 catégories #433/WP-A6 EXP-008 — erreur typée (CRITICAL.md #3).
+    // Entité déjà Decimal (ADR-0007) ; ce WP type l'erreur domaine.
+    // ------------------------------------------------------------------------
+
+    fn mk(amount: Decimal, days: i64) -> Result<CallForFunds, CallForFundsError> {
+        let call_date = Utc::now();
+        CallForFunds::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "Appel".to_string(),
+            "Charges".to_string(),
+            amount,
+            ContributionType::Regular,
+            call_date,
+            call_date + chrono::Duration::days(days),
+            None,
+        )
+    }
+
+    /// @happy — appel nominal : total_amount Decimal exact.
+    #[test]
+    fn happy_total_amount_decimal_exact() {
+        let c = mk(rust_decimal_macros::dec!(9876.54), 30).unwrap();
+        assert_eq!(c.total_amount, rust_decimal_macros::dec!(9876.54));
+        assert_eq!(c.status, CallForFundsStatus::Draft);
+    }
+
+    /// @edge — montant minimal strictement positif accepté ; exactitude
+    /// Decimal sur cumul (0.1+0.2=0.3, f64 échoue).
+    #[test]
+    fn edge_min_positive_and_decimal_exactness() {
+        assert!(mk(rust_decimal_macros::dec!(0.01), 1).is_ok());
+        let c = mk(
+            rust_decimal_macros::dec!(0.1) + rust_decimal_macros::dec!(0.2),
+            7,
+        )
+        .unwrap();
+        assert_eq!(c.total_amount, rust_decimal_macros::dec!(0.3));
+    }
+
+    /// @negative — total ≤ 0, titre/description vides, échéance ≤ appel
+    /// rejetés (erreurs typées, pas de panic).
+    #[test]
+    fn negative_invalid_inputs_rejected() {
+        assert!(matches!(
+            mk(Decimal::ZERO, 30).unwrap_err(),
+            CallForFundsError::NonPositiveTotalAmount
+        ));
+        assert!(matches!(
+            mk(rust_decimal_macros::dec!(100), -1).unwrap_err(),
+            CallForFundsError::DueDateNotAfterCallDate
+        ));
+    }
+
+    /// @security — un appel de fonds falsifié à montant nul/négatif
+    /// (collecte fantôme) ne peut jamais être créé.
+    #[test]
+    fn security_tampered_nonpositive_amount_rejected() {
+        assert!(matches!(
+            mk(rust_decimal_macros::dec!(-1), 30).unwrap_err(),
+            CallForFundsError::NonPositiveTotalAmount
+        ));
     }
 }

--- a/backend/src/domain/entities/mod.rs
+++ b/backend/src/domain/entities/mod.rs
@@ -68,7 +68,7 @@ pub use board_decision::{BoardDecision, DecisionStatus};
 pub use board_member::{BoardMember, BoardPosition};
 pub use budget::{Budget, BudgetStatus};
 pub use building::Building;
-pub use call_for_funds::{CallForFunds, CallForFundsStatus};
+pub use call_for_funds::{CallForFunds, CallForFundsError, CallForFundsStatus};
 pub use challenge::{Challenge, ChallengeProgress, ChallengeStatus, ChallengeType};
 pub use charge_distribution::ChargeDistribution;
 pub use consent::{ConsentRecord, ConsentStatus};
@@ -107,6 +107,7 @@ pub use organization::{Organization, SubscriptionPlan};
 pub use owner::Owner;
 pub use owner_contribution::{
     ContributionPaymentMethod, ContributionPaymentStatus, ContributionType, OwnerContribution,
+    OwnerContributionError,
 };
 pub use owner_credit_balance::{CreditStatus, OwnerCreditBalance, ParticipationLevel};
 pub use payment::{Payment, PaymentMethodType, TransactionStatus};

--- a/backend/src/domain/entities/owner_contribution.rs
+++ b/backend/src/domain/entities/owner_contribution.rs
@@ -96,6 +96,43 @@ pub struct OwnerContribution {
     pub created_by: Option<Uuid>,
 }
 
+/// Domain-typed validation error for owner contributions (PCMN classe 7).
+///
+/// Pure domain type — no infra/application dependency (hexagonal purity).
+/// Précédent `JournalEntryError`/`ChargeDistributionError` : l'entité
+/// renvoie son erreur typée, l'application la mappe vers `AppError`
+/// (#433 / WP-A6 EXP-008) → 400 validation, jamais 500 Internal.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OwnerContributionError {
+    /// Montant négatif (un revenu entrant ne peut être < 0).
+    NonPositiveAmount,
+    /// Description vide.
+    EmptyDescription,
+}
+
+impl std::fmt::Display for OwnerContributionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonPositiveAmount => write!(
+                f,
+                "Contribution amount must be positive (revenue = money coming IN)"
+            ),
+            Self::EmptyDescription => write!(f, "Description cannot be empty"),
+        }
+    }
+}
+
+impl std::error::Error for OwnerContributionError {}
+
+/// Bridge : use-cases/ports `Result<_, String>` inchangés pendant que
+/// l'entité est typée (cascade String→AppError = slice large différée,
+/// précédent WP-A3/A4/A5). Pur, std-only.
+impl From<OwnerContributionError> for String {
+    fn from(e: OwnerContributionError) -> String {
+        e.to_string()
+    }
+}
+
 impl OwnerContribution {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -107,17 +144,15 @@ impl OwnerContribution {
         contribution_type: ContributionType,
         contribution_date: DateTime<Utc>,
         account_code: Option<String>,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, OwnerContributionError> {
         // Validate amount is positive (revenue = money coming IN)
         if amount < Decimal::ZERO {
-            return Err(
-                "Contribution amount must be positive (revenue = money coming IN)".to_string(),
-            );
+            return Err(OwnerContributionError::NonPositiveAmount);
         }
 
         // Validate description
         if description.trim().is_empty() {
-            return Err("Description cannot be empty".to_string());
+            return Err(OwnerContributionError::EmptyDescription);
         }
 
         Ok(Self {
@@ -204,8 +239,10 @@ mod tests {
             None,
         );
 
-        assert!(contrib.is_err());
-        assert!(contrib.unwrap_err().contains("must be positive"));
+        assert!(matches!(
+            contrib.unwrap_err(),
+            OwnerContributionError::NonPositiveAmount
+        ));
     }
 
     #[test]
@@ -221,8 +258,10 @@ mod tests {
             None,
         );
 
-        assert!(contrib.is_err());
-        assert!(contrib.unwrap_err().contains("Description cannot be empty"));
+        assert!(matches!(
+            contrib.unwrap_err(),
+            OwnerContributionError::EmptyDescription
+        ));
     }
 
     #[test]
@@ -273,5 +312,110 @@ mod tests {
         .unwrap();
 
         assert!(contrib.is_overdue());
+    }
+
+    // ------------------------------------------------------------------------
+    // 4 catégories #433/WP-A6 EXP-008 — erreur typée (CRITICAL.md #3).
+    // Entité déjà Decimal (PCMN classe 7) ; ce WP type l'erreur domaine.
+    // ------------------------------------------------------------------------
+
+    /// @happy — contribution nominale : montant Decimal exact conservé.
+    #[test]
+    fn happy_contribution_amount_decimal_exact() {
+        let c = OwnerContribution::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            "Provision Q1".to_string(),
+            rust_decimal_macros::dec!(1234.56),
+            ContributionType::Regular,
+            Utc::now(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(c.amount, rust_decimal_macros::dec!(1234.56));
+    }
+
+    /// @edge — montant exactement zéro accepté (revenu nul, borne incluse) ;
+    /// addition Decimal exacte (0.1+0.2=0.3, f64 échoue).
+    #[test]
+    fn edge_zero_amount_and_decimal_exactness() {
+        let zero = OwnerContribution::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            "Régularisation nulle".to_string(),
+            Decimal::ZERO,
+            ContributionType::Regular,
+            Utc::now(),
+            None,
+        );
+        assert!(zero.is_ok());
+
+        let c = OwnerContribution::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            "x".to_string(),
+            rust_decimal_macros::dec!(0.1) + rust_decimal_macros::dec!(0.2),
+            ContributionType::Regular,
+            Utc::now(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(c.amount, rust_decimal_macros::dec!(0.3));
+    }
+
+    /// @negative — montant négatif & description vide rejetés (erreur typée).
+    #[test]
+    fn negative_amount_and_empty_description_rejected() {
+        assert!(matches!(
+            OwnerContribution::new(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                None,
+                "ok".to_string(),
+                rust_decimal_macros::dec!(-0.01),
+                ContributionType::Regular,
+                Utc::now(),
+                None,
+            )
+            .unwrap_err(),
+            OwnerContributionError::NonPositiveAmount
+        ));
+        assert!(matches!(
+            OwnerContribution::new(
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                None,
+                "  ".to_string(),
+                rust_decimal_macros::dec!(10),
+                ContributionType::Regular,
+                Utc::now(),
+                None,
+            )
+            .unwrap_err(),
+            OwnerContributionError::EmptyDescription
+        ));
+    }
+
+    /// @security — un montant de revenu falsifié négatif (détournement
+    /// comptable PCMN classe 7) ne peut jamais être persisté.
+    #[test]
+    fn security_tampered_negative_revenue_rejected() {
+        let result = OwnerContribution::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            None,
+            "Faux avoir".to_string(),
+            rust_decimal_macros::dec!(-99999.99),
+            ContributionType::Regular,
+            Utc::now(),
+            None,
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            OwnerContributionError::NonPositiveAmount
+        ));
     }
 }

--- a/backend/tests/features/call_for_funds.feature
+++ b/backend/tests/features/call_for_funds.feature
@@ -13,6 +13,16 @@ Feature: Call for Funds
     And a building "Residence Appel" with 4 units exists in organization "org-appel"
     And 4 owners with ownership percentages exist
 
+  # 4 catégories (#433/WP-A6 EXP-008). total_amount Decimal exact (ADR-0007).
+  # @edge (montant minimal / exactitude Decimal), @negative (total ≤ 0,
+  # titre/description vide, échéance ≤ appel) et @security (appel falsifié
+  # à montant ≤ 0 rejeté) sont des invariants de l'entité domaine, vérifiés
+  # par les tests unitaires typés `edge_min_positive_and_decimal_exactness`,
+  # `negative_invalid_inputs_rejected`,
+  # `security_tampered_nonpositive_amount_rejected` (call_for_funds.rs) — le
+  # glue BDD utilise des données valides (précédent WP-A3/A4/A5).
+
+  @happy
   Scenario: Create a call for funds
     When I create a call for funds:
       | title              | Charges Q1 2026           |
@@ -49,6 +59,7 @@ Feature: Call for Funds
     When I delete the call for funds
     Then the call should be deleted
 
+  @edge
   Scenario: Cannot delete a sent call for funds
     Given a sent call for funds exists
     When I try to delete the sent call for funds

--- a/backend/tests/features/owner_contributions.feature
+++ b/backend/tests/features/owner_contributions.feature
@@ -13,6 +13,17 @@ Feature: Owner Contributions
     And a building "Residence Contribution" exists in organization "org-contrib"
     And an owner "Marie Payeuse" exists with a unit in the building
 
+  # 4 catégories (#433/WP-A6 EXP-008). Montant Decimal exact (PCMN classe 7).
+  # @edge (montant zéro / exactitude Decimal), @negative (montant négatif,
+  # description vide) et @security (revenu falsifié négatif rejeté) sont des
+  # invariants de l'entité domaine, vérifiés par les tests unitaires typés
+  # `edge_zero_amount_and_decimal_exactness`,
+  # `negative_amount_and_empty_description_rejected`,
+  # `security_tampered_negative_revenue_rejected` (owner_contribution.rs) —
+  # le glue BDD utilise des données valides et ne peut donc pas exercer
+  # comportementalement ces rejets ici (précédent WP-A3/A4/A5).
+
+  @happy
   Scenario: Create an owner contribution
     When I create a contribution for "Marie Payeuse":
       | description        | Charges trimestrielles Q1 |
@@ -45,6 +56,7 @@ Feature: Owner Contributions
     Then the payment status should be "Paid"
     And the payment date should be set
 
+  @edge
   Scenario: Cannot pay an already-paid contribution
     Given a paid contribution exists
     When I try to mark it as paid again

--- a/docs/WBS_GO_LIVE_v0.1.0.md
+++ b/docs/WBS_GO_LIVE_v0.1.0.md
@@ -2,7 +2,7 @@
 
 `WBS-v0.1.0-beta-r1` · 2026-05-16 · base : `feature/dev` + branche `story/521-C1-governance-decimal` (HEAD `98c1651`, 1 commit devant `origin/feature/dev`).
 
-> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont *référencés*, pas créés.
+> **Provenance & portée** : artefact de planification (Tier 2, logué). Aucune issue/milestone GitHub créée (forme « document WBS versionné unique » choisie pour éviter le gate Tier-1). Les numéros d'issues sont _référencés_, pas créés.
 >
 > **Supersession** : ce document remplace, pour le go-live, les WBS périmés du 2026-04-01 — [`WBS_RELEASE_0_1_0.md`](WBS_RELEASE_0_1_0.md), [`WBS_BUGFIX_UI_v0.1.0.md`](WBS_BUGFIX_UI_v0.1.0.md), [`WBS_CORRECTIONS_v0.1.0.md`](WBS_CORRECTIONS_v0.1.0.md) — qui restent valables comme contexte historique mais ne reflètent plus l'état du code (Story A Decimal mergée, #515 mergé, TLS déjà câblé).
 
@@ -11,6 +11,7 @@
 KoproGo v0.1.0 n'a jamais été taggé ni mis en ligne (aucun tag git, aucune release). Le besoin : **mettre v0.1.0 en ligne en bêta privée fermée (5-10 copropriétés)** avec une infrastructure opérationnelle réelle et tous les tests requis (4 catégories `@happy/@edge/@security/@negative`, RED-first). Le rapport de revue humaine `docs/HUMAN_REVIEW_REPORT_v0.1.0.md` date du **2026-04-01 (~6 semaines, périmé)** et concluait NO-GO public / GO-conditionnel bêta — il doit être **re-rejoué** sur le code courant, pas pris pour argent comptant (plusieurs bugs sont probablement déjà corrigés : #523 dashboard %, #521 Story A mergée).
 
 Décisions produit verrouillées :
+
 1. **Déploiement : VPS d'abord, puis k3s en Phase 2.** Phase 1 = OVH VPS + docker-compose (`infrastructure/monosite/vps/production`, poller systemd `gitops-deploy.sh`). k3s/ArgoCD = Phase 2 post-v0.1.0.
 2. **Périmètre : bêta privée fermée.** Gate = bloquants critiques (sécurité réelle mais allégée vs gate public #427).
 3. **Decimal : umbrella #433 COMPLÈTE** (EXP-003..008 + gouvernance C1 #521/#534/#525). Exactitude PCMN obligatoire même en bêta.
@@ -18,16 +19,16 @@ Décisions produit verrouillées :
 
 ## Faits vérifiés (corrigent le chemin critique — ne pas re-dériver)
 
-| Hypothèse initiale | Réalité vérifiée (code) | Impact |
-|---|---|---|
-| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL. |
-| EXP-005 `charge_distribution` à faire | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`) | `Result→AppError` + BDD 4-cat seulement |
-| #453 TLS = bloquant go-live | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
-| #515 5 gaps ArgoCD bloquants | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s | Phase 2 |
-| Migration gouvernance large | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode |
-| EXP-007 `etat_date` mineur | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC) | WP-A5 = item le plus long de Track A |
-| #443 cascade énorme | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e_*.rs | Cascade réelle mais bornée |
-| JWT stockage | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage` | **Bloquant sécurité bêta fermée** confirmé |
+| Hypothèse initiale                                   | Réalité vérifiée (code)                                                                                                                                                                                                                          | Impact                                                                                                                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| EXP-006 `journal_entry` = gros chantier PRIORITÉ MAX | **Déjà `Decimal`** : `journal_entry.rs:69-78` debit/credit `Decimal`, `BALANCE_TOLERANCE=dec!(0.011)`, validation débit==crédit exacte ; SQL déjà `DECIMAL(12,2)` + trigger DB                                                                   | Long pole se réduit : reste `Result<_,String>`→`AppError` + BDD 4-cat. Pas de migration SQL.                                                  |
+| EXP-005 `charge_distribution` à faire                | Déjà `Decimal` (tolérances `dec!(1.0001)`/`dec!(0.01)`)                                                                                                                                                                                          | `Result→AppError` + BDD 4-cat seulement                                                                                                       |
+| #453 TLS = bloquant go-live                          | `infrastructure/monosite/vps/production/docker-compose.override.yml:10-40` **câble déjà Traefik + Let's Encrypt ACME HTTP-01** (443, redirect http→https, certresolver backend+frontend) ; `ACME_EMAIL` dans `.env.example` + ansible group_vars | **TLS PAS bloquant.** Go-live n'exige que : DNS A→IP VPS, ports 80/443 ouverts, `ACME_EMAIL` set. #453 (DNS-01 non-prod + SOPS/age) = Phase 2 |
+| #515 5 gaps ArgoCD bloquants                         | **Mergés sur `origin/main`** (PR #516, `645b3cb`/`badb049`) — concernent k3s                                                                                                                                                                     | Phase 2                                                                                                                                       |
+| Migration gouvernance large                          | `20260516000000_alter_governance_to_numeric.sql` minimale/correcte : `units.quota` + `meetings.total/present_quotas`→`NUMERIC(10,4)`, idempotente, no-down, no prod data                                                                         | DDL petite/sûre ; risque = call-sites + #525 ColumnDecode                                                                                     |
+| EXP-007 `etat_date` mineur                           | `etat_date.rs` = **17 occ. f64** (plus gros résidu umbrella, doc légal Art. 577 CC)                                                                                                                                                              | WP-A5 = item le plus long de Track A                                                                                                          |
+| #443 cascade énorme                                  | `bdd_financial.rs` ~23 occ. f64 (pas 120) + e2e\_\*.rs                                                                                                                                                                                           | Cascade réelle mais bornée                                                                                                                    |
+| JWT stockage                                         | `frontend/src/stores/auth.ts:139-141` (read) / `233-235` (write) / `169-192` (refresh) en `localStorage`                                                                                                                                         | **Bloquant sécurité bêta fermée** confirmé                                                                                                    |
 
 **Vrai long pole = WP-A2 (#443 cascade tests) → WP-A5 (EXP-007 etat_date)**, à paralléliser avec la chaîne Ops-VPS (latence Tier-1 humaine).
 
@@ -37,43 +38,44 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track A — Backend Decimal
 
-- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · *critique, premier*
+- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · _critique, premier_
   Appliquer `backend/migrations/20260516000000_alter_governance_to_numeric.sql` (DB test) ; `bdd_governance` 4 scénarios VERTS ; tuer le panic #525 ColumnDecode `units.quota`. Décisions bloquantes : (a) **ADR-0008 ratio** pour proxy validation `vote.rs:~312-342` (draft `docs/agent-activity/2026-05-16-adr8-noncompliance-body.md`) ; (b) **politique f64 d'affichage** — `resolution.rs:185-212` `pour/contre/abstention_percentage()` renvoient `f64` depuis comptes entiers : **reco = carve-out ADR-0008 explicite (affichage seul, jamais seuil légal)** + assertion que le chemin quorum/majorité légal n'a aucun aller-retour Decimal→f64→Decimal. Fichiers : la migration, `tests/bdd_governance.rs`, `features/governance_decimal.feature`, `entities/{vote,resolution,meeting,age_request}.rs`, repos impl correspondants. Deps : aucune.
 
-- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · *critique* · **FAIT** (#539 + reconfirmé 2026-05-18)
+- **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · _critique_ · **FAIT** (#539 + reconfirmé 2026-05-18)
   `docker compose run --rm backend cargo check --tests` propre (`--lib` déjà propre). Literals f64→`dec!()` aux call-sites, assertions Decimal-equality, zéro régression scénario @security/@negative. Fichiers : `tests/bdd_financial.rs` (~23 occ.), `tests/e2e_*.rs`, glue `features/*.feature`. Deps : conventions WP-A1. **Concurrent Track F.**
   **Reconfirmé** (post-merge 5 PR + WP-B3 + #526) : `cargo check --tests` **CHECK_EXIT=0**, 0 erreur, aucune cascade f64/Decimal résiduelle (1 warning amont `proc-macro-error2`, non-bloquant). Suite BDD 100% verte (G1/G2/OPS/COM/FIN=0) ⇒ zéro régression @security/@negative confirmée. **Critère GO « `cargo check --tests` propre » atteint.**
 
 - **WP-A3 — EXP-006 journal_entry (réduit)** · #433 · T2 · M
   `Result<_,String>`→`AppError` sur `JournalEntry/JournalEntryLine`. `features/journal_entries.feature` 4-cat RED-first : @negative **débit≠crédit rejeté**, @edge 0.1+0.2=0.3, @security isolation cross-org, @happy écriture équilibrée. Pas de SQL. Deps : A1, A2.
 
-- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · *parallèle A3*
+- **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · _parallèle A3_
   `Result→AppError` ; 4-cat : @security somme quotas==100% à `dec!(1.0001)`, @negative quota>1/négatif rejeté. Deps : A1.
 
 - **WP-A5 — EXP-007 quote/etat_date (Art. 577 CC, plus gros résidu)** · #433 · T2 · L
   f64→Decimal `etat_date` (17 occ.) + `quote` + DTO/use_case/repo ; migration SQL **seulement si** colonnes `DOUBLE PRECISION` (vérifier `20251115000000_create_etats_dates.sql`, `20251120150000_create_quotes.sql`) ; `Result→AppError` ; 4-cat `etat_date.feature`/`quotes.feature`. Deps : A1, A2.
 
-- **WP-A6 — EXP-008 owner_contribution/call_for_funds/gamification** · #433 · T2 · M
+- **WP-A6 — EXP-008 owner_contribution/call_for_funds/gamification** · #433 · T2 · M · **FAIT** (2026-05-19, branche `story/wbs-a6-exp008`)
   Monétaire→Decimal+AppError+4-cat. Gamification/ratings = scores non-PCMN → carve-out ADR-0008, f64 conservé (@happy+@negative légers). Deps : A1, A2.
+  **Réalisé** (slice cohérente WP-A4 — entités **déjà Decimal**, aucune migration f64) : enums domaine purs `OwnerContributionError` (2 var.) + `CallForFundsError` (4 var.) + ponts `From<_> for String` + `From<_> for AppError`→Validation 400 (blocs après `JournalEntryError`). `new()` des 2 entités → `Result<_, …Error>`, assertions `.contains()`→`matches!`. 4-cat RED-first in-module (happy Decimal exact / edge borne+0.1+0.2=0.3 / negative entrées invalides / security montant falsifié ≤0 rejeté) + features `owner_contributions`/`call_for_funds` taggées `@happy`/`@edge` (commentaire style A3/A4/A5). **Carve-out gamification confirmé** : aucun champ monétaire f64 ; seul résidu `challenge.rs:401` = % progression non-PCMN, f64 conservé (ADR-0008). `cargo check --lib --tests` propre, `owner_contribution` 14/14, `call_for_funds` 16/16, fmt propre (fallback hôte — daemon Docker absent). Log `docs/agent-activity/2026-05-19-wbs-a6.md`. **Différé** : cascade port/use-case/handler `String`→`AppError`. **⇒ Umbrella #433 EXP-005/006/007/008 désormais Decimal + erreurs domaine typées.**
 
 - **WP-A7 — Finaliser ADR-0008 + politique #526/#339** · #526/#339/ADR-0008 · T2 (accept=humain) · M
   (a) ADR-0008 finalisé (ratio + %-affichage + carve-out gamification). (b) #526 : garder `expenses_amount_check > 0`, modéliser les annulations en contre-écritures journal (pas de relâche schéma), documenter. (c) #339 rotate 501 `api_key_handlers.rs:506` : **reco = implémenter rotate minimal** derrière 4-cat (@security ancienne clé invalide post-rotate, @negative rotate non-propriétaire→403) ; alternative = retirer la route + documenter pour qu'aucun 501 ne parte en bêta.
 
 ### Track B — Backend autre
 
-- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1*
+- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1\*
   Re-jouer `HUMAN_REVIEW_REPORT_v0.1.0.md` comme checklist vs `feature/dev` courant : **BUG-WF14-2 fuite bâtiments cross-org (Alice voit 3 bâtiments) = bloquant sécurité bêta si reproductible** — tracer scoping `organization_id` repo buildings ; BUG-WF2-1 `voting_power≤1000` vs seed>1280 (vérifier `20260401000000_fix_voting_power_constraint.sql`) ; BUG-WF7-1 ticket 400 ; NaN% compteurs (probablement corrigé par #523 `7c2d664` — vérifier). Repro RED par bug confirmé. Deps : aucune.
 
-- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · *parallèle* · **FAIT** (PR #538)
+- **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · _parallèle_ · **FAIT** (PR #538)
   Réalité : #432 = 100% npm/frontend (le "14 vulns" était périmé). `svelte 5.55.7` + `devalue 5.8.1` → 5 alertes résolues, `npm audit --omit=dev` = 0, build vert. Résiduel 1 HIGH `@babel/plugin-transform-modules-systemjs` (devDependency build-only, `audit fix --force` breaking → accepté/documenté). `cargo audit` (RustSec) exit 0 modulo ignores `.cargo/audit.toml`. Fichiers : `frontend/package-lock.json`. Deps : aucune.
 
-- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · *débruite le gate* · **FAIT** (PR #541)
+- **WP-B3 — Triage BDD pré-existants révélés par #524** · **#540** /#524/#443/#526/#534 · T2 · L · _débruite le gate_ · **FAIT** (PR #541)
   Le fix #524 a rendu le harness honnête → ~27 scénarios BDD pré-existants rouges sur 8 groupes (CI run `25982956110`) bruitent **toute** PR : « Meeting Resolutions » 14/14 (quorum Art. 3.87 §5 ordre workflow), Board CdC mandat ×5 (Art. 3.89 assertion vs règle), Energy/Notice/CallForFunds/Gamification ×6 (seeds/asserts), Stats ×2 (= #526). **Issue de tracking consolidée = #540** (inventaire complet + critères) ; un sous-fix RED-first 4-cat par groupe (P1 = Meeting Resolutions + Board mandat, légalement sensibles ; P2 = seeds/asserts ; Stats = #526 séparé). Aucun fix « comme ça » — comprendre la cause (test faux / prod faux / spec obsolète). Deps : aucune (parallèle). **Prérequis du jugement BDD propre en G1.**
-  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle *syndic* Art. 3.89 1–3 ans au *conseil de copropriété*, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
+  **Réalisé** (commit `73e4651`, validé local les 5 binaires BDD) : **P1-G1** = spec obsolète (resolutions.feature pré-#310/#323 : create_resolution exige quorum Art. 3.87 §5 ; + labels legacy Simple/Qualified jamais migrés vers l'enum belge) → Background quorum + alignement Absolute/TwoThirds + scénario @security ; `bdd_governance` 15/15. **P1-G2** = **bug prod** (board_member.rs appliquait la règle _syndic_ Art. 3.89 1–3 ans au _conseil de copropriété_, qui relève d'Art. 3.90 ~1 an ; DB+tests+legal_compliance.feature unanimes) → Full Option A (entité 330–395, DTO défaut 1095→365, use-cases, 17 tests 4-cat, 3 steps renew, réf Art.3.90) ; `bdd` board 23/23+13/13. **⚠ Suivi : la durée mandat conseil « ~1 an » est un choix de modélisation projet — Art. 3.90 réel laisse la durée à l'AG → ADR à signer (tracé sur #540).** **P2 ×6** = 6 bugs test (4 time-bomb dates hardcodées → helper `parse_seed_date` relatif ×3 binaires + 4 features en tokens `+Nd` ; 2 test-id : Notices author owner_id↔user_id, Energy uploads unit_id↔uploaded_by) ; ops/community/CallForFunds verts. **Infra** : `get_host()` ajouté à bdd/operations/community (pattern #535/#539) → 5 binaires BDD exécutables en local. **Critère #540 atteint** : seul rouge restant = #526 (Zero/Tiny, hors-scope, tracé). Zéro régression.
 
 ### Track C — Frontend sécurité (refacto #343 / SSR client:load DIFFÉRÉS post-bêta)
 
-- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · *critique*
+- **WP-FE1 — JWT hors localStorage (vol session XSS)** · BLOQUANT SÉCURITÉ · T2 · L · _critique_
   `auth.ts:128-235` : refresh token → cookie backend `HttpOnly; Secure; SameSite=Strict` ; access token en mémoire seule + silent-refresh au load. Backend login/refresh : set-cookie + read-cookie + CORS credentials. 4-cat RED-first : @security token illisible JS/`document.cookie` & absent localStorage ; @negative cookie forgé/expiré→401 ; @happy login→refresh→protégé ; @edge refresh à la borne d'expiration. Deps : coordination WP-B1 ; moitié backend nourrit moitié FE.
 
 - **WP-FE2 — Corriger bugs FE revue (WF1-1/2/3)** · T2 · M
@@ -89,7 +91,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track E — Tests IaC (sous-ensemble VPS de #354)
 
-- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · *100% parallèle*
+- **WP-E1 — Lint IaC minimal viable** · #354 · T2 · M · _100% parallèle_
   Job lint dans `ci-infra.yml`, assets VPS seulement : `terraform fmt -check`/`validate` (modules OVH + `monosite/vps/production/terraform`), `ansible-lint` (14 rôles + playbook prod), `yamllint`, `shellcheck` (**gate dur sur `gitops-deploy.sh`** — il exécute le déploiement prod). conftest/molecule/terratest = Phase 2. Deps : aucune.
 
 ### Track F — Ops VPS (concurrent Track A — aucun fichier partagé)
@@ -160,6 +162,7 @@ E1 (lint IaC) ─► F1 (TF/Ansible,T1) ─► F2 (TLS,T1) ─► F3 (poller,T1)
 ## Vérification — commandes exactes & gate humain
 
 Backend (agent) :
+
 ```
 docker compose run --rm backend cargo check --lib
 docker compose run --rm backend cargo check --tests        # propre post WP-A2
@@ -170,7 +173,9 @@ docker compose run --rm backend cargo test --no-fail-fast --test bdd --test bdd_
 docker compose run --rm backend cargo test --test e2e
 docker compose run --rm backend cargo audit                 # #432
 ```
+
 Frontend :
+
 ```
 docker compose run --rm frontend npm run build
 docker compose run --rm frontend npx svelte-check --threshold warning
@@ -179,13 +184,17 @@ docker compose run --rm frontend npx playwright test --project=chromium    # pla
 docker compose run --rm frontend npx playwright test --project=scenarios   # par-scénario
 docker compose run --rm frontend npx prettier --check .
 ```
+
 Gate push / contrat :
+
 ```
 make ci                # VERT obligatoire avant tout push
 make openapi-check     # si DTOs touchés
 make types-sync        # si spec changée
 ```
+
 IaC (post WP-E1) :
+
 ```
 terraform -chdir=infrastructure/monosite/vps/production/terraform fmt -check
 terraform -chdir=infrastructure/monosite/vps/production/terraform validate
@@ -193,7 +202,9 @@ ansible-lint infrastructure/monosite/vps/production/ansible/playbook.yml
 yamllint infrastructure/monosite/vps/production
 shellcheck infrastructure/_shared/scripts/gitops-deploy.sh
 ```
+
 Gate humain (Tier 1 — agent diagnostique/propose seulement) :
+
 1. `terraform apply` (agent fournit plan revu) — F1
 2. `ansible-playbook -i ansible/inventory.ini ansible/playbook.yml` prod — F1
 3. DNS A→IP VPS, ouvrir 80/443, `ACME_EMAIL` dans `.env` prod — F2

--- a/docs/agent-activity/2026-05-19-wbs-a6.md
+++ b/docs/agent-activity/2026-05-19-wbs-a6.md
@@ -1,0 +1,72 @@
+# Agent activity — 2026-05-19 — WBS WP-A6 (EXP-008 contributions/appels)
+
+**Persona :** backend/Rust agent (Tier 2 — implémente + 4-cat RED-first.
+Pas de mutation prod, pas de force-push, pas de `--no-verify`).
+
+**Branche :** `story/wbs-a6-exp008` (depuis `origin/feature/dev`, sans
+A4/FE1/A5 — séparation confirmée). Autorisation permanente humaine (suite
+WBS, un WP par branche/PR).
+
+**Scope :** WBS Track A, WP-A6 — `#433` EXP-008
+`owner_contribution`/`call_for_funds`/gamification. Slice **cohérente
+WP-A4** : les deux entités monétaires sont **déjà `Decimal`** (aucune
+migration f64) → uniquement `Result<_,String>`→erreur domaine typée +
+pont + `From<_> for AppError`. Gamification = carve-out ADR-0008.
+
+## Réalisé
+
+- `domain/entities/owner_contribution.rs` : enum domaine pur
+  `OwnerContributionError` (`NonPositiveAmount`, `EmptyDescription`) +
+  `Display` + `impl Error` + `From<_> for String` (pont) ; `new`
+  → `Result<_, OwnerContributionError>`. 2 assertions `.contains()`
+  → `matches!`. `amount` déjà `Decimal` (PCMN classe 7) — inchangé.
+- `domain/entities/call_for_funds.rs` : enum domaine pur
+  `CallForFundsError` (`NonPositiveTotalAmount`, `EmptyTitle`,
+  `EmptyDescription`, `DueDateNotAfterCallDate`) + `Display` + `impl
+Error` + `From<_> for String` ; `new` → `Result<_, CallForFundsError>`.
+  2 assertions `.contains()` → `matches!`. `total_amount` déjà `Decimal`
+  (ADR-0007) — inchangé.
+- `domain/entities/mod.rs` : exports `OwnerContributionError`,
+  `CallForFundsError`.
+- `application/error.rs` : `From<OwnerContributionError>` +
+  `From<CallForFundsError>` → `AppError::Validation` (400), blocs en fin
+  de section From après `JournalEntryError`.
+- 4-cat RED-first in-module (chaque entité) : `@happy` Decimal exact,
+  `@edge` borne (zéro / montant minimal) + 0.1+0.2=0.3, `@negative`
+  entrées invalides typées, `@security` montant falsifié ≤ 0 / négatif
+  rejeté (intégrité comptable — collecte fantôme / faux avoir).
+- `tests/features/{owner_contributions,call_for_funds}.feature` : taggés
+  `@happy` + `@edge` + commentaire (style A3/A4/A5) renvoyant aux
+  invariants unitaires typés.
+- **Gamification carve-out ADR-0008** : aucun champ monétaire f64 dans
+  `achievement`/`challenge`/`owner_credit_balance` ; seul résidu f64 =
+  `challenge.rs:401` `(current_value as f64 / target_value as f64 * 100)`
+  — **pourcentage de progression non-PCMN**, conservé f64 (carve-out
+  explicite ADR-0008, score de jeu jamais un montant légal). Aucun
+  changement, documenté ici.
+
+## Vérification (daemon Docker absent → fallback cargo hôte, CRITICAL.md #12)
+
+- `cargo check --lib --tests` (SQLX_OFFLINE) : **propre, 0 erreur** — pont
+  String garde use-cases/ports/handlers compilants sans changement.
+- `cargo test --lib owner_contribution` : **14/14** ; `cargo test --lib
+call_for_funds` : **16/16** (dont 4+4 nouveaux 4-cat ; use-cases via le
+  pont OK).
+- `cargo fmt --check` fichiers touchés : **propre**.
+- Aucun DTO modifié ⇒ zéro drift openapi/api.d.ts (gates verts).
+- BDD/e2e : **exécutés en CI** (testcontainers — local compile-check,
+  même limite infra que WP-A4/A5, tracée).
+
+## Différé (slice large unique #433, identique A3/A4/A5, tracé)
+
+- Cascade port/use-case/repo/handler `String`→`AppError` (pont conservé).
+- Réconciliation : PR Track-A/FE1 empilées sur `feature/dev`
+  (#542 A4, #543 FE1, #544 A5, ce A6) — pas de création d'issue (Tier-1).
+
+## Critère GO (DoD bêta) adressé
+
+- `#433` EXP-008 : `owner_contribution`/`call_for_funds` `Decimal` (déjà)
+  - erreur typée mappée `AppError` (400). Carve-out gamification documenté.
+    Aucun `Result<_,String>`/`unwrap`/`expect` hors `#[cfg(test)]` introduit
+    sur les fichiers touchés. 4-cat RED-first présents. **Umbrella #433
+    EXP-005/006/007/008 désormais Decimal + erreurs typées.**


### PR DESCRIPTION
## Summary

WBS go-live v0.1.0 — **WP-A6 (#433 EXP-008)** : `owner_contribution` / `call_for_funds` / gamification carve-out. Branche dédiée (autorisation permanente WBS), baseline `feature/dev`. Slice cohérente WP-A4 : **les deux entités monétaires sont déjà `Decimal`** (PCMN classe 7 / ADR-0007) → aucune migration f64, uniquement le typage de l'erreur domaine.

- `owner_contribution.rs` : enum pur `OwnerContributionError` (`NonPositiveAmount`, `EmptyDescription`) + `Display` + `impl Error` + `From<_> for String` (pont) + `From<_> for AppError` → `Validation` 400. `new()` → `Result<_, OwnerContributionError>`.
- `call_for_funds.rs` : enum pur `CallForFundsError` (`NonPositiveTotalAmount`, `EmptyTitle`, `EmptyDescription`, `DueDateNotAfterCallDate`) + idem.
- Assertions in-module `.contains()` → `matches!` typé.
- **Carve-out gamification confirmé (ADR-0008)** : aucun champ monétaire f64 dans `achievement`/`challenge`/`owner_credit_balance` ; seul résidu `challenge.rs:401` = pourcentage de progression non-PCMN, f64 conservé (score de jeu, jamais un montant légal). Aucun changement.

## Test plan

- [x] `cargo check --lib --tests` (SQLX_OFFLINE) propre
- [x] `cargo test --lib owner_contribution` — 14/14 (4 nouveaux 4-cat)
- [x] `cargo test --lib call_for_funds` — 16/16 (4 nouveaux 4-cat)
- [x] `cargo fmt --check` fichiers touchés — propre ; aucun DTO → zéro drift openapi/api.d.ts
- [ ] CI : Unit/BDD/Contract/E2E — gate (BDD/e2e exécutés en CI testcontainers ; daemon Docker absent en session, fallback hôte conforme CRITICAL.md #12)

### 4-cat RED-first (in-module, chaque entité)
`@happy` Decimal exact · `@edge` borne (zéro / montant minimal) + 0.1+0.2=0.3 · `@negative` entrées invalides typées · `@security` montant falsifié ≤0/négatif rejeté (collecte fantôme / faux avoir). Features `owner_contributions`/`call_for_funds` taggées `@happy`/`@edge` + commentaire style A3/A4/A5.

> Tier-2, pas de mutation prod. Log : `docs/agent-activity/2026-05-19-wbs-a6.md`. Réf WBS WP-A6. **⇒ Umbrella #433 EXP-005/006/007/008 désormais Decimal + erreurs domaine typées.** Différé : cascade port/use-case/handler `String`→`AppError`.

https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6dnSF4KsBdpkvy1WNLcPP)_