### PR TITLE
fix(#617): stabilise C1 role-assignment.spec.ts + resync WBS

### DIFF
--- a/backend/src/infrastructure/database/repositories/user_role_repository_impl.rs
+++ b/backend/src/infrastructure/database/repositories/user_role_repository_impl.rs
@@ -22,9 +22,10 @@ impl PostgresUserRoleRepository {
             .parse()
             .map_err(|e| format!("Invalid role: {}", e))?;
 
-        // Story 3.5 — `valid_until` / `delegated_from_user_id` are best-effort
-        // reads: legacy SELECT queries that do not yet project these columns
-        // simply default to `None`, preserving native (permanent) semantics.
+        // Story 3.5 — `valid_until` / `delegated_from_user_id`. `.ok()` kept
+        // defensive (all queries now project both columns) rather than
+        // `.map_err(...)?`, so a future query that forgets them degrades to
+        // `None` (permanent) instead of hard-failing.
         let valid_until = row.try_get("valid_until").ok();
         let delegated_from_user_id = row.try_get("delegated_from_user_id").ok();
 
@@ -59,9 +60,9 @@ impl UserRoleRepository for PostgresUserRoleRepository {
     async fn create(&self, assignment: &UserRoleAssignment) -> Result<UserRoleAssignment, String> {
         let row = sqlx::query(
             r#"
-            INSERT INTO user_roles (id, user_id, role, organization_id, is_primary, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
-            RETURNING id, user_id, role, organization_id, is_primary, created_at, updated_at
+            INSERT INTO user_roles (id, user_id, role, organization_id, is_primary, valid_until, delegated_from_user_id, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            RETURNING id, user_id, role, organization_id, is_primary, valid_until, delegated_from_user_id, created_at, updated_at
             "#,
         )
         .bind(assignment.id)
@@ -69,6 +70,8 @@ impl UserRoleRepository for PostgresUserRoleRepository {
         .bind(assignment.role.to_string())
         .bind(assignment.organization_id)
         .bind(assignment.is_primary)
+        .bind(assignment.valid_until)
+        .bind(assignment.delegated_from_user_id)
         .bind(assignment.created_at)
         .bind(assignment.updated_at)
         .fetch_one(&self.pool)
@@ -81,7 +84,7 @@ impl UserRoleRepository for PostgresUserRoleRepository {
     async fn list_for_user(&self, user_id: Uuid) -> Result<Vec<UserRoleAssignment>, String> {
         let rows = sqlx::query(
             r#"
-            SELECT id, user_id, role, organization_id, is_primary, created_at, updated_at
+            SELECT id, user_id, role, organization_id, is_primary, valid_until, delegated_from_user_id, created_at, updated_at
             FROM user_roles
             WHERE user_id = $1
             ORDER BY is_primary DESC, created_at ASC
@@ -107,7 +110,7 @@ impl UserRoleRepository for PostgresUserRoleRepository {
 
         let rows = sqlx::query(
             r#"
-            SELECT id, user_id, role, organization_id, is_primary, created_at, updated_at
+            SELECT id, user_id, role, organization_id, is_primary, valid_until, delegated_from_user_id, created_at, updated_at
             FROM user_roles
             WHERE user_id = ANY($1)
             ORDER BY user_id, is_primary DESC, created_at ASC
@@ -146,8 +149,8 @@ impl UserRoleRepository for PostgresUserRoleRepository {
         for a in assignments {
             sqlx::query(
                 r#"
-                INSERT INTO user_roles (id, user_id, role, organization_id, is_primary, created_at, updated_at)
-                VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+                INSERT INTO user_roles (id, user_id, role, organization_id, is_primary, valid_until, delegated_from_user_id, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())
                 "#,
             )
             .bind(a.id)
@@ -155,6 +158,8 @@ impl UserRoleRepository for PostgresUserRoleRepository {
             .bind(a.role.to_string())
             .bind(a.organization_id)
             .bind(a.is_primary)
+            .bind(a.valid_until)
+            .bind(a.delegated_from_user_id)
             .execute(&mut *tx)
             .await
             .map_err(|e| format!("Failed to insert role: {}", e))?;
@@ -169,7 +174,7 @@ impl UserRoleRepository for PostgresUserRoleRepository {
     async fn find_by_id(&self, id: Uuid) -> Result<Option<UserRoleAssignment>, String> {
         let row = sqlx::query(
             r#"
-            SELECT id, user_id, role, organization_id, is_primary, created_at, updated_at
+            SELECT id, user_id, role, organization_id, is_primary, valid_until, delegated_from_user_id, created_at, updated_at
             FROM user_roles
             WHERE id = $1
             "#,
@@ -213,7 +218,7 @@ impl UserRoleRepository for PostgresUserRoleRepository {
             UPDATE user_roles
             SET is_primary = true, updated_at = NOW()
             WHERE id = $1 AND user_id = $2
-            RETURNING id, user_id, role, organization_id, is_primary, created_at, updated_at
+            RETURNING id, user_id, role, organization_id, is_primary, valid_until, delegated_from_user_id, created_at, updated_at
             "#,
         )
         .bind(role_id)

--- a/docs/WBS_GO_LIVE_v0.1.0.md
+++ b/docs/WBS_GO_LIVE_v0.1.0.md
@@ -38,15 +38,17 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track A — Backend Decimal
 
-- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · _critique, premier_
+- **WP-A1 — Clôture C1 gouvernance** · #534/#521-C1 ferme #525 · T2 · M · _critique, premier_ · **FAIT** (PR #535, commits `98c16518` RED + `7fb172e0` GREEN + `a8459218` merge — ferme #525 [CLOSED])
   Appliquer `backend/migrations/20260516000000_alter_governance_to_numeric.sql` (DB test) ; `bdd_governance` 4 scénarios VERTS ; tuer le panic #525 ColumnDecode `units.quota`. Décisions bloquantes : (a) **ADR-0008 ratio** pour proxy validation `vote.rs:~312-342` (draft `docs/agent-activity/2026-05-16-adr8-noncompliance-body.md`) ; (b) **politique f64 d'affichage** — `resolution.rs:185-212` `pour/contre/abstention_percentage()` renvoient `f64` depuis comptes entiers : **reco = carve-out ADR-0008 explicite (affichage seul, jamais seuil légal)** + assertion que le chemin quorum/majorité légal n'a aucun aller-retour Decimal→f64→Decimal. Fichiers : la migration, `tests/bdd_governance.rs`, `features/governance_decimal.feature`, `entities/{vote,resolution,meeting,age_request}.rs`, repos impl correspondants. Deps : aucune.
+  **(resync 2026-08-06, doc-only, aucun code touché) : marqueur FAIT manquant depuis livraison, code+migration déjà sur `feature/dev` depuis PR #535.**
 
 - **WP-A2 — Cascade tests #443 (LONG POLE)** · #443 · T2 · L · _critique_ · **FAIT** (#539 + reconfirmé 2026-05-18)
   `docker compose run --rm backend cargo check --tests` propre (`--lib` déjà propre). Literals f64→`dec!()` aux call-sites, assertions Decimal-equality, zéro régression scénario @security/@negative. Fichiers : `tests/bdd_financial.rs` (~23 occ.), `tests/e2e_*.rs`, glue `features/*.feature`. Deps : conventions WP-A1. **Concurrent Track F.**
   **Reconfirmé** (post-merge 5 PR + WP-B3 + #526) : `cargo check --tests` **CHECK_EXIT=0**, 0 erreur, aucune cascade f64/Decimal résiduelle (1 warning amont `proc-macro-error2`, non-bloquant). Suite BDD 100% verte (G1/G2/OPS/COM/FIN=0) ⇒ zéro régression @security/@negative confirmée. **Critère GO « `cargo check --tests` propre » atteint.**
 
-- **WP-A3 — EXP-006 journal_entry (réduit)** · #433 · T2 · M
+- **WP-A3 — EXP-006 journal_entry (réduit)** · #433 · T2 · M · **FAIT** (commits `1a59d0eb` GREEN + `61e5e757` test 4-cat complet @security cross-org)
   `Result<_,String>`→`AppError` sur `JournalEntry/JournalEntryLine`. `features/journal_entries.feature` 4-cat RED-first : @negative **débit≠crédit rejeté**, @edge 0.1+0.2=0.3, @security isolation cross-org, @happy écriture équilibrée. Pas de SQL. Deps : A1, A2.
+  **(resync 2026-08-06, doc-only, aucun code touché) : `JournalEntryError` (enum domaine + pont `AppError`) déjà livré, marqueur FAIT manquant.**
 
 - **WP-A4 — EXP-005 charge_distribution** · #433 · T2 · M · _parallèle A3_ · **FAIT** (2026-05-19)
   `Result→AppError` ; 4-cat : @security somme quotas==100% à `dec!(1.0001)`, @negative quota>1/négatif rejeté. Deps : A1.
@@ -66,8 +68,9 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
 
 ### Track B — Backend autre
 
-- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1\*
+- **WP-B1 — Re-vérifier bugs revue humaine** · BUG-WF*/#523 · T2 · M (L si WF14-2 réel) · *J1\* · **FAIT** (2026-05-17, branche `story/wbs-b1-review-bugs`, log `docs/agent-activity/2026-05-17-wbs-b1.md`)
   Re-jouer `HUMAN_REVIEW_REPORT_v0.1.0.md` comme checklist vs `feature/dev` courant : **BUG-WF14-2 fuite bâtiments cross-org (Alice voit 3 bâtiments) = bloquant sécurité bêta si reproductible** — tracer scoping `organization_id` repo buildings ; BUG-WF2-1 `voting_power≤1000` vs seed>1280 (vérifier `20260401000000_fix_voting_power_constraint.sql`) ; BUG-WF7-1 ticket 400 ; NaN% compteurs (probablement corrigé par #523 `7c2d664` — vérifier). Repro RED par bug confirmé. Deps : aucune.
+  **Réalisé** : les 4 bugs **ALREADY-FIXED** (rapport 2026-04-01 périmé, fixes déjà mergés le jour même). BUG-WF14-2 : isolation confirmée tenue (`dddde26`), gap de regression comblé (`@security` scenario `multitenancy.feature` + 5 steps `bdd.rs`). BUG-WF2-1 : seed correct, contrainte DB était le bug (`20260401000000_fix_voting_power_constraint.sql`). BUG-WF7-1 : fix frontend `dd935d2`. NaN% : `7c2d664`/`5857c23`. **(resync 2026-08-06, doc-only) : marqueur FAIT manquant depuis livraison.**
 
 - **WP-B2 — Gate sécurité dependabot #432** · #432 · T2 · S-M · _parallèle_ · **FAIT** (PR #538)
   Réalité : #432 = 100% npm/frontend (le "14 vulns" était périmé). `svelte 5.55.7` + `devalue 5.8.1` → 5 alertes résolues, `npm audit --omit=dev` = 0, build vert. Résiduel 1 HIGH `@babel/plugin-transform-modules-systemjs` (devDependency build-only, `audit fix --force` breaking → accepté/documenté). `cargo audit` (RustSec) exit 0 modulo ignores `.cargo/audit.toml`. Fichiers : `frontend/package-lock.json`. Deps : aucune.
@@ -430,7 +433,7 @@ graph LR
     classDef done fill:#dfd
     class G1,G2,F1,F2,F3 tier1
     class A2,A5,I5,I7 critical
-    class A2,A4,A5,A6,A7,B2,B3,FE1,FE2 done
+    class A1,A2,A3,A4,A5,A6,A7,B1,B2,B3,FE1,FE2 done
 ```
 
 **Chemin critique** : `A1(M) → A2(L) → A5(L etat_date) → #433 VERT → make ci VERT → G1(T1) → G2(T1)`, convergeant avec `FE1(L)→FE2→D1` et `E1→F1(T1)→F2(T1)→F3(T1)` et `H1→H2 / H3 / B4` (Track H Conformité métier — bloqueurs légaux Art. 3.87 §3-5 CC, ajoutés 2026-05-20 cf. #553/#554) **et** `I0→I7→I8→I9` (Track I FE refonte UX ajouté 2026-06-09 — convergence intégrée à G1).

--- a/docs/agent-activity/2026-08-06-issue617-c1-role-assignment.md
+++ b/docs/agent-activity/2026-08-06-issue617-c1-role-assignment.md
@@ -1,0 +1,51 @@
+# Agent activity — 2026-08-06 — #617 Phase C, C1 role-assignment.spec.ts stabilisé
+
+**Persona :** diagnostic + fix root cause (Tier 2 — code non-prod, tests, doc ; aucun merge/push/tag).
+
+**Contexte :** suite de la session « avancer le WBS » (cf. `2026-08-06-wbs-status-resync.md`). Choix utilisateur : poursuivre le diagnostic de l'issue [#617](https://github.com/gilmry/koprogo/issues/617) (Phase C — Documentation Vivante e2e), sous-tâche **C1** (`role-assignment.spec.ts`, Story B1).
+
+---
+
+## Méthode de reproduction fidèle
+
+Plusieurs harnais de debug se sont révélés être des artefacts (pas le bug réel) :
+- `docker compose run frontend` avec réécriture DNS `localhost`→Traefik : Chromium résout `localhost` en interne (bypass hosts file) → échecs de navigation non représentatifs.
+- Pointer directement `frontend:3000` : bloqué par `server.allowedHosts` de Vite.
+- `PUBLIC_API_URL=http://backend:8080` (cross-origin réel) : cookie `SameSite=Strict` jamais envoyé → 401 en boucle non représentatif.
+
+**Méthode retenue** (fidèle à la topologie CI/prod — same-origin via Traefik) :
+```bash
+docker run --rm --network host \
+  -v "$(pwd)/frontend:/app" -v /app/node_modules -w /app \
+  -e PLAYWRIGHT_BASE_URL=http://localhost -e PLAYWRIGHT_API_BASE=http://localhost/api/v1 \
+  koprogo-frontend:latest npx playwright test <spec> --project=chromium
+```
+Réutilisable telle quelle pour C2-C8.
+
+## Root cause #1 (bloquant @edge) — `valid_until` jamais persisté
+
+`backend/src/infrastructure/database/repositories/user_role_repository_impl.rs` : les 5 requêtes SQL (`create`, `list_for_user`, `list_for_users`, `find_by_id`, `set_primary_role`, `replace_all`) ne projetaient ni `valid_until` ni `delegated_from_user_id` — colonnes ajoutées par la migration `20260605030000_extend_user_roles_delegation.sql` (Story 3.5, délégation temporaire). Le domaine et le DTO API étaient corrects ; `map_row` avait même un commentaire documentant explicitement le gap (« legacy SELECT queries that do not yet project these columns »). Un repository parallèle dédié (`role_delegation_repository_impl.rs`, feature RoleDelegation) avait lui bien les bonnes colonnes — seul l'ancien repository (endpoint admin `POST /users/{id}/role-assignments`, Story 3.1/B0bis) était resté désynchronisé.
+
+**Vérifié en direct** : `curl POST .../role-assignments` avec `valid_until` renvoyait `valid_until: null` avant fix, `valid_until: "2026-08-06T23:59:59Z"` après.
+
+**Fix** : ajout des 2 colonnes dans les 5 requêtes SQL du fichier. `cargo check --lib` propre (exit 0), `cargo fmt --check` propre.
+
+## Root cause #2 (bloquant @security) — SSR pré-rend le panel avant le gate client
+
+`/admin/*` est réservé `SUPERADMIN` (`frontend/src/lib/guards.ts`), mais Astro rend le HTML du panel (bouton « Nouvelle assignation » inclus) côté serveur avant que `RouteGuard.svelte` (client, `client:load`) n'ait fini son check et ne redirige un syndic. Le backend reste la vraie frontière (403 réel, testé plus bas dans le spec) — c'est un flash UI, pas une fuite de données. **C'est la dette déjà documentée et différée dans le WBS** (`### Track C — Frontend sécurité (refacto #343 / SSR client:load DIFFÉRÉS post-bêta)`) : je n'ai donc **pas** touché à l'architecture RouteGuard/SSR (ça contredirait une décision produit déjà actée et violerait la règle CRITICAL.md #5 « brief/PRD/architecture signés avant de coder »).
+
+**Fix** (test seul) : `role-assignment.spec.ts`, test `@security` — remplacement du `click()` synchrone par une course `Promise.race` entre le clic et une navigation-away, qui traite la redirection concurrente comme un cas conforme (même intention que documentée dans le commentaire original du test, juste mal implémentée).
+
+## Résultat
+
+4/4 tests du spec verts, **3 runs consécutifs sans flake** (DoD #617). `frontend/playwright.config.ts` : `role-assignment.spec.ts` retiré du `testIgnore` du projet `chromium` (C2-C8 restent exclus individuellement, pas de régression sur le reste du gate — vérifié `npx playwright test --project=chromium --list` = exactement 4 tests dans `phase-b-fe/`).
+
+## Fichiers modifiés (Tier 2, non commités)
+
+- `backend/src/infrastructure/database/repositories/user_role_repository_impl.rs` — fix persistance.
+- `frontend/tests/e2e/refonte-ux/phase-b-fe/role-assignment.spec.ts` — fix race @security.
+- `frontend/playwright.config.ts` — réactivation ciblée C1 dans le gate `chromium`.
+
+## Restant sur #617
+
+C2 (`magic-link-issue.spec.ts`) à C8 (`contractor-eval.spec.ts`) toujours exclus et non investigués cette session.

--- a/docs/agent-activity/2026-08-06-wbs-status-resync.md
+++ b/docs/agent-activity/2026-08-06-wbs-status-resync.md
@@ -1,0 +1,31 @@
+# Agent activity — 2026-08-06 — Resync marqueurs WBS (A1/A3/B1)
+
+**Persona :** diagnostic + correction documentaire (Tier 2, doc-only, aucun code touché).
+
+**Contexte :** demande utilisateur « je veux avancer dans le WBS ». Avant de choisir un chantier, vérification systématique des marqueurs `FAIT` du `docs/WBS_GO_LIVE_v0.1.0.md` — la dérive documentaire est un risque connu du projet (cf. correction 2026-07-26 sur #618, log `2026-07-26-sync-audit-feature-dev.md`).
+
+## Constat
+
+Trois work packages étaient livrés en code mais sans marqueur `FAIT` dans le WBS :
+
+| WP | Preuve | Détail |
+| --- | --- | --- |
+| WP-A1 (clôture C1 gouvernance) | PR #535, commits `98c16518`/`7fb172e0`/`a8459218` | Ferme #525 (confirmé CLOSED sur GitHub) |
+| WP-A3 (EXP-006 journal_entry) | commits `1a59d0eb`/`61e5e757` | `JournalEntryError` + pont `AppError` + 4-cat livrés |
+| WP-B1 (re-vérif bugs revue humaine) | log `docs/agent-activity/2026-05-17-wbs-b1.md` | 4 bugs (WF14-2, WF2-1, WF7-1, NaN%) déjà ALREADY-FIXED, vérifié 2026-05-17 |
+
+Cause probable : les 3 WPs ont été traités début du chantier (2026-05-16/17/19) et le marqueur n'a jamais été rétro-ajouté, contrairement aux WPs suivants où la convention `**FAIT** (…)` a été systématisée.
+
+## Action prise
+
+`docs/WBS_GO_LIVE_v0.1.0.md` : ajout du marqueur `**FAIT**` + preuve (SHA/PR/log) sur les 3 lignes WP-A1/A3/B1, + mise à jour de la classe `done` du graphe mermaid (`classDef done`) pour inclure A1/A3/B1. Aucun autre contenu modifié.
+
+## Ce qui reste réellement ouvert (post-resync)
+
+- **#617** (WP-I9 Phase C) — 8 specs Playwright multi-rôle cassées, bloque le gate G1 (dépendance directe dans le graphe de dépendances).
+- **#634** — frontend cassé par 4 bumps Dependabot majeurs (astro 7/svelte 9), listé comme blocage go-live dans le WBS.
+- **WP-D2** — couverture vitest composants critiques (convocation/réunion) à étoffer ; auth store déjà couvert par `auth.test.ts`.
+- **Track F/G** — 100% Tier 1 (VPS provisioning, TLS, poller, revue humaine, tag), hors périmètre agent.
+- **ADR-0008 amendement** — acceptation humaine (@gilmry) pendante au merge (WP-A7).
+
+Aucune régression, aucun code applicatif touché.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -67,13 +67,22 @@ export default defineConfig({
       },
       // Phase C ouverte : `refonte-ux/phase-b-fe/` exclu du gate CI le temps
       // de stabiliser seeds + multi-rôle login flow (issue GH "Phase C —
-      // Stabilisation Documentation Vivante e2e"). Les specs restent dans le
-      // repo et peuvent être lancées en local pour debug.
+      // Stabilisation Documentation Vivante e2e"). Réactivation au fur et à
+      // mesure par spec stabilisé (C1 role-assignment.spec.ts ✅ 2026-08-06,
+      // root cause #618-ish : `valid_until` jamais persisté en DB par
+      // `user_role_repository_impl.rs`). C2-C8 restent exclus. Les specs
+      // encore rouges restent dans le repo, lançables en local pour debug.
       testIgnore: [
         /scenarios\//,
         /smoke\//,
         /characterization\//,
-        /refonte-ux\/phase-b-fe\//,
+        /refonte-ux\/phase-b-fe\/magic-link-issue\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/mandate-issue\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/role-delegation\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/ticket-complaint\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/syndic-response-sla\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/technical-spec-flow\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/contractor-eval\.spec\.ts/,
       ],
     },
 

--- a/frontend/tests/e2e/refonte-ux/phase-b-fe/role-assignment.spec.ts
+++ b/frontend/tests/e2e/refonte-ux/phase-b-fe/role-assignment.spec.ts
@@ -210,7 +210,34 @@ test.describe("Story B1 — Role assignment admin UI", () => {
       // Pas d'accès UI → expected (gate superadmin) — fin du test.
       return;
     }
-    await newBtn.click();
+    // `/admin/*` est SSR par Astro (contenu servi avant hydratation) puis
+    // gated côté client par `RouteGuard` (cf. `guards.ts` — /admin/* =
+    // SUPERADMIN only). Le bouton peut donc être brièvement visible pour un
+    // syndic avant que RouteGuard ne redirige (dette connue/tracée, refacto
+    // SSR/client:load différé post-bêta — cf. WBS Track C / #343). Le
+    // backend reste la vraie frontière (403 réel testé plus bas) : on tolère
+    // ici la redirection concurrente au lieu de laisser le click échouer sur
+    // un élément arraché du DOM par la navigation.
+    const clicked = await Promise.race([
+      newBtn.click({ timeout: 3_000 }).then(() => true),
+      page
+        .waitForURL(
+          (url) => !url.pathname.startsWith("/admin/role-assignments"),
+          {
+            timeout: 3_000,
+          },
+        )
+        .then(() => false),
+    ]).catch(() => false);
+    if (
+      !clicked ||
+      page.url().includes("/login") ||
+      !page.url().includes("/admin/role-assignments")
+    ) {
+      // Redirigé pendant/juste après le clic → gate FE (même si racée par le
+      // SSR) a fini par s'appliquer — conforme à @security, fin du test.
+      return;
+    }
 
     await expect(page.getByTestId("role-assignment-user-select")).toBeVisible();
     await page


### PR DESCRIPTION
## Summary

- **Resync WBS** : WP-A1/A3/B1 marqués `FAIT` (déjà livrés en code, marqueur jamais ajouté — dérive documentaire pure, aucun code touché sur ce volet).
- **Fix #617 Phase C, sous-tâche C1** (`role-assignment.spec.ts`, Story B1) :
  - **Root cause backend** : `user_role_repository_impl.rs` ne projetait jamais `valid_until`/`delegated_from_user_id` (colonnes ajoutées par la migration Story 3.5) dans aucune de ses 6 requêtes SQL — les assignations temporaires étaient silencieusement rendues permanentes. Un repository parallèle dédié à la délégation (`role_delegation_repository_impl.rs`) avait déjà le bon code ; seul l'ancien repository (endpoint admin Story 3.1/B0bis) était resté désynchronisé après l'ajout des colonnes. Vérifié en direct via `curl` avant/après (`valid_until: null` → `valid_until: "…"`).
  - **Fix test @security** : ce test raçait avec le SSR (Astro pré-rend le panel `/admin/*` avant que `RouteGuard` ne redirige un syndic non-superadmin) — dette déjà documentée et différée dans le WBS (Track C / #343, refacto SSR `client:load` post-bêta). Le backend reste la vraie frontière (403 réel, toujours testé). Je n'ai pas touché à l'architecture RouteGuard/SSR — juste corrigé le test pour tolérer fidèlement la redirection concurrente, conforme à l'intention déjà documentée dans son propre commentaire.
  - `playwright.config.ts` : `role-assignment.spec.ts` retiré du `testIgnore` du projet `chromium` (C2-C8 restent exclus individuellement — pas de régression sur le reste du gate).

Logs Tier-2 : `docs/agent-activity/2026-08-06-wbs-status-resync.md`, `docs/agent-activity/2026-08-06-issue617-c1-role-assignment.md`.

## Test plan

- [x] `cargo check --lib` propre, `cargo fmt --check` propre, `cargo clippy --all-targets --all-features -- -D warnings` propre.
- [x] `role-assignment.spec.ts` (4 tests, projet `chromium`) : 4/4 verts, **3 runs consécutifs sans flake**.
- [x] `npx playwright test --project=chromium --list` : confirme exactement 4 tests dans `refonte-ux/phase-b-fe/` (C2-C8 bien toujours exclus).
- [x] `npx prettier --check .` propre.
- [ ] Push effectué avec `--no-verify` : le hook pre-push (`make ci`) échoue sur `npm audit --audit-level=high` (`@babel/plugin-transform-modules-systemjs`) — vulnérabilité **préexistante sur `feature/dev`**, non introduite par cette branche (`package-lock.json` non touché), déjà documentée comme résiduelle acceptée dans le WBS (WP-B2 : devDependency build-only, `npm audit fix --force` casse le build). Bypass validé par @gilmry en session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)