### PR TITLE
fix(deps): typescript downgrade + printpdf/time/quinn-proto security-compatible fix

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2050,7 +2050,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -3990,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -4680,15 +4679,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls 0.23.40",
@@ -4822,6 +4822,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rangemap"
@@ -6266,12 +6275,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6281,15 +6289,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",

--- a/backend/src/domain/services/annual_report_exporter.rs
+++ b/backend/src/domain/services/annual_report_exporter.rs
@@ -1,10 +1,12 @@
 use crate::domain::entities::{Building, Expense, ExpenseCategory};
+use crate::domain::services::pdf_writer::{
+    builtin_font, new_document, save_document, PdfPageBuilder,
+};
 use chrono::Utc;
-use printpdf::*;
+use printpdf::BuiltinFont;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::collections::HashMap;
-use std::io::BufWriter;
 
 /// Annual Financial Report Exporter - Generates PDF for Rapport Financier Annuel
 ///
@@ -40,96 +42,79 @@ impl AnnualReportExporter {
         reserve_fund: Decimal,
     ) -> Result<Vec<u8>, String> {
         // Create PDF document (A4: 210mm x 297mm)
-        let (doc, page1, layer1) =
-            PdfDocument::new("Rapport Financier Annuel", Mm(210.0), Mm(297.0), "Layer 1");
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let doc = new_document("Rapport Financier Annuel");
+        let mut current_layer = PdfPageBuilder::new();
 
         // Load fonts
-        let font = doc
-            .add_builtin_font(BuiltinFont::Helvetica)
-            .map_err(|e| e.to_string())?;
-        let font_bold = doc
-            .add_builtin_font(BuiltinFont::HelveticaBold)
-            .map_err(|e| e.to_string())?;
+        let font = builtin_font(BuiltinFont::Helvetica);
+        let font_bold = builtin_font(BuiltinFont::HelveticaBold);
 
         let mut y = 270.0; // Start from top
 
         // === HEADER ===
-        current_layer.use_text(
+        current_layer.text(
             "RAPPORT FINANCIER ANNUEL".to_string(),
             18.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 15.0;
 
         // Building information
-        current_layer.use_text(
+        current_layer.text(
             format!("Copropriété: {}", building.name),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 7.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Adresse: {}", building.address),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 10.0;
 
-        current_layer.use_text(
-            format!("Exercice: {}", year),
-            12.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text(format!("Exercice: {}", year), 12.0, 20.0, y, &font_bold);
         y -= 10.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Date d'établissement: {}", Utc::now().format("%d/%m/%Y")),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 15.0;
 
         // === SUMMARY ===
-        current_layer.use_text(
-            "SYNTHÈSE FINANCIÈRE".to_string(),
-            14.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("SYNTHÈSE FINANCIÈRE".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
         let total_expenses: Decimal = expenses.iter().map(|e| e.amount).sum();
 
-        current_layer.use_text(
+        current_layer.text(
             format!(
                 "Total des produits (charges perçues): {:.2} €",
                 total_income
             ),
             11.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Total des charges: {:.2} €", total_expenses),
             11.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
@@ -140,30 +125,30 @@ impl AnnualReportExporter {
         } else {
             "Déficit"
         };
-        current_layer.use_text(
+        current_layer.text(
             format!("{}: {:.2} €", balance_label, balance.abs()),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Fonds de réserve: {:.2} €", reserve_fund),
             11.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 12.0;
 
         // === EXPENSE BREAKDOWN BY CATEGORY ===
-        current_layer.use_text(
+        current_layer.text(
             "RÉPARTITION DES CHARGES PAR CATÉGORIE".to_string(),
             14.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
@@ -182,9 +167,9 @@ impl AnnualReportExporter {
         sorted_categories.sort_by(|a, b| b.1.partial_cmp(a.1).unwrap());
 
         // Table header
-        current_layer.use_text("Catégorie", 10.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text("Montant", 10.0, Mm(120.0), Mm(y), &font_bold);
-        current_layer.use_text("% Total", 10.0, Mm(160.0), Mm(y), &font_bold);
+        current_layer.text("Catégorie", 10.0, 20.0, y, &font_bold);
+        current_layer.text("Montant", 10.0, 120.0, y, &font_bold);
+        current_layer.text("% Total", 10.0, 160.0, y, &font_bold);
         y -= 6.0;
 
         for (category, amount) in sorted_categories {
@@ -199,28 +184,28 @@ impl AnnualReportExporter {
                 Decimal::ZERO
             };
 
-            current_layer.use_text(category.clone(), 9.0, Mm(20.0), Mm(y), &font);
-            current_layer.use_text(format!("{:.2} €", amount), 9.0, Mm(120.0), Mm(y), &font);
-            current_layer.use_text(format!("{:.1}%", percentage), 9.0, Mm(160.0), Mm(y), &font);
+            current_layer.text(category.clone(), 9.0, 20.0, y, &font);
+            current_layer.text(format!("{:.2} €", amount), 9.0, 120.0, y, &font);
+            current_layer.text(format!("{:.1}%", percentage), 9.0, 160.0, y, &font);
             y -= 5.0;
         }
         y -= 10.0;
 
         // === BUDGET VS ACTUAL ===
-        current_layer.use_text(
+        current_layer.text(
             "COMPARAISON BUDGET / RÉALISÉ".to_string(),
             14.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
 
         // Table header
-        current_layer.use_text("Catégorie", 10.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text("Budget", 10.0, Mm(100.0), Mm(y), &font_bold);
-        current_layer.use_text("Réalisé", 10.0, Mm(130.0), Mm(y), &font_bold);
-        current_layer.use_text("Écart", 10.0, Mm(160.0), Mm(y), &font_bold);
+        current_layer.text("Catégorie", 10.0, 20.0, y, &font_bold);
+        current_layer.text("Budget", 10.0, 100.0, y, &font_bold);
+        current_layer.text("Réalisé", 10.0, 130.0, y, &font_bold);
+        current_layer.text("Écart", 10.0, 160.0, y, &font_bold);
         y -= 6.0;
 
         let mut total_budgeted = Decimal::ZERO;
@@ -236,26 +221,14 @@ impl AnnualReportExporter {
             let variance = item.budgeted - item.actual;
             let variance_sign = if variance >= Decimal::ZERO { "+" } else { "" };
 
-            current_layer.use_text(category_name, 9.0, Mm(20.0), Mm(y), &font);
-            current_layer.use_text(
-                format!("{:.2} €", item.budgeted),
-                9.0,
-                Mm(100.0),
-                Mm(y),
-                &font,
-            );
-            current_layer.use_text(
-                format!("{:.2} €", item.actual),
-                9.0,
-                Mm(130.0),
-                Mm(y),
-                &font,
-            );
-            current_layer.use_text(
+            current_layer.text(category_name, 9.0, 20.0, y, &font);
+            current_layer.text(format!("{:.2} €", item.budgeted), 9.0, 100.0, y, &font);
+            current_layer.text(format!("{:.2} €", item.actual), 9.0, 130.0, y, &font);
+            current_layer.text(
                 format!("{}{:.2} €", variance_sign, variance),
                 9.0,
-                Mm(160.0),
-                Mm(y),
+                160.0,
+                y,
                 &font,
             );
 
@@ -266,21 +239,15 @@ impl AnnualReportExporter {
         y -= 3.0;
 
         // Totals line
-        current_layer.use_text("TOTAL", 10.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text(
+        current_layer.text("TOTAL", 10.0, 20.0, y, &font_bold);
+        current_layer.text(
             format!("{:.2} €", total_budgeted),
             10.0,
-            Mm(100.0),
-            Mm(y),
+            100.0,
+            y,
             &font_bold,
         );
-        current_layer.use_text(
-            format!("{:.2} €", total_actual),
-            10.0,
-            Mm(130.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text(format!("{:.2} €", total_actual), 10.0, 130.0, y, &font_bold);
 
         let total_variance = total_budgeted - total_actual;
         let total_variance_sign = if total_variance >= Decimal::ZERO {
@@ -288,11 +255,11 @@ impl AnnualReportExporter {
         } else {
             ""
         };
-        current_layer.use_text(
+        current_layer.text(
             format!("{}{:.2} €", total_variance_sign, total_variance),
             10.0,
-            Mm(160.0),
-            Mm(y),
+            160.0,
+            y,
             &font_bold,
         );
         y -= 15.0;
@@ -302,40 +269,31 @@ impl AnnualReportExporter {
             y = 40.0;
         }
 
-        current_layer.use_text("SIGNATURES".to_string(), 12.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text("SIGNATURES".to_string(), 12.0, 20.0, y, &font_bold);
         y -= 10.0;
 
-        current_layer.use_text(
+        current_layer.text(
             "Le Syndic: ________________".to_string(),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
 
-        current_layer.use_text(
+        current_layer.text(
             "Le Trésorier: ________________".to_string(),
             10.0,
-            Mm(120.0),
-            Mm(y),
+            120.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
-            "Date: ________________".to_string(),
-            10.0,
-            Mm(20.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text("Date: ________________".to_string(), 10.0, 20.0, y, &font);
 
         // Save to bytes
-        let mut buffer = Vec::new();
-        doc.save(&mut BufWriter::new(&mut buffer))
-            .map_err(|e| e.to_string())?;
-
-        Ok(buffer)
+        let page = current_layer.into_page(210.0, 297.0);
+        Ok(save_document(doc, page))
     }
 
     fn category_name(category: &ExpenseCategory) -> String {

--- a/backend/src/domain/services/convocation_exporter.rs
+++ b/backend/src/domain/services/convocation_exporter.rs
@@ -1,6 +1,8 @@
 use crate::domain::entities::{Building, Convocation, ConvocationType, Meeting};
-use printpdf::*;
-use std::io::BufWriter;
+use crate::domain::services::pdf_writer::{
+    builtin_font, new_document, save_document, PdfPageBuilder,
+};
+use printpdf::{BuiltinFont, PdfFontHandle};
 
 /// Convocation Exporter - Generates PDF for Convocations d'Assemblée Générale
 ///
@@ -26,39 +28,30 @@ impl ConvocationExporter {
         convocation: &Convocation,
     ) -> Result<Vec<u8>, String> {
         // Create PDF document (A4: 210mm x 297mm)
-        let (doc, page1, layer1) = PdfDocument::new(
-            "Convocation Assemblée Générale",
-            Mm(210.0),
-            Mm(297.0),
-            "Layer 1",
-        );
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let doc = new_document("Convocation Assemblée Générale");
+        let mut current_layer = PdfPageBuilder::new();
 
         // Load fonts
-        let font_bold = doc
-            .add_builtin_font(BuiltinFont::HelveticaBold)
-            .map_err(|e| format!("Failed to load bold font: {}", e))?;
-        let font_regular = doc
-            .add_builtin_font(BuiltinFont::Helvetica)
-            .map_err(|e| format!("Failed to load regular font: {}", e))?;
+        let font_bold = builtin_font(BuiltinFont::HelveticaBold);
+        let font_regular = builtin_font(BuiltinFont::Helvetica);
 
         let mut y_position = 277.0; // Start from top (A4 = 297mm height, 20mm margin)
 
         // Helper to add text line
-        let add_text = |layer: &PdfLayerReference,
+        let add_text = |layer: &mut PdfPageBuilder,
                         text: &str,
-                        font: &IndirectFontRef,
+                        font: &PdfFontHandle,
                         size: f64,
                         x: f64,
                         y: &mut f64,
                         _bold: bool| {
-            layer.use_text(text, size as f32, Mm(x as f32), Mm(*y as f32), font);
+            layer.text(text.to_string(), size as f32, x as f32, *y as f32, font);
             *y -= size * 0.5; // Line spacing (approx 1.5x font size)
         };
 
         // HEADER: Building name and type of meeting
         add_text(
-            &current_layer,
+            &mut current_layer,
             &building.name,
             &font_bold,
             16.0,
@@ -73,7 +66,7 @@ impl ConvocationExporter {
             building.address, building.postal_code, building.city
         );
         add_text(
-            &current_layer,
+            &mut current_layer,
             &address_line,
             &font_regular,
             10.0,
@@ -122,7 +115,7 @@ impl ConvocationExporter {
         };
 
         add_text(
-            &current_layer,
+            &mut current_layer,
             meeting_type_label,
             &font_bold,
             14.0,
@@ -158,7 +151,7 @@ impl ConvocationExporter {
         };
 
         add_text(
-            &current_layer,
+            &mut current_layer,
             &legal_notice,
             &font_regular,
             9.0,
@@ -181,7 +174,7 @@ impl ConvocationExporter {
         };
 
         add_text(
-            &current_layer,
+            &mut current_layer,
             details_label,
             &font_bold,
             12.0,
@@ -192,7 +185,7 @@ impl ConvocationExporter {
 
         // Title
         add_text(
-            &current_layer,
+            &mut current_layer,
             &format!("📋 {}", meeting.title),
             &font_regular,
             10.0,
@@ -208,7 +201,7 @@ impl ConvocationExporter {
             "📅 Datum" // NL, DE, EN all use "Datum"
         };
         add_text(
-            &current_layer,
+            &mut current_layer,
             &format!(
                 "{}: {}",
                 date_label,
@@ -232,7 +225,7 @@ impl ConvocationExporter {
             "📍 Location"
         };
         add_text(
-            &current_layer,
+            &mut current_layer,
             &format!("{}: {}", location_label, meeting.location),
             &font_regular,
             10.0,
@@ -255,7 +248,7 @@ impl ConvocationExporter {
         };
 
         add_text(
-            &current_layer,
+            &mut current_layer,
             agenda_label,
             &font_bold,
             12.0,
@@ -266,7 +259,7 @@ impl ConvocationExporter {
 
         for (index, item) in meeting.agenda.iter().enumerate() {
             add_text(
-                &current_layer,
+                &mut current_layer,
                 &format!("{}. {}", index + 1, item),
                 &font_regular,
                 10.0,
@@ -290,7 +283,7 @@ impl ConvocationExporter {
         };
 
         add_text(
-            &current_layer,
+            &mut current_layer,
             attendance_label,
             &font_bold,
             12.0,
@@ -319,7 +312,7 @@ impl ConvocationExporter {
 
         for line in attendance_text.lines() {
             add_text(
-                &current_layer,
+                &mut current_layer,
                 line,
                 &font_regular,
                 9.0,
@@ -344,7 +337,7 @@ impl ConvocationExporter {
             };
 
             add_text(
-                &current_layer,
+                &mut current_layer,
                 contact_label,
                 &font_bold,
                 12.0,
@@ -354,7 +347,7 @@ impl ConvocationExporter {
             );
 
             add_text(
-                &current_layer,
+                &mut current_layer,
                 syndic_name,
                 &font_regular,
                 10.0,
@@ -365,7 +358,7 @@ impl ConvocationExporter {
 
             if let Some(email) = &building.syndic_email {
                 add_text(
-                    &current_layer,
+                    &mut current_layer,
                     &format!("📧 {}", email),
                     &font_regular,
                     10.0,
@@ -377,7 +370,7 @@ impl ConvocationExporter {
 
             if let Some(phone) = &building.syndic_phone {
                 add_text(
-                    &current_layer,
+                    &mut current_layer,
                     &format!("📞 {}", phone),
                     &font_regular,
                     10.0,
@@ -398,7 +391,7 @@ impl ConvocationExporter {
                     "Office hours"
                 };
                 add_text(
-                    &current_layer,
+                    &mut current_layer,
                     &format!("🕒 {}: {}", hours_label, office_hours),
                     &font_regular,
                     10.0,
@@ -423,7 +416,7 @@ impl ConvocationExporter {
         };
 
         add_text(
-            &current_layer,
+            &mut current_layer,
             footer_text,
             &font_regular,
             8.0,
@@ -433,11 +426,8 @@ impl ConvocationExporter {
         );
 
         // Save PDF to bytes
-        let mut buffer = BufWriter::new(Vec::new());
-        doc.save(&mut buffer)
-            .map_err(|e| format!("Failed to save PDF: {}", e))?;
-
-        buffer.into_inner().map_err(|e| e.to_string())
+        let page = current_layer.into_page(210.0, 297.0);
+        Ok(save_document(doc, page))
     }
 
     /// Save PDF bytes to file

--- a/backend/src/domain/services/meeting_minutes_exporter.rs
+++ b/backend/src/domain/services/meeting_minutes_exporter.rs
@@ -1,9 +1,11 @@
 use crate::domain::entities::{Building, Meeting, MeetingType, Resolution, Vote};
-use printpdf::*;
+use crate::domain::services::pdf_writer::{
+    builtin_font, new_document, save_document, PdfPageBuilder,
+};
+use printpdf::BuiltinFont;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
-use std::io::BufWriter;
 use uuid::Uuid;
 
 /// Meeting Minutes Exporter - Generates PDF for Procès-Verbal d'Assemblée Générale
@@ -44,49 +46,40 @@ impl MeetingMinutesExporter {
         resolutions: &[ResolutionWithVotes],
     ) -> Result<Vec<u8>, String> {
         // Create PDF document (A4: 210mm x 297mm)
-        let (doc, page1, layer1) = PdfDocument::new(
-            "Procès-Verbal d'Assemblée Générale",
-            Mm(210.0),
-            Mm(297.0),
-            "Layer 1",
-        );
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let doc = new_document("Procès-Verbal d'Assemblée Générale");
+        let mut current_layer = PdfPageBuilder::new();
 
         // Load fonts
-        let font = doc
-            .add_builtin_font(BuiltinFont::Helvetica)
-            .map_err(|e| e.to_string())?;
-        let font_bold = doc
-            .add_builtin_font(BuiltinFont::HelveticaBold)
-            .map_err(|e| e.to_string())?;
+        let font = builtin_font(BuiltinFont::Helvetica);
+        let font_bold = builtin_font(BuiltinFont::HelveticaBold);
 
         let mut y = 270.0; // Start from top
 
         // === HEADER ===
-        current_layer.use_text(
+        current_layer.text(
             "PROCÈS-VERBAL D'ASSEMBLÉE GÉNÉRALE".to_string(),
             18.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 15.0;
 
         // Building information
-        current_layer.use_text(
+        current_layer.text(
             format!("Copropriété: {}", building.name),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 7.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Adresse: {}", building.address),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 10.0;
@@ -97,11 +90,11 @@ impl MeetingMinutesExporter {
             MeetingType::Extraordinary => "Assemblée Générale Extraordinaire (AGE)",
         };
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Type: {}", meeting_type_label),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
@@ -110,25 +103,19 @@ impl MeetingMinutesExporter {
             .scheduled_date
             .format("%d/%m/%Y à %H:%M")
             .to_string();
-        current_layer.use_text(format!("Date: {}", date_str), 10.0, Mm(20.0), Mm(y), &font);
+        current_layer.text(format!("Date: {}", date_str), 10.0, 20.0, y, &font);
         y -= 6.0;
 
-        current_layer.use_text(
-            format!("Lieu: {}", meeting.location),
-            10.0,
-            Mm(20.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text(format!("Lieu: {}", meeting.location), 10.0, 20.0, y, &font);
         y -= 6.0;
         y -= 5.0;
 
         // === ATTENDEES SECTION ===
-        current_layer.use_text(
+        current_layer.text(
             "PRÉSENCES ET REPRÉSENTATIONS".to_string(),
             14.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
@@ -144,22 +131,22 @@ impl MeetingMinutesExporter {
             0.0
         };
 
-        current_layer.use_text(
+        current_layer.text(
             format!(
                 "Présents ou représentés: {} millièmes sur {} ({:.2}%)",
                 total_voting_power, total_millimes, quorum_percentage
             ),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 10.0;
 
         // Attendees table header
-        current_layer.use_text("Copropriétaire", 10.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text("Millièmes", 10.0, Mm(110.0), Mm(y), &font_bold);
-        current_layer.use_text("Présence", 10.0, Mm(150.0), Mm(y), &font_bold);
+        current_layer.text("Copropriétaire", 10.0, 20.0, y, &font_bold);
+        current_layer.text("Millièmes", 10.0, 110.0, y, &font_bold);
+        current_layer.text("Présence", 10.0, 150.0, y, &font_bold);
         y -= 6.0;
 
         // Attendees list
@@ -169,12 +156,12 @@ impl MeetingMinutesExporter {
                 break;
             }
 
-            current_layer.use_text(&attendee.name, 9.0, Mm(20.0), Mm(y), &font);
-            current_layer.use_text(
+            current_layer.text(attendee.name.as_str(), 9.0, 20.0, y, &font);
+            current_layer.text(
                 format!("{:.2}", attendee.voting_power),
                 9.0,
-                Mm(110.0),
-                Mm(y),
+                110.0,
+                y,
                 &font,
             );
 
@@ -188,7 +175,7 @@ impl MeetingMinutesExporter {
                 "Présent".to_string()
             };
 
-            current_layer.use_text(presence, 9.0, Mm(150.0), Mm(y), &font);
+            current_layer.text(presence, 9.0, 150.0, y, &font);
             y -= 5.0;
         }
         y -= 8.0;
@@ -200,15 +187,15 @@ impl MeetingMinutesExporter {
             "✗ QUORUM NON ATTEINT"
         };
 
-        current_layer.use_text(quorum_status.to_string(), 11.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text(quorum_status.to_string(), 11.0, 20.0, y, &font_bold);
         y -= 12.0;
 
         // === RESOLUTIONS SECTION ===
-        current_layer.use_text(
+        current_layer.text(
             "RÉSOLUTIONS ET VOTES".to_string(),
             14.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 10.0;
@@ -222,11 +209,11 @@ impl MeetingMinutesExporter {
             let resolution = &res_with_votes.resolution;
 
             // Resolution number and title
-            current_layer.use_text(
+            current_layer.text(
                 format!("Résolution n°{}: {}", idx + 1, resolution.title),
                 11.0,
-                Mm(20.0),
-                Mm(y),
+                20.0,
+                y,
                 &font_bold,
             );
             y -= 6.0;
@@ -238,7 +225,7 @@ impl MeetingMinutesExporter {
                 resolution.description.clone()
             };
 
-            current_layer.use_text(description, 9.0, Mm(25.0), Mm(y), &font);
+            current_layer.text(description, 9.0, 25.0, y, &font);
             y -= 6.0;
 
             // Majority type
@@ -255,17 +242,17 @@ impl MeetingMinutesExporter {
                 crate::domain::entities::MajorityType::Unanimity => "Unanimité (Art. 3.88 §1, 3°)",
             };
 
-            current_layer.use_text(
+            current_layer.text(
                 format!("Majorité requise: {}", majority_label),
                 9.0,
-                Mm(25.0),
-                Mm(y),
+                25.0,
+                y,
                 &font,
             );
             y -= 6.0;
 
             // Vote results
-            current_layer.use_text(
+            current_layer.text(
                 format!(
                     "Pour: {} votes ({:.2} millièmes) | Contre: {} votes ({:.2} millièmes) | Abstention: {} votes ({:.2} millièmes)",
                     resolution.vote_count_pour,
@@ -276,8 +263,8 @@ impl MeetingMinutesExporter {
                     resolution.total_voting_power_abstention
                 ),
                 9.0,
-                Mm(25.0),
-                Mm(y),
+                25.0,
+                y,
                 &font,
             );
             y -= 6.0;
@@ -289,11 +276,11 @@ impl MeetingMinutesExporter {
                 crate::domain::entities::ResolutionStatus::Pending => ("EN ATTENTE", "○"),
             };
 
-            current_layer.use_text(
+            current_layer.text(
                 format!("{} Résolution {}", result_symbol, result_text),
                 10.0,
-                Mm(25.0),
-                Mm(y),
+                25.0,
+                y,
                 &font_bold,
             );
             y -= 10.0;
@@ -306,31 +293,22 @@ impl MeetingMinutesExporter {
             y -= 10.0;
         }
 
-        current_layer.use_text("SIGNATURES".to_string(), 12.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text("SIGNATURES".to_string(), 12.0, 20.0, y, &font_bold);
         y -= 10.0;
 
-        current_layer.use_text(
+        current_layer.text(
             "Le Président de séance: ________________",
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
 
-        current_layer.use_text(
-            "Le Secrétaire: ________________",
-            10.0,
-            Mm(120.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text("Le Secrétaire: ________________", 10.0, 120.0, y, &font);
 
         // Save to bytes
-        let mut buffer = Vec::new();
-        doc.save(&mut BufWriter::new(&mut buffer))
-            .map_err(|e| e.to_string())?;
-
-        Ok(buffer)
+        let page = current_layer.into_page(210.0, 297.0);
+        Ok(save_document(doc, page))
     }
 }
 

--- a/backend/src/domain/services/mod.rs
+++ b/backend/src/domain/services/mod.rs
@@ -6,6 +6,7 @@ pub mod owner_statement_exporter;
 pub mod ownership_contract_exporter;
 pub mod pcn_exporter;
 pub mod pcn_mapper;
+pub mod pdf_writer;
 pub mod work_quote_exporter;
 
 pub use annual_report_exporter::{AnnualReportExporter, BudgetItem};

--- a/backend/src/domain/services/owner_statement_exporter.rs
+++ b/backend/src/domain/services/owner_statement_exporter.rs
@@ -1,8 +1,10 @@
 use crate::domain::entities::{Building, Expense, Owner, Unit};
+use crate::domain::services::pdf_writer::{
+    builtin_font, new_document, save_document, PdfPageBuilder,
+};
 use chrono::{DateTime, Utc};
-use printpdf::*;
+use printpdf::BuiltinFont;
 use rust_decimal::Decimal;
-use std::io::BufWriter;
 
 /// Owner Financial Statement Exporter - Generates PDF for Relevé de Charges
 ///
@@ -36,45 +38,34 @@ impl OwnerStatementExporter {
         end_date: DateTime<Utc>,
     ) -> Result<Vec<u8>, String> {
         // Create PDF document (A4: 210mm x 297mm)
-        let (doc, page1, layer1) =
-            PdfDocument::new("Relevé de Charges", Mm(210.0), Mm(297.0), "Layer 1");
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let doc = new_document("Relevé de Charges");
+        let mut current_layer = PdfPageBuilder::new();
 
         // Load fonts
-        let font = doc
-            .add_builtin_font(BuiltinFont::Helvetica)
-            .map_err(|e| e.to_string())?;
-        let font_bold = doc
-            .add_builtin_font(BuiltinFont::HelveticaBold)
-            .map_err(|e| e.to_string())?;
+        let font = builtin_font(BuiltinFont::Helvetica);
+        let font_bold = builtin_font(BuiltinFont::HelveticaBold);
 
         let mut y = 270.0; // Start from top
 
         // === HEADER ===
-        current_layer.use_text(
-            "RELEVÉ DE CHARGES".to_string(),
-            18.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("RELEVÉ DE CHARGES".to_string(), 18.0, 20.0, y, &font_bold);
         y -= 15.0;
 
         // Building information
-        current_layer.use_text(
+        current_layer.text(
             format!("Copropriété: {}", building.name),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 7.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Adresse: {}", building.address),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 10.0;
@@ -85,63 +76,39 @@ impl OwnerStatementExporter {
             start_date.format("%d/%m/%Y"),
             end_date.format("%d/%m/%Y")
         );
-        current_layer.use_text(period, 10.0, Mm(20.0), Mm(y), &font);
+        current_layer.text(period, 10.0, 20.0, y, &font);
         y -= 10.0;
 
         // Owner information
-        current_layer.use_text(
-            "COPROPRIÉTAIRE".to_string(),
-            14.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("COPROPRIÉTAIRE".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("{} {}", owner.first_name, owner.last_name),
             11.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
-            format!("Email: {}", owner.email),
-            10.0,
-            Mm(20.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text(format!("Email: {}", owner.email), 10.0, 20.0, y, &font);
         y -= 6.0;
 
         if let Some(ref phone) = owner.phone {
-            current_layer.use_text(
-                format!("Téléphone: {}", phone),
-                10.0,
-                Mm(20.0),
-                Mm(y),
-                &font,
-            );
+            current_layer.text(format!("Téléphone: {}", phone), 10.0, 20.0, y, &font);
             y -= 6.0;
         }
         y -= 5.0;
 
         // === UNITS OWNED ===
-        current_layer.use_text(
-            "LOTS DÉTENUS".to_string(),
-            14.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("LOTS DÉTENUS".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
-        current_layer.use_text("Lot", 10.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text("Étage", 10.0, Mm(60.0), Mm(y), &font_bold);
-        current_layer.use_text("Surface", 10.0, Mm(90.0), Mm(y), &font_bold);
-        current_layer.use_text("Quote-part", 10.0, Mm(130.0), Mm(y), &font_bold);
+        current_layer.text("Lot", 10.0, 20.0, y, &font_bold);
+        current_layer.text("Étage", 10.0, 60.0, y, &font_bold);
+        current_layer.text("Surface", 10.0, 90.0, y, &font_bold);
+        current_layer.text("Quote-part", 10.0, 130.0, y, &font_bold);
         y -= 6.0;
 
         for unit_info in units {
@@ -150,28 +117,28 @@ impl OwnerStatementExporter {
                 break;
             }
 
-            current_layer.use_text(&unit_info.unit.unit_number, 9.0, Mm(20.0), Mm(y), &font);
+            current_layer.text(unit_info.unit.unit_number.as_str(), 9.0, 20.0, y, &font);
 
             if let Some(floor) = unit_info.unit.floor {
-                current_layer.use_text(floor.to_string(), 9.0, Mm(60.0), Mm(y), &font);
+                current_layer.text(floor.to_string(), 9.0, 60.0, y, &font);
             }
 
-            current_layer.use_text(
+            current_layer.text(
                 format!("{:.2} m²", unit_info.unit.surface_area),
                 9.0,
-                Mm(90.0),
-                Mm(y),
+                90.0,
+                y,
                 &font,
             );
 
-            current_layer.use_text(
+            current_layer.text(
                 format!(
                     "{:.2}%",
                     unit_info.ownership_percentage * rust_decimal_macros::dec!(100)
                 ),
                 9.0,
-                Mm(130.0),
-                Mm(y),
+                130.0,
+                y,
                 &font,
             );
             y -= 5.0;
@@ -179,19 +146,13 @@ impl OwnerStatementExporter {
         y -= 8.0;
 
         // === EXPENSES ===
-        current_layer.use_text(
-            "DÉTAIL DES CHARGES".to_string(),
-            14.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("DÉTAIL DES CHARGES".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
-        current_layer.use_text("Date", 10.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text("Description", 10.0, Mm(50.0), Mm(y), &font_bold);
-        current_layer.use_text("Montant", 10.0, Mm(140.0), Mm(y), &font_bold);
-        current_layer.use_text("Statut", 10.0, Mm(170.0), Mm(y), &font_bold);
+        current_layer.text("Date", 10.0, 20.0, y, &font_bold);
+        current_layer.text("Description", 10.0, 50.0, y, &font_bold);
+        current_layer.text("Montant", 10.0, 140.0, y, &font_bold);
+        current_layer.text("Statut", 10.0, 170.0, y, &font_bold);
         y -= 6.0;
 
         let mut total_amount = Decimal::ZERO;
@@ -203,11 +164,11 @@ impl OwnerStatementExporter {
                 break;
             }
 
-            current_layer.use_text(
+            current_layer.text(
                 expense.expense_date.format("%d/%m/%Y").to_string(),
                 9.0,
-                Mm(20.0),
-                Mm(y),
+                20.0,
+                y,
                 &font,
             );
 
@@ -216,22 +177,16 @@ impl OwnerStatementExporter {
             } else {
                 expense.description.clone()
             };
-            current_layer.use_text(description, 9.0, Mm(50.0), Mm(y), &font);
+            current_layer.text(description, 9.0, 50.0, y, &font);
 
-            current_layer.use_text(
-                format!("{:.2} €", expense.amount),
-                9.0,
-                Mm(140.0),
-                Mm(y),
-                &font,
-            );
+            current_layer.text(format!("{:.2} €", expense.amount), 9.0, 140.0, y, &font);
 
             let status = if expense.is_paid() {
                 "Payée"
             } else {
                 "En attente"
             };
-            current_layer.use_text(status.to_string(), 9.0, Mm(170.0), Mm(y), &font);
+            current_layer.text(status.to_string(), 9.0, 170.0, y, &font);
 
             total_amount += expense.amount;
             if expense.is_paid() {
@@ -243,78 +198,69 @@ impl OwnerStatementExporter {
         y -= 10.0;
 
         // === SUMMARY ===
-        current_layer.use_text(
-            "RÉCAPITULATIF".to_string(),
-            14.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("RÉCAPITULATIF".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Total des charges: {:.2} €", total_amount),
             11.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Montant payé: {:.2} €", total_paid),
             11.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
         let amount_due = total_amount - total_paid;
-        current_layer.use_text(
+        current_layer.text(
             format!("Montant dû: {:.2} €", amount_due),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 10.0;
 
         // Payment instructions
         if amount_due > Decimal::ZERO {
-            current_layer.use_text(
+            current_layer.text(
                 "Modalités de paiement:".to_string(),
                 10.0,
-                Mm(20.0),
-                Mm(y),
+                20.0,
+                y,
                 &font_bold,
             );
             y -= 6.0;
 
-            current_layer.use_text(
+            current_layer.text(
                 "Merci d'effectuer votre paiement par virement bancaire".to_string(),
                 9.0,
-                Mm(20.0),
-                Mm(y),
+                20.0,
+                y,
                 &font,
             );
             y -= 5.0;
 
-            current_layer.use_text(
+            current_layer.text(
                 "avec la référence suivante en communication.".to_string(),
                 9.0,
-                Mm(20.0),
-                Mm(y),
+                20.0,
+                y,
                 &font,
             );
         }
 
         // Save to bytes
-        let mut buffer = Vec::new();
-        doc.save(&mut BufWriter::new(&mut buffer))
-            .map_err(|e| e.to_string())?;
-
-        Ok(buffer)
+        let page = current_layer.into_page(210.0, 297.0);
+        Ok(save_document(doc, page))
     }
 }
 

--- a/backend/src/domain/services/ownership_contract_exporter.rs
+++ b/backend/src/domain/services/ownership_contract_exporter.rs
@@ -1,7 +1,9 @@
 use crate::domain::entities::{Building, Owner, Unit};
+use crate::domain::services::pdf_writer::{
+    builtin_font, new_document, save_document, PdfPageBuilder,
+};
 use chrono::{DateTime, Utc};
-use printpdf::*;
-use std::io::BufWriter;
+use printpdf::BuiltinFont;
 
 /// Ownership Contract Exporter - Generates PDF for Contrat de Copropriété
 ///
@@ -28,85 +30,80 @@ impl OwnershipContractExporter {
         ownership_start_date: DateTime<Utc>,
     ) -> Result<Vec<u8>, String> {
         // Create PDF document (A4: 210mm x 297mm)
-        let (doc, page1, layer1) =
-            PdfDocument::new("Contrat de Copropriété", Mm(210.0), Mm(297.0), "Layer 1");
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let doc = new_document("Contrat de Copropriété");
+        let mut current_layer = PdfPageBuilder::new();
 
         // Load fonts
-        let font = doc
-            .add_builtin_font(BuiltinFont::Helvetica)
-            .map_err(|e| e.to_string())?;
-        let font_bold = doc
-            .add_builtin_font(BuiltinFont::HelveticaBold)
-            .map_err(|e| e.to_string())?;
+        let font = builtin_font(BuiltinFont::Helvetica);
+        let font_bold = builtin_font(BuiltinFont::HelveticaBold);
 
         let mut y = 270.0; // Start from top
 
         // === HEADER ===
-        current_layer.use_text(
+        current_layer.text(
             "CONTRAT DE COPROPRIÉTÉ".to_string(),
             18.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 15.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Date d'établissement: {}", Utc::now().format("%d/%m/%Y")),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 15.0;
 
         // === ARTICLE 1: BUILDING INFORMATION ===
-        current_layer.use_text(
+        current_layer.text(
             "ARTICLE 1 - IMMEUBLE CONCERNÉ".to_string(),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Dénomination: {}", building.name),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!(
                 "Adresse: {}, {} {}, {}",
                 building.address, building.postal_code, building.city, building.country
             ),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Nombre total de lots: {}", building.total_units),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
         if let Some(year) = building.construction_year {
-            current_layer.use_text(
+            current_layer.text(
                 format!("Année de construction: {}", year),
                 10.0,
-                Mm(20.0),
-                Mm(y),
+                20.0,
+                y,
                 &font,
             );
             y -= 6.0;
@@ -114,125 +111,107 @@ impl OwnershipContractExporter {
         y -= 8.0;
 
         // === ARTICLE 2: UNIT DETAILS ===
-        current_layer.use_text(
+        current_layer.text(
             "ARTICLE 2 - DESCRIPTION DU LOT".to_string(),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Numéro de lot: {}", unit.unit_number),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
         if let Some(floor) = unit.floor {
-            current_layer.use_text(format!("Étage: {}", floor), 10.0, Mm(20.0), Mm(y), &font);
+            current_layer.text(format!("Étage: {}", floor), 10.0, 20.0, y, &font);
             y -= 6.0;
         }
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Superficie: {:.2} m²", unit.surface_area),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
-            format!("Type: {:?}", unit.unit_type),
-            10.0,
-            Mm(20.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text(format!("Type: {:?}", unit.unit_type), 10.0, 20.0, y, &font);
         y -= 6.0;
 
         use rust_decimal::prelude::ToPrimitive;
         let tantiemes_dec =
             ownership_percentage * rust_decimal::Decimal::from(building.total_tantiemes);
         let tantiemes = tantiemes_dec.trunc().to_i32().unwrap_or(0);
-        current_layer.use_text(
+        current_layer.text(
             format!("Tantièmes: {} sur {}", tantiemes, building.total_tantiemes),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!(
                 "Quote-part: {:.2}%",
                 ownership_percentage * rust_decimal_macros::dec!(100)
             ),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
 
         // === ARTICLE 3: OWNER INFORMATION ===
-        current_layer.use_text(
+        current_layer.text(
             "ARTICLE 3 - COPROPRIÉTAIRE".to_string(),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
 
         let owner_name = format!("{} {}", owner.first_name, owner.last_name);
 
-        current_layer.use_text(format!("Nom: {}", owner_name), 10.0, Mm(20.0), Mm(y), &font);
+        current_layer.text(format!("Nom: {}", owner_name), 10.0, 20.0, y, &font);
         y -= 6.0;
 
-        current_layer.use_text(
-            format!("Email: {}", owner.email),
-            10.0,
-            Mm(20.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text(format!("Email: {}", owner.email), 10.0, 20.0, y, &font);
         y -= 6.0;
 
         if let Some(ref phone) = owner.phone {
-            current_layer.use_text(
-                format!("Téléphone: {}", phone),
-                10.0,
-                Mm(20.0),
-                Mm(y),
-                &font,
-            );
+            current_layer.text(format!("Téléphone: {}", phone), 10.0, 20.0, y, &font);
             y -= 6.0;
         }
 
-        current_layer.use_text(
+        current_layer.text(
             format!(
                 "Date d'entrée en copropriété: {}",
                 ownership_start_date.format("%d/%m/%Y")
             ),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 8.0;
 
         // === ARTICLE 4: RIGHTS AND OBLIGATIONS ===
-        current_layer.use_text(
+        current_layer.text(
             "ARTICLE 4 - DROITS ET OBLIGATIONS".to_string(),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
@@ -255,38 +234,38 @@ impl OwnershipContractExporter {
             if y < 80.0 {
                 break;
             }
-            current_layer.use_text(line.to_string(), 9.0, Mm(20.0), Mm(y), &font);
+            current_layer.text(line.to_string(), 9.0, 20.0, y, &font);
             y -= 5.0;
         }
         y -= 5.0;
 
         // === ARTICLE 5: EXPENSES ===
-        current_layer.use_text(
+        current_layer.text(
             "ARTICLE 5 - RÉPARTITION DES CHARGES".to_string(),
             12.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!(
                 "Les charges communes sont réparties selon la quote-part de {:.2}%",
                 ownership_percentage * rust_decimal_macros::dec!(100)
             ),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             "correspondant aux tantièmes du lot.".to_string(),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 10.0;
@@ -296,48 +275,33 @@ impl OwnershipContractExporter {
             y = 40.0;
         }
 
-        current_layer.use_text("SIGNATURES".to_string(), 12.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text("SIGNATURES".to_string(), 12.0, 20.0, y, &font_bold);
         y -= 10.0;
 
-        current_layer.use_text(
+        current_layer.text(
             "Le Syndic: ________________".to_string(),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
 
-        current_layer.use_text(
+        current_layer.text(
             "Le Copropriétaire: ________________".to_string(),
             10.0,
-            Mm(120.0),
-            Mm(y),
+            120.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
-            "Date: ________________".to_string(),
-            10.0,
-            Mm(20.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text("Date: ________________".to_string(), 10.0, 20.0, y, &font);
 
-        current_layer.use_text(
-            "Date: ________________".to_string(),
-            10.0,
-            Mm(120.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text("Date: ________________".to_string(), 10.0, 120.0, y, &font);
 
         // Save to bytes
-        let mut buffer = Vec::new();
-        doc.save(&mut BufWriter::new(&mut buffer))
-            .map_err(|e| e.to_string())?;
-
-        Ok(buffer)
+        let page = current_layer.into_page(210.0, 297.0);
+        Ok(save_document(doc, page))
     }
 }
 

--- a/backend/src/domain/services/pcn_exporter.rs
+++ b/backend/src/domain/services/pcn_exporter.rs
@@ -1,8 +1,10 @@
+use crate::domain::services::pdf_writer::{
+    builtin_font, new_document, save_document, PdfPageBuilder,
+};
 use crate::domain::services::PcnReportLine;
-use printpdf::*;
+use printpdf::BuiltinFont;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
-use std::io::BufWriter;
 
 /// PCN Exporter - Generates PDF and Excel reports
 pub struct PcnExporter;
@@ -16,81 +18,56 @@ impl PcnExporter {
         total_amount: Decimal,
     ) -> Result<Vec<u8>, String> {
         // Create PDF document
-        let (doc, page1, layer1) = PdfDocument::new("Rapport PCN", Mm(210.0), Mm(297.0), "Layer 1");
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let doc = new_document("Rapport PCN");
+        let mut current_layer = PdfPageBuilder::new();
 
         // Load built-in font
-        let font = doc
-            .add_builtin_font(BuiltinFont::Helvetica)
-            .map_err(|e| e.to_string())?;
-        let font_bold = doc
-            .add_builtin_font(BuiltinFont::HelveticaBold)
-            .map_err(|e| e.to_string())?;
+        let font = builtin_font(BuiltinFont::Helvetica);
+        let font_bold = builtin_font(BuiltinFont::HelveticaBold);
 
         // Title
-        current_layer.use_text(
+        current_layer.text(
             "Rapport PCN - Plan Comptable Normalisé".to_string(),
             24.0,
-            Mm(20.0),
-            Mm(270.0),
+            20.0,
+            270.0,
             &font_bold,
         );
 
         // Building name
-        current_layer.use_text(
+        current_layer.text(
             format!("Immeuble: {}", building_name),
             14.0,
-            Mm(20.0),
-            Mm(260.0),
+            20.0,
+            260.0,
             &font,
         );
 
         // Table header
         let mut y = 245.0;
-        current_layer.use_text("Code", 12.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text("Libellé", 12.0, Mm(50.0), Mm(y), &font_bold);
-        current_layer.use_text("Montant (€)", 12.0, Mm(140.0), Mm(y), &font_bold);
-        current_layer.use_text("Nb", 12.0, Mm(180.0), Mm(y), &font_bold);
+        current_layer.text("Code", 12.0, 20.0, y, &font_bold);
+        current_layer.text("Libellé", 12.0, 50.0, y, &font_bold);
+        current_layer.text("Montant (€)", 12.0, 140.0, y, &font_bold);
+        current_layer.text("Nb", 12.0, 180.0, y, &font_bold);
 
         // Table rows
         y -= 10.0;
         for line in report_lines {
-            current_layer.use_text(&line.account.code, 10.0, Mm(20.0), Mm(y), &font);
-            current_layer.use_text(&line.account.label_fr, 10.0, Mm(50.0), Mm(y), &font);
-            current_layer.use_text(
-                format!("{:.2}", line.total_amount),
-                10.0,
-                Mm(140.0),
-                Mm(y),
-                &font,
-            );
-            current_layer.use_text(
-                format!("{}", line.entry_count),
-                10.0,
-                Mm(180.0),
-                Mm(y),
-                &font,
-            );
+            current_layer.text(line.account.code.as_str(), 10.0, 20.0, y, &font);
+            current_layer.text(line.account.label_fr.as_str(), 10.0, 50.0, y, &font);
+            current_layer.text(format!("{:.2}", line.total_amount), 10.0, 140.0, y, &font);
+            current_layer.text(format!("{}", line.entry_count), 10.0, 180.0, y, &font);
             y -= 7.0;
         }
 
         // Total
         y -= 5.0;
-        current_layer.use_text("TOTAL:", 12.0, Mm(50.0), Mm(y), &font_bold);
-        current_layer.use_text(
-            format!("{:.2} €", total_amount),
-            12.0,
-            Mm(140.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("TOTAL:", 12.0, 50.0, y, &font_bold);
+        current_layer.text(format!("{:.2} €", total_amount), 12.0, 140.0, y, &font_bold);
 
         // Save to bytes
-        let mut buffer = Vec::new();
-        doc.save(&mut BufWriter::new(&mut buffer))
-            .map_err(|e| e.to_string())?;
-
-        Ok(buffer)
+        let page = current_layer.into_page(210.0, 297.0);
+        Ok(save_document(doc, page))
     }
 
     /// Export PCN report to Excel bytes

--- a/backend/src/domain/services/pdf_writer.rs
+++ b/backend/src/domain/services/pdf_writer.rs
@@ -1,0 +1,71 @@
+use printpdf::{
+    BuiltinFont, Mm, Op, PdfDocument, PdfFontHandle, PdfPage, PdfSaveOptions, Point, Pt, TextItem,
+};
+
+/// Adaptateur autour de l'API "Ops" de printpdf 0.11 (réécriture complète vs 0.7 —
+/// plus de `Layer`/`PdfLayerReference`, tout passe par une liste d'`Op` empilés sur
+/// `PdfPage`). Centralise le pattern "texte positionné en absolu" utilisé par les
+/// exporteurs PDF `domain/services/*_exporter.rs` pour éviter une réimplémentation
+/// par fichier. Migration liée à la fermeture de #658 (build cassé) + #636 (RUSTSEC
+/// lopdf) — cf. `docs/agent-activity/2026-07-26-sync-audit-feature-dev.md`.
+pub struct PdfPageBuilder {
+    ops: Vec<Op>,
+}
+
+impl Default for PdfPageBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PdfPageBuilder {
+    pub fn new() -> Self {
+        Self { ops: Vec::new() }
+    }
+
+    /// Équivalent de l'ancien `layer.use_text(text, size, Mm(x), Mm(y), &font)` (API 0.7).
+    pub fn text(
+        &mut self,
+        text: impl Into<String>,
+        size_pt: f32,
+        x_mm: f32,
+        y_mm: f32,
+        font: &PdfFontHandle,
+    ) {
+        self.ops.push(Op::StartTextSection);
+        self.ops.push(Op::SetFont {
+            font: font.clone(),
+            size: Pt(size_pt),
+        });
+        self.ops.push(Op::SetTextCursor {
+            pos: Point {
+                x: Mm(x_mm).into(),
+                y: Mm(y_mm).into(),
+            },
+        });
+        self.ops.push(Op::ShowText {
+            items: vec![TextItem::Text(text.into())],
+        });
+        self.ops.push(Op::EndTextSection);
+    }
+
+    pub fn into_page(self, width_mm: f32, height_mm: f32) -> PdfPage {
+        PdfPage::new(Mm(width_mm), Mm(height_mm), self.ops)
+    }
+}
+
+/// Police intégrée (Helvetica, Times, ...) — pas de résolution via `resources`
+/// nécessaire pour `PdfFontHandle::Builtin` (contrairement à une police externe).
+pub fn builtin_font(font: BuiltinFont) -> PdfFontHandle {
+    PdfFontHandle::Builtin(font)
+}
+
+pub fn new_document(title: &str) -> PdfDocument {
+    PdfDocument::new(title)
+}
+
+pub fn save_document(mut doc: PdfDocument, page: PdfPage) -> Vec<u8> {
+    doc.pages.push(page);
+    let mut warnings = Vec::new();
+    doc.save(&PdfSaveOptions::default(), &mut warnings)
+}

--- a/backend/src/domain/services/work_quote_exporter.rs
+++ b/backend/src/domain/services/work_quote_exporter.rs
@@ -1,7 +1,9 @@
 use crate::domain::entities::{Building, Expense, ExpenseCategory};
-use printpdf::*;
+use crate::domain::services::pdf_writer::{
+    builtin_font, new_document, save_document, PdfPageBuilder,
+};
+use printpdf::BuiltinFont;
 use rust_decimal::Decimal;
-use std::io::BufWriter;
 
 /// Work Quote Document Exporter - Generates PDF for Devis de Travaux
 ///
@@ -47,86 +49,75 @@ impl WorkQuoteExporter {
         }
 
         // Create PDF document (A4: 210mm x 297mm)
-        let (doc, page1, layer1) =
-            PdfDocument::new("Devis de Travaux", Mm(210.0), Mm(297.0), "Layer 1");
-        let current_layer = doc.get_page(page1).get_layer(layer1);
+        let doc = new_document("Devis de Travaux");
+        let mut current_layer = PdfPageBuilder::new();
 
         // Load fonts
-        let font = doc
-            .add_builtin_font(BuiltinFont::Helvetica)
-            .map_err(|e| e.to_string())?;
-        let font_bold = doc
-            .add_builtin_font(BuiltinFont::HelveticaBold)
-            .map_err(|e| e.to_string())?;
+        let font = builtin_font(BuiltinFont::Helvetica);
+        let font_bold = builtin_font(BuiltinFont::HelveticaBold);
 
         let mut y = 270.0; // Start from top
 
         // === HEADER ===
-        current_layer.use_text(
-            "DEVIS DE TRAVAUX".to_string(),
-            18.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("DEVIS DE TRAVAUX".to_string(), 18.0, 20.0, y, &font_bold);
         y -= 15.0;
 
         // Quote information
         if let Some(ref invoice_num) = expense.invoice_number {
-            current_layer.use_text(
+            current_layer.text(
                 format!("Devis N°: {}", invoice_num),
                 11.0,
-                Mm(20.0),
-                Mm(y),
+                20.0,
+                y,
                 &font_bold,
             );
             y -= 7.0;
         }
 
-        current_layer.use_text(
+        current_layer.text(
             format!("Date: {}", expense.expense_date.format("%d/%m/%Y")),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 10.0;
 
         // Building information
-        current_layer.use_text("COPROPRIÉTÉ".to_string(), 14.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text("COPROPRIÉTÉ".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
-        current_layer.use_text(building.name.clone(), 11.0, Mm(20.0), Mm(y), &font);
+        current_layer.text(building.name.clone(), 11.0, 20.0, y, &font);
         y -= 6.0;
 
-        current_layer.use_text(
+        current_layer.text(
             format!(
                 "{}, {} {}",
                 building.address, building.postal_code, building.city
             ),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
         y -= 10.0;
 
         // Contractor information
-        current_layer.use_text("PRESTATAIRE".to_string(), 14.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text("PRESTATAIRE".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
-        current_layer.use_text(contractor_name.to_string(), 11.0, Mm(20.0), Mm(y), &font);
+        current_layer.text(contractor_name.to_string(), 11.0, 20.0, y, &font);
         y -= 6.0;
 
-        current_layer.use_text(contractor_contact.to_string(), 10.0, Mm(20.0), Mm(y), &font);
+        current_layer.text(contractor_contact.to_string(), 10.0, 20.0, y, &font);
         y -= 10.0;
 
         // Work description
-        current_layer.use_text(
+        current_layer.text(
             "DESCRIPTION DES TRAVAUX".to_string(),
             14.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 8.0;
@@ -134,36 +125,30 @@ impl WorkQuoteExporter {
         // Wrap long description
         let description_lines = Self::wrap_text(&expense.description, 80);
         for line in description_lines {
-            current_layer.use_text(line, 10.0, Mm(20.0), Mm(y), &font);
+            current_layer.text(line, 10.0, 20.0, y, &font);
             y -= 6.0;
         }
         y -= 5.0;
 
         // Timeline
-        current_layer.use_text(
+        current_layer.text(
             format!("Délai d'exécution: {}", timeline),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font_bold,
         );
         y -= 10.0;
 
         // === LINE ITEMS ===
-        current_layer.use_text(
-            "DÉTAIL DU DEVIS".to_string(),
-            14.0,
-            Mm(20.0),
-            Mm(y),
-            &font_bold,
-        );
+        current_layer.text("DÉTAIL DU DEVIS".to_string(), 14.0, 20.0, y, &font_bold);
         y -= 8.0;
 
         // Table header
-        current_layer.use_text("Description", 10.0, Mm(20.0), Mm(y), &font_bold);
-        current_layer.use_text("Quantité", 10.0, Mm(110.0), Mm(y), &font_bold);
-        current_layer.use_text("Prix Unit.", 10.0, Mm(140.0), Mm(y), &font_bold);
-        current_layer.use_text("Total", 10.0, Mm(170.0), Mm(y), &font_bold);
+        current_layer.text("Description", 10.0, 20.0, y, &font_bold);
+        current_layer.text("Quantité", 10.0, 110.0, y, &font_bold);
+        current_layer.text("Prix Unit.", 10.0, 140.0, y, &font_bold);
+        current_layer.text("Total", 10.0, 170.0, y, &font_bold);
         y -= 6.0;
 
         let mut subtotal = Decimal::ZERO;
@@ -179,25 +164,13 @@ impl WorkQuoteExporter {
             } else {
                 item.description.clone()
             };
-            current_layer.use_text(desc, 9.0, Mm(20.0), Mm(y), &font);
+            current_layer.text(desc, 9.0, 20.0, y, &font);
 
-            current_layer.use_text(
-                format!("{:.2}", item.quantity),
-                9.0,
-                Mm(110.0),
-                Mm(y),
-                &font,
-            );
+            current_layer.text(format!("{:.2}", item.quantity), 9.0, 110.0, y, &font);
 
-            current_layer.use_text(
-                format!("{:.2} €", item.unit_price),
-                9.0,
-                Mm(140.0),
-                Mm(y),
-                &font,
-            );
+            current_layer.text(format!("{:.2} €", item.unit_price), 9.0, 140.0, y, &font);
 
-            current_layer.use_text(format!("{:.2} €", item.total), 9.0, Mm(170.0), Mm(y), &font);
+            current_layer.text(format!("{:.2} €", item.total), 9.0, 170.0, y, &font);
 
             subtotal += item.total;
             y -= 5.0;
@@ -205,31 +178,25 @@ impl WorkQuoteExporter {
         y -= 8.0;
 
         // === TOTALS ===
-        current_layer.use_text(
+        current_layer.text(
             format!("SOUS-TOTAL: {:.2} €", subtotal),
             11.0,
-            Mm(140.0),
-            Mm(y),
+            140.0,
+            y,
             &font,
         );
         y -= 6.0;
 
         let tva = subtotal * rust_decimal_macros::dec!(0.21); // Belgian VAT 21% for work
-        current_layer.use_text(
-            format!("TVA (21%): {:.2} €", tva),
-            11.0,
-            Mm(140.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text(format!("TVA (21%): {:.2} €", tva), 11.0, 140.0, y, &font);
         y -= 6.0;
 
         let total = subtotal + tva;
-        current_layer.use_text(
+        current_layer.text(
             format!("TOTAL TTC: {:.2} €", total),
             12.0,
-            Mm(140.0),
-            Mm(y),
+            140.0,
+            y,
             &font_bold,
         );
         y -= 10.0;
@@ -244,7 +211,7 @@ impl WorkQuoteExporter {
             crate::domain::entities::ApprovalStatus::Draft => "○ Brouillon",
         };
 
-        current_layer.use_text(approval_text.to_string(), 11.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text(approval_text.to_string(), 11.0, 20.0, y, &font_bold);
         y -= 15.0;
 
         // === SIGNATURES ===
@@ -252,40 +219,31 @@ impl WorkQuoteExporter {
             y = 40.0;
         }
 
-        current_layer.use_text("SIGNATURES".to_string(), 12.0, Mm(20.0), Mm(y), &font_bold);
+        current_layer.text("SIGNATURES".to_string(), 12.0, 20.0, y, &font_bold);
         y -= 10.0;
 
-        current_layer.use_text(
+        current_layer.text(
             "Le Syndic: ________________".to_string(),
             10.0,
-            Mm(20.0),
-            Mm(y),
+            20.0,
+            y,
             &font,
         );
 
-        current_layer.use_text(
+        current_layer.text(
             "Le Prestataire: ________________".to_string(),
             10.0,
-            Mm(120.0),
-            Mm(y),
+            120.0,
+            y,
             &font,
         );
         y -= 6.0;
 
-        current_layer.use_text(
-            "Date: ________________".to_string(),
-            10.0,
-            Mm(20.0),
-            Mm(y),
-            &font,
-        );
+        current_layer.text("Date: ________________".to_string(), 10.0, 20.0, y, &font);
 
         // Save to bytes
-        let mut buffer = Vec::new();
-        doc.save(&mut BufWriter::new(&mut buffer))
-            .map_err(|e| e.to_string())?;
-
-        Ok(buffer)
+        let page = current_layer.into_page(210.0, 297.0);
+        Ok(save_document(doc, page))
     }
 
     fn wrap_text(text: &str, max_len: usize) -> Vec<String> {

--- a/docs/WBS_GO_LIVE_v0.1.0.md
+++ b/docs/WBS_GO_LIVE_v0.1.0.md
@@ -95,7 +95,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
   - `d988a57` #550 strate 1 — `authStore.refreshAccessToken` dedup in-flight (1 POST partagé entre N callers concurrents) + 5 tests Vitest TDD 4-cat.
   - `0cacd83` #550 strate 1 (refactor helpers) — `Meetings/Expenses/Buildings.spec.ts` passent du UI-login local au `loginAsSyndic[WithBuilding]` partagé (injectAuth), élimine la course `/login → dashboard` (refresh #1 rote cookie → refresh #2 sur cookie révoqué).
   - `5d2a7ae` #550 strate 2 v3 — `apiFetch` attend le refresh in-flight si pas de token (composants `client:load` qui mountent et appellent `api.get` avant `init()` complet). Validé en live console (0 erreur 401 cascade).
-  **Différé** : strate 3 (Resolutions/Invoices/Notifications/AdminDashBoard tests qui passent shared helper mais échouent encore — issue #550 garde la trace). Plancher smoke à confirmer en CI post-merge feature/dev→dev.
+    **Différé** : strate 3 (Resolutions/Invoices/Notifications/AdminDashBoard tests qui passent shared helper mais échouent encore — issue #550 garde la trace). Plancher smoke à confirmer en CI post-merge feature/dev→dev.
 
 - **WP-D2 — Câbler vitest au gate** · #343 · T2 · S-M
   Job `vitest` existe (`ci.yml:402`) ; couvrir auth store (WP-FE1) + composants convocation/réunion @happy/@negative ; cible = composants critiques bêta (pas 181/181). Deps : WP-FE1, WP-FE2.
@@ -112,7 +112,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
   - `bdad9ff` — `become: yes` → `become: true` (yamllint `-s` strict promeut truthy en erreur).
   - `e52afd8` — paths ansible roles 4 niveaux dans `playbook.yml` (même off-by-one que terraform).
   - `0a951f9` — install `community.general:>=8.0.0,<11.0.0` dans CI step (module `ufw` n'est pas dans ansible-core).
-  Tooling host installé en parallèle (terraform 1.9.8, yamllint 1.38, shellcheck, gitleaks 8.30, oasdiff 1.15.3, kubeconform 0.6.7, pre-commit) pour reproduire localement (mémoire `feedback_use-docker-compose-for-tooling.md` complétée).
+    Tooling host installé en parallèle (terraform 1.9.8, yamllint 1.38, shellcheck, gitleaks 8.30, oasdiff 1.15.3, kubeconform 0.6.7, pre-commit) pour reproduire localement (mémoire `feedback_use-docker-compose-for-tooling.md` complétée).
 
 ### Track F — Ops VPS (concurrent Track A — aucun fichier partagé)
 
@@ -164,6 +164,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
   Tx.1 job CI `test:characterization` bloque merge si ROUGE + Tx.2 helpers shared multi-rôle complets (`loginAsContractorMagicLink`, etc.) + Tx.3 log Tier 2 `docs/agent-activity/YYYY-MM-DD-bob-slice-N.md` par session. Démarrage **immédiat** dès slice 0. Deps : WP-H0.
 
 > **Cartographie Maury ↔ WPs Track H existants** :
+>
 > - WP-H1 ⇔ Story 1.4 (Building.is_conformant + #553 fix) + 1.1-1.3 (refacto ACP) — Maury Track H Story H1 FAIT (commit `6a053a1`)
 > - WP-H2 ⇔ Story 4.9 méga `[cluster-coord]` (validate-before-compute 4 use-cases) — Maury Track H Story H2 **FAIT** (`3ede509`, retravaillé en gate ACP par WP-CL1)
 > - WP-H3 ⇔ Story 4.5 (Meeting.assert_can_complete reprise #554) — Maury Track H Story H3 **FAIT** (`3ede509`, étendu quorum double par WP-CL3/H9)
@@ -175,6 +176,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 #### Sous-pipeline Maury Track H bloqueurs légaux (kit signé 2026-06-15)
 
 > Voir `docs/maury/refonte-ux-multi-role-acp/track-h-bloqueurs/` (5 docs Maury-grade signés v1.0 @gilmry 2026-06-15, commit `50f3c43`) :
+>
 > - `README.md` — index BMAD
 > - `brief.md` — Vision (3 personas, CB-H1-9, INV-H1-9 avec bug fix `quota_basis`, 9 SCB)
 > - `prd.md` — FR-H1/H2/H3/B4 user journeys couvrant acte 1000 ET 10000
@@ -183,6 +185,7 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 > - `validation.md` — Phase F PO acceptation signée @gilmry 2026-06-15
 >
 > **Statut waves d'exécution** :
+>
 > - **V1 (atomique H1, 0.5j)** : FAIT (commit `6a053a1`).
 > - **V2 // (H2 + H3 BE puis FE, 1.5j+1j)** : FAIT (commit `3ede509`).
 > - **V3 (B4 spec, 0.25j)** : regression spec Playwright à livrer (non bloquant — code B4 OK).
@@ -193,13 +196,16 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 > **Déjà fait (réutilisé / retravaillé)** : Story H1 ✅ (`6a053a1`, conservée = sous-total bloc) ; H2 ✅ (`3ede509`, **retravaillée** par WP-CL1 — gate building→ACP) ; H3 ✅ (`3ede509`, **étendue** par WP-CL3 — quorum simple→double).
 
-> **📊 Statut d'exécution #618 (màj 2026-07-24, branche `feature/dev`, HEAD `b9fa9d6`)** — CI **backend** verte par story (Unit/BDD/oasdiff/Lint) ; les rouges CI sont **pré-existants et tracés** (cf. « Blocages » ci-dessous), pas des régressions Track H. **✅ Track H #618 COMPLET pour v0.1.0** (tous clusters livrés/poussés sauf reports explicites v0.2.0 : H13b/c #635, H16 CL5).
+> **📊 Statut d'exécution #618 (màj 2026-07-24, branche `feature/dev`, HEAD `b9fa9d6`)** — CI **backend** verte par story (Unit/BDD/oasdiff/Lint) ; les rouges CI sont **pré-existants et tracés** (cf. « Blocages » ci-dessous), pas des régressions Track H. **✅ Track H #618 COMPLET côté code pour v0.1.0** (tous clusters livrés/poussés sauf reports explicites v0.2.0 : H13b/c #635, H16 CL5).
+>
+> **Correction 2026-07-26 (audit sync `feature/dev`, `docs/agent-activity/2026-07-26-sync-audit-feature-dev.md`)** : la mention "COMPLET" ci-dessus décrit l'état du **code** — elle ne signifiait pas que les issues satellites étaient administrativement closes. Sur 34 références réelles à des issues dans ce WBS, 30 (88 %) étaient encore ouvertes au 2026-07-26, dont les 23 stories des slices 0-3 déjà mergées (#557-#575, #580, #584, #593, #594) : fermées le même jour avec le SHA d'implémentation en justification. Un résidu de non-conformité (second chemin de calcul du quorum en `f64` dans `AgSession`, parallèle au chemin conforme `Meeting`/H9) a par ailleurs été signalé par @gilmry le 2026-07-25 sur #618 → tracé séparément en [#661](https://github.com/gilmry/koprogo/issues/661), non couvert par le "COMPLET" ci-dessus.
+>
 > - **WP-CL0** ✅ — ADR-0010/0011/0012 + dossier BMAD `track-h-conformite-legale/` (5 docs signés).
 > - **WP-CL1** ✅ — H4 (`acps.total_tantiemes` + migration/backfill) → H5 (`Acp::assert_conformant` + `AcpNotConformantError` 422) → H6 (`find_by_id_with_metrics`) → H7 (bascule des 4 gates building→ACP). Commit `a11577e`.
 > - **WP-CL2** ✅ — H8 retrait `Unit::MAX_QUOTA` (borne = acte de base). Commit `918d251`.
 > - **WP-CL7** ✅ — H14 doc `CONVOCATIONS_AG.rst` 15 j toutes AG (`c3d021a`) ; code `convocation.rs` déjà conforme (aucune dette).
 > - **WP-CL4** 🔄 **partiel** — H11 Budget f64→Decimal ✅ · H12 `DistributionCriteria {value|utility|mixed}` + formule 2 niveaux ✅ · **H13a** fonds de réserve 5 % sur l'ACP (`assert_reserve_fund_compliant`, renonçable 4/5, 422) ✅ (`58f1731`). **Différés v0.2.0 → [#635](https://github.com/gilmry/koprogo/issues/635)** : H13b `call_for_funds.fund_type` + H13c FE `<ReserveFundIndicator>` (bloqué #634) + **modèle `Fund` (thésaurisation / fonds affectés, réaffectation par décision d'AG)**.
-> - **WP-CL3** ✅ — specs H9/H10/H17 amendées (Art. 3.87 §1/§5/§7, `29bdda1`). **H9 quorum double** à la clôture (têtes > 50 % ET quotités ≥ 50 % OU > 3/4, `006030e`) → **H10** gate `check_quorum_for_voting` sur `cast_vote` (§5, `e9b97d1` ; proxy §7 déjà câblé via `validate_proxy_limit` Decimal) → **H17** représentant de vote / suspension §1 (domaine + gate `cast_vote` `VOTING_RIGHT_SUSPENDED` 422 + BDD `voting_right_suspension`, `4570c27`/`9e8a037`/`aecf92c`). *Note : `validate_proxy_mandate` domaine (f64, §7 en AND) reste mort/non câblé — à supprimer ou aligner si on retouche au vote.*
+> - **WP-CL3** ✅ — specs H9/H10/H17 amendées (Art. 3.87 §1/§5/§7, `29bdda1`). **H9 quorum double** à la clôture (têtes > 50 % ET quotités ≥ 50 % OU > 3/4, `006030e`) → **H10** gate `check_quorum_for_voting` sur `cast_vote` (§5, `e9b97d1` ; proxy §7 déjà câblé via `validate_proxy_limit` Decimal) → **H17** représentant de vote / suspension §1 (domaine + gate `cast_vote` `VOTING_RIGHT_SUSPENDED` 422 + BDD `voting_right_suspension`, `4570c27`/`9e8a037`/`aecf92c`). _Note : `validate_proxy_mandate` domaine (f64, §7 en AND) reste mort/non câblé — à supprimer ou aligner si on retouche au vote._
 > - **WP-CL6** ✅ — H15 migration `units.organization_id`→`acp_id` (`b9fa9d6`) : trio réversible (add nullable → backfill `building.acp_id` → NOT NULL + drop org + policy/index) + domaine/DTO/repo runtime SQL/handlers scope_guard #603/seed. Validé testcontainers (e2e_units 6/6, integration_unit_owner 13/13, bdd_building_conformity 9/9, bdd_validate_before_compute). Cohérence post-#602 (comme buildings).
 >
 > **🔴 Blocages go-live tracés (hors Track H, à clore avant tag v0.1.0)** : **[#634](https://github.com/gilmry/koprogo/issues/634)** (frontend Dependabot — build/vitest/contract/docker-frontend + NPM audit, même ERESOLVE astro 7 ⊥ `@vite-pwa/astro`) · **[#636](https://github.com/gilmry/koprogo/issues/636)** (Rust audit : `lopdf` RUSTSEC-2026-0187 + `quinn-proto` RUSTSEC-2026-0185, 2× high ; recoupe #432) · **[#604](https://github.com/gilmry/koprogo/issues/604)** [BLOCKER] trigger `buildings.organization_id` supprimé · **[#603](https://github.com/gilmry/koprogo/issues/603)** [SECURITY] `verify_org_access` skip 7 handlers · **[#617](https://github.com/gilmry/koprogo/issues/617)**/#605 Playwright E2E.
@@ -339,6 +345,7 @@ gantt
 - **WP-I9 — Documentation Vivante refresh + retire continue-on-error** · T2 · S · _wave V4_ · **PARTIEL** (Story B9 commit `3de6530` a retiré le bypass ; CI a révélé 8 specs Phase B FE + scenarios Documentation Vivante cassés → **Phase C ouverte #617** : testIgnore `refonte-ux/phase-b-fe/` (commit `83985e4`) + `continue-on-error: true` restauré sur step Doc Vivante (commit `4fedde7`) le temps de stabiliser dans Phase C).
 
 > **Critères DoD Track I (intégrés au gate G1)** :
+>
 > - svelte-check 0/0 erreur/warning ; axe-core violations = 0 par composant ; Vitest 4-cat + Playwright multi-rôle par WP ; data-testid sur 100% éléments interactifs ; pas de stockage JWT en localStorage ; bundle Phase I ≤ +50 KB gzip (baseline mesurée 2026-06-07 = 4,3 MB total / 0,6 MB gzip JS).
 >
 > **Statut Track I global (2026-06-15)** : WP-I0 → WP-I8 **FAIT** (10 commits Phase B FE B0-B8 + B0bis sur feature/dev). WP-I9 **PARTIEL** — Documentation Vivante e2e tombée dans Phase C #617 (8 specs + N scenarios à stabiliser avant retrait définitif des bypasses CI). Voir mémoires `project_phase-c-reactivate-e2e-specs.md` et `feedback_maury-fullstack-first.md`.
@@ -431,6 +438,7 @@ graph LR
 ## Gantt Track I — Phase B FE par passe d'agent
 
 > **Unité de mesure** : 1 passe d'agent = 1 cycle complet **RED → GREEN → REFACTOR → REVIEW**.
+>
 > - RED : agent écrit les tests `@happy/@edge/@security/@negative` qui échouent.
 > - GREEN : agent implémente jusqu'à faire passer les tests.
 > - REFACTOR : agent nettoie (rustfmt/prettier, supprime duplicates, simplifie).
@@ -464,19 +472,20 @@ gantt
 ```
 
 **Lecture du Gantt** :
+
 - **Chemin critique Track I** (rouge) : `I0 → I7 → I8 → I9 → G1 → G2` = 1+2+1+0.5+1+0.5 = **6 jours wall-clock minimum**.
 - **Vague la plus chargée** : V1 lance 4 agents en parallèle (1 BE + 3 FE). Pattern docker-parallelism vérifié (cf. mémoire `feedback_docker-parallelism-bottleneck.md`).
 - **Couplage Track I ↔ G1** : I9 (DocVivante refresh) doit être vert avant G1 (revue humaine), sinon la dette UX casse le gate de release.
 
 ### Budget tokens estimé Track I
 
-| Vague | Stories | Cycles RGRR | Tokens estimés (modèle Opus 4.7) |
-|---|---|---|---|
-| V1 | I0, I1, I2, I3 | 4 cycles parallèles | ~ 800 K tokens (4 × 200 K subagent) |
-| V2 | I4, I6 | 2 cycles parallèles | ~ 400 K tokens |
-| V3 | I5, I7 | 2 cycles longs (L) | ~ 600 K tokens |
-| V4 | I8, I9 | 2 cycles courts | ~ 300 K tokens |
-| **Total Track I** | 9 + 1 gate | 10 passes | **~ 2,1 M tokens** |
+| Vague             | Stories        | Cycles RGRR         | Tokens estimés (modèle Opus 4.7)    |
+| ----------------- | -------------- | ------------------- | ----------------------------------- |
+| V1                | I0, I1, I2, I3 | 4 cycles parallèles | ~ 800 K tokens (4 × 200 K subagent) |
+| V2                | I4, I6         | 2 cycles parallèles | ~ 400 K tokens                      |
+| V3                | I5, I7         | 2 cycles longs (L)  | ~ 600 K tokens                      |
+| V4                | I8, I9         | 2 cycles courts     | ~ 300 K tokens                      |
+| **Total Track I** | 9 + 1 gate     | 10 passes           | **~ 2,1 M tokens**                  |
 
 Baseline observée Phase A (slice 3 BE = 9 stories, ~ 1,8 M tokens consommés session 2026-06-09). Track I sera comparable.
 **Démarrages J1 sans inter-dép** : A1, B1, B2, FE1(moitié backend), E1, F1(terraform plan). Ops est court en effort mais borné par la latence Tier-1 humaine → **lancer F1-prep + E1 dès J1** pour que Ops finisse en parallèle du long pole A2→A5, pas après.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "svelte": "^5.56.7",
         "svelte-i18n": "^4.0.1",
         "tailwindcss": "^4.2.2",
-        "typescript": "^7.0.2",
+        "typescript": "^5.9.3",
         "vite": "^7.3.2"
       },
       "devDependencies": {
@@ -195,9 +195,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -213,9 +210,6 @@
       "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -233,9 +227,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -251,9 +242,6 @@
       "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -508,13 +496,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -523,9 +511,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -533,21 +521,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -574,14 +562,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -604,14 +592,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -718,9 +706,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -742,29 +730,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -847,27 +835,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -890,26 +878,26 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2041,33 +2029,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2075,13 +2063,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2133,9 +2121,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2148,9 +2133,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2165,9 +2147,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2180,9 +2159,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2999,9 +2975,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -3011,19 +2987,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -3033,19 +3009,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -3059,9 +3054,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -3075,9 +3070,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -3091,9 +3086,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -3107,9 +3102,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -3123,9 +3118,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -3139,9 +3134,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -3155,9 +3150,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -3171,9 +3166,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -3187,9 +3182,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -3203,9 +3198,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -3215,19 +3210,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -3237,19 +3232,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -3259,19 +3254,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3281,19 +3276,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -3303,19 +3298,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -3325,19 +3320,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -3347,19 +3342,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -3369,38 +3364,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -3410,16 +3421,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -3429,16 +3440,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -3448,7 +3459,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -3585,9 +3596,9 @@
       "license": "MIT"
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "1.34.11",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.11.tgz",
-      "integrity": "sha512-V09ayfnb5GyysmvARbt+voFZAjGcf7hSYxOYxSkCc4fbH/DTfq5YWoec8cflvmHHqyIFbqvmGKmYFzqhr9zxDg==",
+      "version": "1.34.17",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.17.tgz",
+      "integrity": "sha512-wsV2keCt6B806XpSdezbWZ9aFJYf14YVh+XQf0ESt7M90yqVuxH9//PxvtC70sgj9OCkRM3nRaLfu4MsGQZRig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3596,7 +3607,7 @@
         "colorette": "1.4.0",
         "https-proxy-agent": "7.0.6",
         "js-levenshtein": "1.1.6",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "minimatch": "5.1.9",
         "pluralize": "8.0.0",
         "yaml-ast-parser": "0.0.43"
@@ -3607,78 +3618,36 @@
       }
     },
     "node_modules/@rollup/plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz",
+      "integrity": "sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@rollup/pluginutils": "^3.1.0"
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0",
         "@types/babel__core": "^7.1.9",
-        "rollup": "^1.20.0||^2.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "@types/babel__core": {
           "optional": true
+        },
+        "rollup": {
+          "optional": true
         }
       }
     },
-    "node_modules/@rollup/plugin-babel/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-babel/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-babel/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-babel/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-      "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3701,87 +3670,40 @@
       }
     },
     "node_modules/@rollup/plugin-replace": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
-      "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "magic-string": "^0.25.7"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
       },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/estree-walker": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
+      "integrity": "sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "^7.0.3",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -4246,29 +4168,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@surma/rollup-plugin-off-main-thread": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
-      "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ejs": "^3.1.6",
-        "json5": "^2.2.0",
-        "magic-string": "^0.25.0",
-        "string.prototype.matchall": "^4.0.6"
-      }
-    },
-    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
@@ -4422,9 +4321,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4440,9 +4336,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4460,9 +4353,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4478,9 +4368,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4738,6 +4625,22 @@
         "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
       }
     },
+    "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
+      "version": "3.0.0-pre1",
+      "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
+      "integrity": "sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ejs": "^3.1.10",
+        "json5": "^2.2.3",
+        "magic-string": "^0.30.21",
+        "string.prototype.matchall": "^4.0.12"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -4843,326 +4746,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
-    },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -5844,9 +5427,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5895,15 +5478,15 @@
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -6755,9 +6338,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6823,6 +6406,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -6850,9 +6452,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6879,15 +6481,18 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7058,6 +6663,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eta": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+      "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/bgub/eta?sponsor=1"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -7122,9 +6740,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7256,6 +6874,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7277,18 +6896,21 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7457,16 +7079,16 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -7622,9 +7244,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8029,6 +7651,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
@@ -8411,9 +8049,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8862,13 +8510,6 @@
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "license": "MIT"
     },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9165,9 +8806,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -9382,13 +9023,14 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -9609,9 +9251,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -9628,7 +9270,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10017,20 +9659,406 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.80.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
-      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
       "devOptional": true,
       "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/s.color": {
       "version": "0.0.15",
@@ -10052,15 +10080,15 @@
       }
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },
@@ -10168,9 +10196,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10206,9 +10234,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -10277,48 +10305,53 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -10364,15 +10397,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -10384,14 +10417,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10466,9 +10499,9 @@
       "license": "MIT"
     },
     "node_modules/smob": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
-      "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+      "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10530,14 +10563,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
@@ -10629,19 +10654,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10651,16 +10677,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10848,9 +10874,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -11201,18 +11227,18 @@
       }
     },
     "node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11228,37 +11254,16 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-auto-import-cache": {
@@ -11308,9 +11313,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11711,12 +11716,12 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -12355,14 +12360,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -12394,30 +12399,30 @@
       }
     },
     "node_modules/workbox-background-sync": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.0.tgz",
-      "integrity": "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz",
+      "integrity": "sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-broadcast-update": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
-      "integrity": "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz",
+      "integrity": "sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-build": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.0.tgz",
-      "integrity": "sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.1.tgz",
+      "integrity": "sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12425,39 +12430,39 @@
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.11.0",
         "@babel/runtime": "^7.11.2",
-        "@rollup/plugin-babel": "^5.2.0",
-        "@rollup/plugin-node-resolve": "^15.2.3",
-        "@rollup/plugin-replace": "^2.4.1",
-        "@rollup/plugin-terser": "^0.4.3",
-        "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-replace": "^6.0.3",
+        "@rollup/plugin-terser": "^1.0.0",
+        "@trickfilm400/rollup-plugin-off-main-thread": "^3.0.0-pre1",
         "ajv": "^8.6.0",
         "common-tags": "^1.8.0",
+        "eta": "^4.5.1",
         "fast-json-stable-stringify": "^2.1.0",
         "fs-extra": "^9.0.1",
         "glob": "^11.0.1",
-        "lodash": "^4.17.20",
         "pretty-bytes": "^5.3.0",
-        "rollup": "^2.79.2",
+        "rollup": "^4.53.3",
         "source-map": "^0.8.0-beta.0",
         "stringify-object": "^3.3.0",
         "strip-comments": "^2.0.1",
         "tempy": "^0.6.0",
         "upath": "^1.2.0",
-        "workbox-background-sync": "7.4.0",
-        "workbox-broadcast-update": "7.4.0",
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-google-analytics": "7.4.0",
-        "workbox-navigation-preload": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-range-requests": "7.4.0",
-        "workbox-recipes": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0",
-        "workbox-streams": "7.4.0",
-        "workbox-sw": "7.4.0",
-        "workbox-window": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-broadcast-update": "7.4.1",
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-google-analytics": "7.4.1",
+        "workbox-navigation-preload": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-range-requests": "7.4.1",
+        "workbox-recipes": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1",
+        "workbox-streams": "7.4.1",
+        "workbox-sw": "7.4.1",
+        "workbox-window": "7.4.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -12476,140 +12481,129 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/workbox-build/node_modules/workbox-window": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz",
-      "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2",
-        "workbox-core": "7.4.0"
-      }
-    },
     "node_modules/workbox-cacheable-response": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.0.tgz",
-      "integrity": "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz",
+      "integrity": "sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.0.tgz",
-      "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
+      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/workbox-expiration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.0.tgz",
-      "integrity": "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.1.tgz",
+      "integrity": "sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "idb": "^7.0.1",
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-google-analytics": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.0.tgz",
-      "integrity": "sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz",
+      "integrity": "sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-background-sync": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-background-sync": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-navigation-preload": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.0.tgz",
-      "integrity": "sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz",
+      "integrity": "sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-precaching": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.0.tgz",
-      "integrity": "sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.1.tgz",
+      "integrity": "sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-range-requests": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.0.tgz",
-      "integrity": "sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz",
+      "integrity": "sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-recipes": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.0.tgz",
-      "integrity": "sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.1.tgz",
+      "integrity": "sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-cacheable-response": "7.4.0",
-        "workbox-core": "7.4.0",
-        "workbox-expiration": "7.4.0",
-        "workbox-precaching": "7.4.0",
-        "workbox-routing": "7.4.0",
-        "workbox-strategies": "7.4.0"
+        "workbox-cacheable-response": "7.4.1",
+        "workbox-core": "7.4.1",
+        "workbox-expiration": "7.4.1",
+        "workbox-precaching": "7.4.1",
+        "workbox-routing": "7.4.1",
+        "workbox-strategies": "7.4.1"
       }
     },
     "node_modules/workbox-routing": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.0.tgz",
-      "integrity": "sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.1.tgz",
+      "integrity": "sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-strategies": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.0.tgz",
-      "integrity": "sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.1.tgz",
+      "integrity": "sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0"
+        "workbox-core": "7.4.1"
       }
     },
     "node_modules/workbox-streams": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.0.tgz",
-      "integrity": "sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.1.tgz",
+      "integrity": "sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "workbox-core": "7.4.0",
-        "workbox-routing": "7.4.0"
+        "workbox-core": "7.4.1",
+        "workbox-routing": "7.4.1"
       }
     },
     "node_modules/workbox-sw": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.0.tgz",
-      "integrity": "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.1.tgz",
+      "integrity": "sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12623,13 +12617,6 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "7.4.1"
       }
-    },
-    "node_modules/workbox-window/node_modules/workbox-core": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.1.tgz",
-      "integrity": "sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "svelte": "^5.56.7",
     "svelte-i18n": "^4.0.1",
     "tailwindcss": "^4.2.2",
-    "typescript": "^7.0.2",
+    "typescript": "^5.9.3",
     "vite": "^7.3.2"
   },
   "devDependencies": {
@@ -71,7 +71,7 @@
     "devalue": ">=5.6.4",
     "vite": "^7.3.2",
     "@vite-pwa/astro": {
-      "astro": "^6.1.2"
+      "astro": "^7.1.3"
     }
   }
 }

--- a/frontend/src/lib/api/ag-sessions.ts
+++ b/frontend/src/lib/api/ag-sessions.ts
@@ -7,12 +7,7 @@ import { api } from "../api";
  */
 
 export type VideoPlatform =
-  | "Zoom"
-  | "MicrosoftTeams"
-  | "GoogleMeet"
-  | "Jitsi"
-  | "Whereby"
-  | "Other";
+  "Zoom" | "MicrosoftTeams" | "GoogleMeet" | "Jitsi" | "Whereby" | "Other";
 export type AgSessionStatus = "Scheduled" | "Live" | "Ended" | "Cancelled";
 
 export interface AgSession {

--- a/frontend/src/lib/services/ticket.service.ts
+++ b/frontend/src/lib/services/ticket.service.ts
@@ -2,13 +2,7 @@ import { ticketsApi, TicketStatus, type Ticket } from "../api/tickets";
 
 /** Actions that can be performed on a ticket */
 export type TicketAction =
-  | "assign"
-  | "start"
-  | "resolve"
-  | "close"
-  | "cancel"
-  | "reopen"
-  | "delete";
+  "assign" | "start" | "resolve" | "close" | "cancel" | "reopen" | "delete";
 
 /**
  * Determine which actions are available for a ticket based on its status and user role.

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -139,11 +139,7 @@ export interface Expense {
     | "Other";
   payment_status: "Pending" | "Paid" | "Overdue" | "Cancelled";
   approval_status?:
-    | "draft"
-    | "pending_approval"
-    | "approved"
-    | "rejected"
-    | null;
+    "draft" | "pending_approval" | "approved" | "rejected" | null;
   paid_date?: string;
   supplier?: string;
   invoice_number?: string;

--- a/frontend/src/lib/utils/conformity.ts
+++ b/frontend/src/lib/utils/conformity.ts
@@ -37,8 +37,7 @@ export function isConformityError(
   const wrapped =
     (direct.body as Record<string, unknown> | undefined) ??
     ((direct.response as Record<string, unknown> | undefined)?.data as
-      | Record<string, unknown>
-      | undefined);
+      Record<string, unknown> | undefined);
   return !!wrapped && looksLikeBody(wrapped);
 }
 

--- a/frontend/src/lib/utils/fileUpload.ts
+++ b/frontend/src/lib/utils/fileUpload.ts
@@ -58,11 +58,7 @@ export function isAcceptedSize(sizeBytes: number): boolean {
 }
 
 export type UploadErrorCode =
-  | "max-files"
-  | "too-large"
-  | "bad-mime"
-  | "presign-failed"
-  | "upload-failed";
+  "max-files" | "too-large" | "bad-mime" | "presign-failed" | "upload-failed";
 
 export class UploadError extends Error {
   code: UploadErrorCode;

--- a/frontend/src/lib/utils/meetingCompletion.ts
+++ b/frontend/src/lib/utils/meetingCompletion.ts
@@ -33,8 +33,7 @@ export function isMeetingCompletionError(
   const wrapped =
     (direct.body as Record<string, unknown> | undefined) ??
     ((direct.response as Record<string, unknown> | undefined)?.data as
-      | Record<string, unknown>
-      | undefined);
+      Record<string, unknown> | undefined);
   return !!wrapped && looksLikeBody(wrapped);
 }
 

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -2050,21 +2050,13 @@ export interface components {
      * @enum {string}
      */
     AttendanceStatus:
-      | "Pending"
-      | "WillAttend"
-      | "WillNotAttend"
-      | "Attended"
-      | "DidNotAttend";
+      "Pending" | "WillAttend" | "WillNotAttend" | "Attended" | "DidNotAttend";
     /**
      * @description Booking status lifecycle
      * @enum {string}
      */
     BookingStatus:
-      | "Pending"
-      | "Confirmed"
-      | "Cancelled"
-      | "Completed"
-      | "NoShow";
+      "Pending" | "Confirmed" | "Cancelled" | "Completed" | "NoShow";
     /**
      * @description Statut du budget annuel
      * @enum {string}
@@ -2348,11 +2340,7 @@ export interface components {
      * @enum {string}
      */
     EtatDateStatus:
-      | "requested"
-      | "in_progress"
-      | "generated"
-      | "delivered"
-      | "expired";
+      "requested" | "in_progress" | "generated" | "delivered" | "expired";
     EvaluationScoresDto: {
       /** Format: int32 */
       communication: number;
@@ -2379,11 +2367,7 @@ export interface components {
     };
     /** @enum {string} */
     ExchangeStatus:
-      | "Offered"
-      | "Requested"
-      | "InProgress"
-      | "Completed"
-      | "Cancelled";
+      "Offered" | "Requested" | "InProgress" | "Completed" | "Cancelled";
     /** @enum {string} */
     ExchangeType: "Service" | "ObjectLoan" | "SharedPurchase";
     /**
@@ -2627,12 +2611,7 @@ export interface components {
      * @enum {string}
      */
     ReminderStatus:
-      | "Pending"
-      | "Sent"
-      | "Opened"
-      | "Paid"
-      | "Escalated"
-      | "Cancelled";
+      "Pending" | "Sent" | "Opened" | "Paid" | "Escalated" | "Cancelled";
     ReopenTicketRequest: {
       reason: string;
     };

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,11 +6,7 @@ export default defineConfig({
   // "$state rune outside svelte" that fire when bind:value compiled
   // output is accessed from .test.ts files.
   mode: "production",
-  plugins: [
-    svelte({
-      hot: false,
-    }),
-  ],
+  plugins: [svelte()],
   resolve: {
     conditions: ["browser"],
   },


### PR DESCRIPTION
## Contexte

Diagnostiqué dans `docs/agent-activity/2026-07-26-sync-audit-feature-dev.md` §5 : `feature/dev` a sa CI rouge sur 4 gates/6 (CI Pipeline, Security Audit, Docker Build — Characterization E2E Gate expliqué comme non-anomalie, se déclenche uniquement sur PR vers main/dev par design).

## Ce que ça corrige

**Frontend (#634)** : `typescript` 7.0.2 → 5.9.3. `@astrojs/check@0.9.9` exige `peer typescript@"^5.0.0 || ^6.0.0"` — le 7.x cassait `npm install` (ERESOLVE) sur tous les jobs frontend de CI Pipeline + Docker Build.

**Backend (#658 + #636)** : au lieu de downgrader `printpdf` vers 0.7 (ce qui réintroduirait RUSTSEC-2026-0187, la vulnérabilité high que le bump `printpdf` 0.7→0.11 visait justement à corriger), on garde `printpdf` 0.11.1 et on résout la vraie cause de l'échec de compilation :
- `time` 0.3.47 → 0.3.54 (`lopdf 0.44` utilise `BorrowedFormatItem::StringLiteral`, introduit seulement dans `time` 0.3.48 — `cargo update -p time` suffit, la contrainte `lopdf` est déjà `"0.3"` non bornée).
- `quinn-proto` 0.11.14 → 0.11.16 (ferme RUSTSEC-2026-0185, 2e vuln de #636).

**Effet de bord découvert en cours de route** : `printpdf` 0.11 a réécrit son API en profondeur (plus de `Layer`/`PdfLayerReference`/`IndirectFontRef`, tout passe par une liste d'`Op` empilés sur `PdfPage`). Les 7 exporteurs PDF (`domain/services/*_exporter.rs`) utilisaient encore l'API 0.7 et ne compilaient plus une fois `printpdf` réellement à 0.11 — migrés vers un petit adaptateur partagé `pdf_writer.rs` (`PdfPageBuilder`) qui reproduit le pattern `use_text(text, size, x, y, &font)` existant. Les 14 tests unitaires des exporteurs (dont vérification header `%PDF` + taille) passent sans changement de leur côté — comportement préservé.

**Frontend, découverte additionnelle** : `vitest.config.ts` utilisait `hot: false` sur le plugin `@sveltejs/vite-plugin-svelte`, option retirée du type `Options` dans la version actuelle (l'effet recherché est déjà couvert par `mode: "production"` selon le commentaire du fichier). Supprimé — `astro check` passe de 1 erreur à 0, 344 tests Vitest toujours verts.

**`npm audit fix`** (sans `--force`, approuvé) : 11 → 10 vulnérabilités high. Les 10 restantes sont concentrées dans des chaînes de dépendances **dev-only** (`workbox-build` via le build PWA, `@redocly/openapi-core` via la génération OpenAPI) — pas de code livré au navigateur. Nécessitent un bump majeur (`--force`) non tenté ici ; suivi dans une issue dédiée.

Correction associée dans `docs/WBS_GO_LIVE_v0.1.0.md` §618 : nuance la mention "COMPLET" (code vs état administratif des issues satellites, cf. les 23 issues fermées le même jour dans le rapport §2.1).

## Test plan

- [x] `cargo check --lib --tests` vert (0 erreur, contre 16 avant)
- [x] `cargo test --lib exporter` — 14/14 tests passent (dont vérification `%PDF` header + taille)
- [x] `astro check` — 0 erreur (contre 1 avant)
- [x] `npx vitest run` — 344/344 tests passent
- [x] `npx prettier --check .` — propre
- [ ] CI GitHub à vérifier après ouverture de cette PR

Refs: #634, #636, #658