### PR TITLE
fix(#617): stabilise C5/C6/C7/C8 (Phase C, Documentation Vivante e2e)

### DIFF
--- a/docs/agent-activity/2026-08-06-issue617-c3-investigation.md
+++ b/docs/agent-activity/2026-08-06-issue617-c3-investigation.md
@@ -1,0 +1,35 @@
+# Agent activity — 2026-08-06 — #617 Phase C, C3 investigué (même blocage que C2)
+
+**Persona :** diagnostic (Tier 2). Aucun code modifié, aucun commit — investigation seule.
+
+**Contexte :** suite de C2 (cf. `2026-08-06-issue617-c2-investigation.md` + brief `docs/maury/syndic-org-users-endpoint/brief.md`, PR #691 en attente de signature). Sous-tâche **C3** (`mandate-issue.spec.ts`, Story B3).
+
+---
+
+## Constat
+
+Le test `@happy` échoue dès `mandate-new-button` introuvable (`page.goto('/syndic/mandates')` puis timeout). Screenshot : redirigé vers `/admin` (dashboard superadmin), pas vers le formulaire.
+
+**Cause immédiate** : le test se logue en tant qu'**admin** (superadmin), pas en tant que syndic — son propre commentaire l'assume : « login admin (= role syndic-like superadmin in-context) ». Or `guards.ts` restreint `/syndic/*` au seul rôle `SYNDIC` (pas de carve-out superadmin) → `RouteGuard` redirige tout superadmin visitant `/syndic/mandates` vers `/admin`.
+
+**Pourquoi l'auteur a utilisé admin plutôt qu'un vrai syndic** : `require_syndic_or_superadmin` côté backend (`mandate_handlers.rs:112`) autorise bien les deux rôles à émettre un mandat — donc admin *semblait* un raccourci valide. Mais ce choix viole la règle CRITICAL.md #9 (« Scénarios E2E ont les bons acteurs ») — un syndic aurait dû être seedé, comme le fait `role-assignment.spec.ts` (C1) pour son test `@security`.
+
+## Vérification empirique — même root cause que C2
+
+Utiliser le VRAI acteur (syndic, conforme #9) ne résout rien : `MandatesPage.svelte:50` appelle le même `GET /users` superadmin-only déjà identifié dans le brief C2. Confirmé en direct :
+
+```
+curl GET /api/v1/users -H "Authorization: Bearer <token syndic>"
+→ 403
+```
+
+**C3 est donc bloqué par exactement la même cause que C2** (`docs/maury/syndic-org-users-endpoint/brief.md`) — pas une cause indépendante. Le contournement "admin" du test masque le vrai trou en changeant d'acteur, mais se prend le garde-fou FE à la place.
+
+## Ce qu'il faudra faire une fois le brief signé/implémenté
+
+En plus du fix produit (endpoint `GET /organizations/{id}/users` + `MandatesPage.svelte` migré) :
+- Réécrire `mandate-issue.spec.ts` pour utiliser un **vrai syndic** seedé (pattern `seedOrgWithUser` de C1), pas admin — conformité règle #9. Une fois le vrai syndic utilisé, `/syndic/mandates` passera nativement le `RouteGuard` (déjà correct pour SYNDIC).
+
+## Aucune action prise
+
+Pas de code touché, pas de commit. `playwright.config.ts` inchangé (testIgnore intact).

--- a/docs/agent-activity/2026-08-06-issue617-c5-ticket-complaint.md
+++ b/docs/agent-activity/2026-08-06-issue617-c5-ticket-complaint.md
@@ -1,0 +1,28 @@
+# Agent activity — 2026-08-06 — #617 Phase C, C5 stabilisé (ticket-complaint.spec.ts)
+
+**Persona :** diagnostic + fix root cause (Tier 2 — code non-prod, tests). Fix appliqué et vérifié 3x sans flake.
+
+**Contexte :** suite de C4. Sous-tâche **C5** (`ticket-complaint.spec.ts`, Story B5).
+
+---
+
+## Root cause — bug de test (ordre de capture de l'URL)
+
+Contrairement à C2/C3/C4, ce spec utilise déjà les bons acteurs (owner-plaignant puis syndic, jamais admin) et ne dépend pas du endpoint `/users` cassé — l'owner crée son ticket via `/tickets/new`, pas via un sélecteur de destinataire.
+
+Le test capturait `page.url()` **après** `logoutUi(page)` + `uiLogin(page, syndic...)` pour en extraire l'id du ticket (`/ticket-detail?id=...`) — mais à ce moment, `page.url()` pointe déjà vers le dashboard du syndic (`/syndic`), pas vers la page ticket-detail de l'owner (écrasée par la navigation de login). Le regex `id=` ne matchait donc jamais, le `if` restait silencieusement no-op, et le test terminait sur `/syndic` au lieu de `/ticket-detail` — d'où l'échec sur `ticket-detail-title` introuvable.
+
+**Fix** : capture de `ticketUrl`/`ticketIdMatch` déplacée juste après `page.waitForURL(/\/ticket-detail/)` (pendant que l'owner est encore connecté), avant le `logoutUi`. Ajout d'une assertion explicite `expect(ticketIdMatch).not.toBeNull()` pour que ce genre de régression échoue bruyamment plutôt que silencieusement à l'avenir.
+
+## Résultat
+
+1/1 test vert, **3 runs consécutifs sans flake**.
+
+## Actions prises
+
+- `frontend/tests/e2e/refonte-ux/phase-b-fe/ticket-complaint.spec.ts` — fix ordre de capture URL.
+- `frontend/playwright.config.ts` — `ticket-complaint.spec.ts` retiré du `testIgnore` du projet `chromium` (vérifié : `--project=chromium --list` ne remonte plus que ce seul test dans `phase-b-fe/`, les 6 autres specs C2/C3/C4/C6/C7/C8 restent exclus).
+
+## Restant sur #617
+
+C6 (`syndic-response-sla.spec.ts`), C7 (`technical-spec-flow.spec.ts`), C8 (`contractor-eval.spec.ts`) non investigués. C8 partage probablement le même trou `/users` que C2/C3/C4 (`ContractorEvaluationsPage.svelte:71`, déjà identifié dans l'investigation C2).

--- a/docs/agent-activity/2026-08-06-issue617-c6-syndic-response-sla.md
+++ b/docs/agent-activity/2026-08-06-issue617-c6-syndic-response-sla.md
@@ -1,0 +1,28 @@
+# Agent activity — 2026-08-06 — #617 Phase C, C6 stabilisé (syndic-response-sla.spec.ts)
+
+**Persona :** diagnostic (Tier 2). Aucun nouveau fix nécessaire — débloqué par un fix déjà en place (C4).
+
+**Contexte :** suite de C5. Sous-tâche **C6** (`syndic-response-sla.spec.ts`, Story B6).
+
+---
+
+## Constat
+
+Ce spec utilise déjà les bons acteurs (owner puis syndic, jamais admin) et ne dépend pas de l'endpoint `/users` cassé (le ticket est créé via l'API directement par l'owner, pas via un sélecteur). Son email de test est construit avec un préfixe capitalisé (`B6-syndic-<ts>@example.com`) — exactement le pattern qui déclenchait le bug de casse email trouvé en C4.
+
+**Résultat : passe du premier coup**, sans aucune modification du spec — entièrement débloqué par le fix `auth_use_cases.rs` de C4 (normalisation email login/register), encore non commité à ce stade.
+
+**3 runs consécutifs, zéro flake.**
+
+## Actions prises
+
+- `frontend/playwright.config.ts` : `syndic-response-sla.spec.ts` retiré du `testIgnore` du projet `chromium`.
+- Aucun autre fichier modifié.
+
+## Implication
+
+Le fix email de C4 a maintenant débloqué **2 specs** (C6 entièrement, et il lève aussi le premier obstacle de C4 lui-même même si C4 reste bloqué par le trou `/users`). Renforce l'intérêt de le committer/PR séparément et rapidement — c'est un vrai bug utilisateur à impact large, pas seulement un fix de confort pour les tests.
+
+## Restant sur #617
+
+C7 (`technical-spec-flow.spec.ts`), C8 (`contractor-eval.spec.ts`) non investigués. C8 partage probablement le trou `/users` (`ContractorEvaluationsPage.svelte:71`, déjà identifié en C2).

--- a/docs/agent-activity/2026-08-06-issue617-c7-technical-spec-flow.md
+++ b/docs/agent-activity/2026-08-06-issue617-c7-technical-spec-flow.md
@@ -1,0 +1,46 @@
+# Agent activity — 2026-08-06 — #617 Phase C, C7 stabilisé : bug produit significatif
+
+**Persona :** diagnostic + fix root cause (Tier 2 — code non-prod). Fix appliqué et vérifié (Vitest + E2E 3x sans flake).
+
+**Contexte :** suite de C6. Sous-tâche **C7** (`technical-spec-flow.spec.ts`, Story B7).
+
+---
+
+## Root cause #1 (test) — admin au lieu d'un vrai syndic
+
+Même classe de bug que C3 : le test utilisait admin comme « syndic-émulé » pour accéder à `/syndic/technical-spec`, route gated côté FE au seul rôle SYNDIC (`guards.ts`). Contrairement à C3, ce test n'a en réalité que 2 acteurs actifs dans le code (le docstring en annonce 3 dont un AMO jamais exercé) — remplacer admin par un vrai syndic seedé (conforme règle CRITICAL.md #9) suffit, pas besoin de l'endpoint `/users` bloqué.
+
+## Root cause #2 (PRODUIT, réel, impact large) — status snake_case comparé en PascalCase
+
+`TechnicalSpecDetail.svelte` comparait `spec.status` contre des littéraux **PascalCase** (`"Draft"`, `"PendingSignatures"`, `"Approved"`, `"Superseded"`) dans 4 `$derived` + 2 fonctions de badge (classes + label). Le backend sérialise `TechnicalSpecStatus` via son `impl Display` (`technical_spec.rs:141-149`), qui renvoie du **snake_case** (`"draft"`, `"pending_signatures"`, `"approved"`, `"superseded"`) — confirmé par `TechnicalSpecDto::from` (`status: s.status.to_string()`) et vérifié en direct (attribut `data-status` réellement rendu).
+
+**Conséquence en production, pour TOUS les users, TOUTES les fiches techniques** : `isDraft`/`isPendingSignatures`/`isApproved`/`isSuperseded` étaient TOUJOURS `false` → les boutons "Soumettre pour signatures", "Signer" et "Bump" ne s'affichaient **jamais**, quel que soit le statut réel. Même bug répliqué dans `TechnicalSpecVersionTimeline.svelte` (badge + grisage "Superseded" jamais appliqué).
+
+**Fix** : les 4 dérivations + les 2 maps de badge (Detail + Timeline) corrigées en snake_case.
+
+## Root cause #3 (produit, mineur, catché) — `listSpecs()` sans `acp_id` obligatoire
+
+Toast d'erreur parasite visible à chaque ouverture du détail d'une fiche technique : `listSpecs()` (utilisée pour l'historique des versions, résultat non-fatal car catché) appelait `GET /technical-specs` sans aucun paramètre, alors que le backend exige `acp_id: Uuid` (non-Option, `ListTechnicalSpecsQuery`). Fix : `listSpecs(acpId?: string)` — `TechnicalSpecPage.svelte` passe maintenant `s.acp_id` (déjà disponible après `getSpec`).
+
+**Hors scope, non touché** : `TechnicalSpecsPage.svelte` (liste globale) et `ContractorEvaluationsPage.svelte` (Story B8) appellent encore `listSpecs()` sans argument pour lister across-ACP — ce cas reste cassé (même trou), nécessiterait soit un endpoint cross-ACP soit une itération multi-appels côté FE. Signalé pour référence future (possiblement pertinent pour C8).
+
+## Vérifications
+
+- `npx astro check` : 0 erreur, 0 warning (inchangé vs baseline).
+- Vitest `TechnicalSpecDetail.test.ts` (8 tests) + `TechnicalSpecVersionTimeline.test.ts` (6 tests) + `TechnicalSpecCreate.test.ts` (7 tests, non touché mais revérifié) : **21/21 verts**. Les fixtures PascalCase des 2 premiers fichiers (testaient un monde auto-cohérent mais faux vs le vrai contrat backend) mises à jour en snake_case.
+- E2E `technical-spec-flow.spec.ts` : **3 runs consécutifs, zéro flake**.
+
+## Actions prises
+
+- `backend` : aucun changement (le bug était uniquement FE).
+- `frontend/src/lib/components/syndic/TechnicalSpecDetail.svelte` — 4 dérivations + 2 maps badge en snake_case.
+- `frontend/src/lib/components/syndic/TechnicalSpecVersionTimeline.svelte` — idem (map badge + comparaison isSuperseded).
+- `frontend/src/lib/components/syndic/TechnicalSpecDetail.test.ts` + `TechnicalSpecVersionTimeline.test.ts` — fixtures snake_case.
+- `frontend/src/lib/api/technical_specs.ts` — `listSpecs(acpId?: string)`.
+- `frontend/src/lib/components/syndic/TechnicalSpecPage.svelte` — passe `s.acp_id` à `listSpecs()`.
+- `frontend/tests/e2e/refonte-ux/phase-b-fe/technical-spec-flow.spec.ts` — acteur syndic réel (au lieu d'admin) + assertion status en snake_case.
+- `frontend/playwright.config.ts` — `technical-spec-flow.spec.ts` retiré du `testIgnore` du projet `chromium`.
+
+## Restant sur #617
+
+C8 (`contractor-eval.spec.ts`) non investigué — probablement affecté par le même trou `/users` (C2) **et** potentiellement par le même trou `listSpecs()` cross-ACP identifié ci-dessus (Root cause #3, `ContractorEvaluationsPage.svelte` fait partie des appelants non corrigés).

--- a/docs/agent-activity/2026-08-06-issue617-c8-contractor-eval.md
+++ b/docs/agent-activity/2026-08-06-issue617-c8-contractor-eval.md
@@ -1,0 +1,58 @@
+# Agent activity — 2026-08-06 — #617 Phase C, C8 stabilisé (contractor-eval.spec.ts) — dernier de la liste C1-C8
+
+**Persona :** diagnostic + fix (Tier 2 — code test uniquement, aucun code produit touché). Fix appliqué et vérifié 3x sans flake — avec une réserve honnête (voir ci-dessous).
+
+**Contexte :** suite de C7. Sous-tâche **C8** (`contractor-eval.spec.ts`, Story B8) — dernière du lot #617 Phase C.
+
+---
+
+## Root cause #1 (test) — admin au lieu de 2 vrais syndics
+
+Même classe de bug que C3/C7 : le test utilisait admin pour incarner à la fois « Syndic A » et « Syndic B », alors que `/syndic/contractor-evaluations` est gated côté FE au seul rôle SYNDIC (`guards.ts`). Fix : deux vrais syndics seedés (`syndicA`, `syndicB`), conforme à l'intention narrative du docstring et à la règle CRITICAL.md #9.
+
+## Root cause #2 (test) — même bug de casse status que C7
+
+`spec.status === "Approved"` (le check qui gate la branche de création d'évaluation) comparait contre le mauvais format — le backend renvoie `"approved"` en snake_case (cf. C7). Corrigé.
+
+## Ce qui reste **non résolu** (honnêteté du log) — branche @happy vacuously skip
+
+Le test avait été écrit avec une tolérance explicite pour le cas où `/users` ne renvoie pas les contractors (« si le contractor n'apparaît pas dans le select... on skip le scenario @happy » — l'auteur savait déjà). Confirmé en direct dans les logs backend pendant le run :
+
+```
+GET /api/v1/users → 403   (syndic, page contractor-evaluations)
+```
+
+Donc **la branche de création d'évaluation ne s'exécute jamais actuellement** — le test passe, mais uniquement grâce à sa propre tolérance intégrée, pas parce que le flow @happy complet a été exercé. Ça reste bloqué par le même trou que C2/C3 (brief `docs/maury/syndic-org-users-endpoint/brief.md`, PR #691). Une fois cet endpoint livré, il faudra revérifier que la branche `if (newBtnEnabled && spec.status === "approved")` s'exécute réellement (pas juste que le test reste vert).
+
+## Découverte annexe — `GET /users/{id}` inexistant
+
+Repéré dans les logs backend pendant le run :
+```
+GET /api/v1/users/{id} → 404
+```
+`ContractorReputation.svelte` attend un `contractorName` résolu par le parent via `/users/{id}` (cf. commentaire du composant) — **cet endpoint n'existe pas du tout** côté backend (aucun handler `#[get("/users/{id}")]`). La page reputation affiche donc probablement l'UUID brut ou un placeholder à la place du nom du contractor. Cosmétique (l'assertion du test ne vérifie que la visibilité, pas le contenu), non bloquant, mais même classe de trou que le brief #691 (accès en lecture aux users hors superadmin) — **pas fixé ici**, à ajouter au brief ou traiter séparément si @gilmry le juge utile.
+
+## Vérifications
+
+- E2E `contractor-eval.spec.ts` : 3 runs consécutifs, zéro flake.
+- Pas de code produit touché — uniquement le spec de test.
+
+## Actions prises
+
+- `frontend/tests/e2e/refonte-ux/phase-b-fe/contractor-eval.spec.ts` — 2 vrais syndics + fix casse status.
+- `frontend/playwright.config.ts` — `contractor-eval.spec.ts` retiré du `testIgnore` du projet `chromium`.
+
+## Bilan #617 Phase C — C1 à C8, tous investigués
+
+| # | Spec | Statut | Nature |
+|---|---|---|---|
+| C1 | role-assignment.spec.ts | ✅ (PR #690) | bug backend `valid_until` + fix test |
+| C2 | magic-link-issue.spec.ts | ⏸️ bloqué | endpoint `/users` manquant — brief PR #691 |
+| C3 | mandate-issue.spec.ts | ⏸️ bloqué | même cause que C2 |
+| C4 | role-delegation.spec.ts | ⏸️ bloqué* | *bug email casse fixé (indépendant), reste bloqué par C2 |
+| C5 | ticket-complaint.spec.ts | ✅ | bug de test (ordre capture URL) |
+| C6 | syndic-response-sla.spec.ts | ✅ | gratuit (fix C4) |
+| C7 | technical-spec-flow.spec.ts | ✅ | **bug produit réel** (status casing) |
+| C8 | contractor-eval.spec.ts | ✅ (partiel) | bug de test + branche @happy vacuously skip (bloquée par C2) |
+
+**Prochaine étape logique** : signature du brief `docs/maury/syndic-org-users-endpoint/brief.md` par @gilmry, qui débloquerait C2/C3/C4 complètement et compléterait réellement C8.

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -67,13 +67,24 @@ export default defineConfig({
       },
       // Phase C ouverte : `refonte-ux/phase-b-fe/` exclu du gate CI le temps
       // de stabiliser seeds + multi-rôle login flow (issue GH "Phase C —
-      // Stabilisation Documentation Vivante e2e"). Les specs restent dans le
-      // repo et peuvent être lancées en local pour debug.
+      // Stabilisation Documentation Vivante e2e"). Réactivation au fur et à
+      // mesure par spec stabilisé — 2026-08-06 : C5 ticket-complaint.spec.ts
+      // ✅ (bug de test), C6 syndic-response-sla.spec.ts ✅ (débloqué par le
+      // fix casse email de C4), C7 technical-spec-flow.spec.ts ✅ (bug
+      // produit réel : status snake_case du backend comparé en PascalCase
+      // côté FE) et C8 contractor-eval.spec.ts ✅ (acteur admin→syndic, la
+      // branche création reste vacuously skip tant que #691 n'est pas
+      // implémenté — GET /users toujours 403 pour un syndic). Les autres
+      // restent exclus tant que non stabilisés (cf. docs/agent-activity/
+      // 2026-08-06-issue617-c*.md et PR #690/#691).
       testIgnore: [
         /scenarios\//,
         /smoke\//,
         /characterization\//,
-        /refonte-ux\/phase-b-fe\//,
+        /refonte-ux\/phase-b-fe\/role-assignment\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/magic-link-issue\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/mandate-issue\.spec\.ts/,
+        /refonte-ux\/phase-b-fe\/role-delegation\.spec\.ts/,
       ],
     },
 

--- a/frontend/src/lib/api/technical_specs.ts
+++ b/frontend/src/lib/api/technical_specs.ts
@@ -142,13 +142,24 @@ export function isMajorBump(prev: string, next: string): boolean {
 // -----------------------------------------------------------------------------
 
 /**
- * Liste les TechnicalSpecs accessibles à l'utilisateur courant.
+ * Liste les TechnicalSpecs d'une ACP.
+ *
+ * ⚠️ Backend : `acp_id` est un paramètre obligatoire côté handler
+ * (`ListTechnicalSpecsQuery.acp_id: Uuid`, non-Option) — appeler cette
+ * fonction SANS `acpId` échoue toujours en "missing field `acp_id`" (trouvé
+ * en investiguant #617 C7, corrigé ici pour `TechnicalSpecPage.svelte` qui
+ * connaît déjà l'acp_id de la spec affichée). `TechnicalSpecsPage.svelte`
+ * et `ContractorEvaluationsPage.svelte` appellent encore cette fonction sans
+ * argument pour lister au travers de plusieurs ACPs — ce cas reste cassé,
+ * hors scope de ce fix (nécessiterait un endpoint cross-ACP ou une
+ * itération multi-appels côté FE).
  *
  * Backend filtre par RBAC (syndic / superadmin / mandataires des ACPs).
  * Hors scope → 403 (toast automatique).
  */
-export async function listSpecs(): Promise<TechnicalSpecDto[]> {
-  return api.get<TechnicalSpecDto[]>("/technical-specs");
+export async function listSpecs(acpId?: string): Promise<TechnicalSpecDto[]> {
+  const qs = acpId ? `?acp_id=${encodeURIComponent(acpId)}` : "";
+  return api.get<TechnicalSpecDto[]>(`/technical-specs${qs}`);
 }
 
 /**

--- a/frontend/src/lib/components/syndic/TechnicalSpecDetail.svelte
+++ b/frontend/src/lib/components/syndic/TechnicalSpecDetail.svelte
@@ -83,10 +83,16 @@
   // Dérivations — gating signature + status + actions
   // ---------------------------------------------------------------------------
 
-  let isDraft = $derived(spec.status === "Draft");
-  let isPendingSignatures = $derived(spec.status === "PendingSignatures");
-  let isApproved = $derived(spec.status === "Approved");
-  let isSuperseded = $derived(spec.status === "Superseded");
+  // Le backend sérialise `TechnicalSpecStatus` via son `Display` (snake_case
+  // : "draft"/"pending_signatures"/"approved"/"superseded"), pas le nom
+  // d'enum Rust PascalCase — comparer contre la mauvaise casse rendait ces
+  // 4 dérivations TOUJOURS fausses, donc les boutons Signer/Soumettre/Bump
+  // ne s'affichaient jamais pour aucun status, en production (trouvé en
+  // investiguant #617 C7).
+  let isDraft = $derived(spec.status === "draft");
+  let isPendingSignatures = $derived(spec.status === "pending_signatures");
+  let isApproved = $derived(spec.status === "approved");
+  let isSuperseded = $derived(spec.status === "superseded");
 
   /** Le user a-t-il un rôle parmi les required_signatures de la spec ? */
   let userHasRequiredRole = $derived(
@@ -171,13 +177,15 @@
   // Helpers display
   // ---------------------------------------------------------------------------
 
+  // Clés en snake_case — cf. commentaire sur `isDraft`/etc. ci-dessus
+  // (Display du backend, pas le nom d'enum Rust).
   function statusBadgeClasses(s: string): string {
     return (
       {
-        Draft: "bg-gray-100 text-gray-700 border-gray-300",
-        PendingSignatures: "bg-orange-100 text-orange-800 border-orange-300",
-        Approved: "bg-green-100 text-green-800 border-green-300",
-        Superseded: "bg-gray-200 text-gray-500 border-gray-300",
+        draft: "bg-gray-100 text-gray-700 border-gray-300",
+        pending_signatures: "bg-orange-100 text-orange-800 border-orange-300",
+        approved: "bg-green-100 text-green-800 border-green-300",
+        superseded: "bg-gray-200 text-gray-500 border-gray-300",
       }[s] ?? "bg-gray-100 text-gray-700 border-gray-300"
     );
   }
@@ -185,10 +193,10 @@
   function statusLabel(s: string): string {
     return (
       {
-        Draft: "Brouillon",
-        PendingSignatures: "En attente de signatures",
-        Approved: "Approuvée",
-        Superseded: "Remplacée",
+        draft: "Brouillon",
+        pending_signatures: "En attente de signatures",
+        approved: "Approuvée",
+        superseded: "Remplacée",
       }[s] ?? s
     );
   }

--- a/frontend/src/lib/components/syndic/TechnicalSpecDetail.test.ts
+++ b/frontend/src/lib/components/syndic/TechnicalSpecDetail.test.ts
@@ -40,7 +40,7 @@ function spec(over: Partial<TechnicalSpecDto> = {}): TechnicalSpecDto {
     deliverables: ["Démontage", "Pose voligeage"],
     required_signatures: ["syndic", "amo"],
     attachments: [],
-    status: "PendingSignatures",
+    status: "pending_signatures",
     created_by: "syndic-uuid",
     previous_version_id: null,
     created_at: "2026-06-09T10:00:00Z",
@@ -69,7 +69,7 @@ beforeEach(() => {
 
 describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
   it("@happy PendingSignatures + user a rôle requis → bouton Signer RENDU + status badge", () => {
-    const s = spec({ status: "PendingSignatures" });
+    const s = spec({ status: "pending_signatures" });
     const { getByTestId, queryByTestId } = render(TechnicalSpecDetail, {
       props: {
         spec: s,
@@ -90,7 +90,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
       /1\.0\.0/,
     );
     const badge = getByTestId("tech-spec-detail-status-badge");
-    expect(badge.getAttribute("data-status")).toBe("PendingSignatures");
+    expect(badge.getAttribute("data-status")).toBe("pending_signatures");
     expect(badge.textContent).toMatch(/attente/i);
 
     // Bouton Signer présent.
@@ -101,7 +101,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
   });
 
   it("@edge status Draft → bouton 'Soumettre pour signatures' présent + Bump présent + Signer absent", async () => {
-    const s = spec({ status: "Draft" });
+    const s = spec({ status: "draft" });
     const onSubmitForSign = vi.fn().mockResolvedValue(undefined);
     const { getByTestId, queryByTestId } = render(TechnicalSpecDetail, {
       props: {
@@ -127,7 +127,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
   });
 
   it("@edge status Approved → bouton Bump présent, Soumettre absent, Signer absent", () => {
-    const s = spec({ status: "Approved" });
+    const s = spec({ status: "approved" });
     const { queryByTestId } = render(TechnicalSpecDetail, {
       props: {
         spec: s,
@@ -150,7 +150,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
   });
 
   it("@security Owner sans rôle requis → bouton Signer ABSENT du DOM", () => {
-    const s = spec({ status: "PendingSignatures" });
+    const s = spec({ status: "pending_signatures" });
     const { queryByTestId } = render(TechnicalSpecDetail, {
       props: {
         spec: s,
@@ -171,7 +171,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
 
   it("@security mandataire amo sans activeMandate → bouton Signer ABSENT (mandatePrereq KO)", () => {
     const s = spec({
-      status: "PendingSignatures",
+      status: "pending_signatures",
       required_signatures: ["syndic", "amo"],
     });
     const { queryByTestId } = render(TechnicalSpecDetail, {
@@ -189,7 +189,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
   });
 
   it("@security user a déjà signé sous son rôle → bouton Signer ABSENT (INV unique)", () => {
-    const s = spec({ status: "PendingSignatures" });
+    const s = spec({ status: "pending_signatures" });
     const { queryByTestId } = render(TechnicalSpecDetail, {
       props: {
         spec: s,
@@ -213,7 +213,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
 
   it("@negative bump button → modal warning visible avec aria-modal='true' + autofocus", async () => {
     const onBump = vi.fn();
-    const s = spec({ status: "Approved" });
+    const s = spec({ status: "approved" });
     const { getByTestId, queryByTestId } = render(TechnicalSpecDetail, {
       props: {
         spec: s,
@@ -248,7 +248,7 @@ describe("TechnicalSpecDetail — Story B7 (4-cat)", () => {
 
   it("liste des signatures + missing — render correct", () => {
     const s = spec({
-      status: "PendingSignatures",
+      status: "pending_signatures",
       required_signatures: ["syndic", "amo"],
     });
     const { getByTestId, queryByTestId } = render(TechnicalSpecDetail, {

--- a/frontend/src/lib/components/syndic/TechnicalSpecPage.svelte
+++ b/frontend/src/lib/components/syndic/TechnicalSpecPage.svelte
@@ -76,7 +76,7 @@
 
       // Charge l'historique des versions (filtre client side sur title/acp).
       try {
-        const all = await listSpecs();
+        const all = await listSpecs(s.acp_id);
         historyVersions = all.filter(
           (x) =>
             x.title === s.title &&

--- a/frontend/src/lib/components/syndic/TechnicalSpecVersionTimeline.svelte
+++ b/frontend/src/lib/components/syndic/TechnicalSpecVersionTimeline.svelte
@@ -68,20 +68,24 @@
     label: string;
     classes: string;
   } {
+    // Clés en snake_case — le backend sérialise `TechnicalSpecStatus` via
+    // son `Display` ("draft"/"pending_signatures"/...), pas le nom d'enum
+    // Rust PascalCase (trouvé en investiguant #617 C7, même bug que
+    // TechnicalSpecDetail.svelte : ces clés PascalCase ne matchaient jamais).
     const map: Record<string, { label: string; classes: string }> = {
-      Draft: {
+      draft: {
         label: "Brouillon",
         classes: "bg-gray-100 text-gray-700 border-gray-300",
       },
-      PendingSignatures: {
+      pending_signatures: {
         label: "Attente signatures",
         classes: "bg-orange-100 text-orange-800 border-orange-300",
       },
-      Approved: {
+      approved: {
         label: "Approuvée",
         classes: "bg-green-100 text-green-800 border-green-300",
       },
-      Superseded: {
+      superseded: {
         label: "Remplacée",
         classes: "bg-gray-200 text-gray-500 border-gray-300",
       },
@@ -119,7 +123,7 @@
     >
       {#each sorted as spec (spec.id)}
         {@const badge = statusBadge(spec.status)}
-        {@const isSuperseded = spec.status === "Superseded"}
+        {@const isSuperseded = spec.status === "superseded"}
         {@const isCurrent = spec.id === currentVersionId}
         <li
           data-testid={`tech-spec-version-row-${spec.version}`}

--- a/frontend/src/lib/components/syndic/TechnicalSpecVersionTimeline.test.ts
+++ b/frontend/src/lib/components/syndic/TechnicalSpecVersionTimeline.test.ts
@@ -23,7 +23,7 @@ function spec(over: Partial<TechnicalSpecDto>): TechnicalSpecDto {
     deliverables: ["dlv"],
     required_signatures: ["syndic"],
     attachments: [],
-    status: "Approved",
+    status: "approved",
     created_by: "u",
     previous_version_id: null,
     created_at: "2026-06-09T10:00:00Z",
@@ -37,13 +37,13 @@ describe("TechnicalSpecVersionTimeline — Story B7 (4-cat)", () => {
     const v100 = spec({
       id: "v100",
       version: "1.0.0",
-      status: "Superseded",
+      status: "superseded",
       created_at: "2026-06-09T10:00:00Z",
     });
     const v110 = spec({
       id: "v110",
       version: "1.1.0",
-      status: "Approved",
+      status: "approved",
       created_at: "2026-06-10T10:00:00Z",
     });
 
@@ -55,18 +55,18 @@ describe("TechnicalSpecVersionTimeline — Story B7 (4-cat)", () => {
     const row110 = getByTestId("tech-spec-version-row-1.1.0");
     const row100 = getByTestId("tech-spec-version-row-1.0.0");
 
-    expect(row110.getAttribute("data-status")).toBe("Approved");
+    expect(row110.getAttribute("data-status")).toBe("approved");
     expect(row110.getAttribute("data-current")).toBe("true");
     expect(row110.getAttribute("aria-current")).toBe("true");
 
-    expect(row100.getAttribute("data-status")).toBe("Superseded");
+    expect(row100.getAttribute("data-status")).toBe("superseded");
     expect(row100.getAttribute("data-current")).toBe("false");
     // Grisage via class opacity (combiné avec text-gray-500 — INV-FE9 daltoniens).
     expect(row100.className).toMatch(/opacity-70|text-gray-500/);
   });
 
   it("@happy onSelect callback déclenché au click sur 'Voir'", () => {
-    const v = spec({ id: "v100", version: "1.0.0", status: "Approved" });
+    const v = spec({ id: "v100", version: "1.0.0", status: "approved" });
     const onSelect = vi.fn();
     const { container } = render(TechnicalSpecVersionTimeline, {
       props: { versions: [v], currentVersionId: "v100", onSelect },
@@ -90,7 +90,7 @@ describe("TechnicalSpecVersionTimeline — Story B7 (4-cat)", () => {
   });
 
   it("@security pas de bouton Edit/Delete sur les lignes (read-only)", () => {
-    const v = spec({ id: "v100", version: "1.0.0", status: "Approved" });
+    const v = spec({ id: "v100", version: "1.0.0", status: "approved" });
     const { container } = render(TechnicalSpecVersionTimeline, {
       props: { versions: [v], currentVersionId: "v100" },
     });

--- a/frontend/tests/e2e/refonte-ux/phase-b-fe/contractor-eval.spec.ts
+++ b/frontend/tests/e2e/refonte-ux/phase-b-fe/contractor-eval.spec.ts
@@ -272,8 +272,16 @@ test.describe("Story B8 — ContractorEvaluation multi-rôle (Syndic A évalue, 
       "B8",
     );
 
-    // ─── Phase 2 : login admin (acte Syndic A) → page contractor-evaluations
-    await uiLogin(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    // Syndic A + Syndic B réels — `/syndic/*` est gated côté FE
+    // (RouteGuard, guards.ts) au seul rôle SYNDIC, superadmin non inclus.
+    // Utiliser admin comme proxy des 2 syndics (comme avant ce fix) redirige
+    // silencieusement vers /admin — trouvé en investiguant #617 C8, même
+    // classe de bug que C3/C7.
+    const syndicA = await registerUser(request, cabinet.id, "syndic", "B8-a");
+    const syndicB = await registerUser(request, cabinet.id, "syndic", "B8-b");
+
+    // ─── Phase 2 : login Syndic A → page contractor-evaluations ──────────
+    await uiLogin(page, syndicA.email, TEST_PASSWORD);
     await page.goto("/syndic/contractor-evaluations", {
       waitUntil: "networkidle",
     });
@@ -291,7 +299,10 @@ test.describe("Story B8 — ContractorEvaluation multi-rôle (Syndic A évalue, 
     const newBtn = page.getByTestId("contractor-eval-new-button");
     const newBtnEnabled = await newBtn.isEnabled().catch(() => false);
 
-    if (newBtnEnabled && spec.status === "Approved") {
+    // Le backend sérialise le status en snake_case ("approved"), pas le nom
+    // d'enum Rust PascalCase — cf. #617 C7 (même bug, ici dans une
+    // comparaison de test plutôt que dans un composant).
+    if (newBtnEnabled && spec.status === "approved") {
       await newBtn.click();
 
       // Form visible.
@@ -346,17 +357,11 @@ test.describe("Story B8 — ContractorEvaluation multi-rôle (Syndic A évalue, 
       await page.waitForTimeout(1000);
     }
 
-    // ─── Phase 3 : Syndic B (admin re-login = même session pour simplifier
-    //     le test infra, mais le scenario business est de consulter la page
-    //     reputation depuis une autre identité — admin est déjà un proxy de
-    //     "consulter cross-syndic" puisqu'il voit toute l'org).
-    //
-    // Pour respecter l'esprit multi-rôle B8 (Syndic A ≠ Syndic B), on
-    // logout admin et on tente un second syndic via register.
+    // ─── Phase 3 : Syndic A logout ────────────────────────────────────────
     await logoutUi(page);
 
-    // ─── Phase 4 : Syndic B (consulte reputation read-only INV-24)
-    await uiLogin(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    // ─── Phase 4 : Syndic B (consulte reputation read-only INV-24) ───────
+    await uiLogin(page, syndicB.email, TEST_PASSWORD);
 
     await page.goto(
       `/contractor-reputation?contractorId=${encodeURIComponent(

--- a/frontend/tests/e2e/refonte-ux/phase-b-fe/technical-spec-flow.spec.ts
+++ b/frontend/tests/e2e/refonte-ux/phase-b-fe/technical-spec-flow.spec.ts
@@ -236,24 +236,36 @@ test.describe("Story B7 — TechnicalSpec full flow (multi-rôle 3 acteurs)", ()
     const acp = await createAcp(request, adminToken, cabinet.id, "B7");
     const building = await createBuilding(request, adminToken, acp.id, "B7");
 
+    // Acteur syndic réel — `/syndic/*` est gated côté FE (RouteGuard,
+    // guards.ts) au seul rôle SYNDIC, superadmin non inclus malgré
+    // `require_syndic_or_superadmin` côté backend. Utiliser admin comme
+    // "syndic-emulé" (comme avant ce fix) redirige silencieusement vers
+    // /admin — trouvé en investiguant #617 C7, même classe de bug que C3.
+    const syndic = await registerUser(
+      request,
+      cabinet.id,
+      "syndic",
+      "B7-syndic",
+    );
+
     // Acteur 3 : Owner observer (rôle copropriétaire — ne devrait PAS voir
     // le bouton "Signer").
     const owner = await registerUser(request, cabinet.id, "owner", "B7-owner");
 
-    // ─── Phase 2 : Admin / syndic-emulé crée la spec via API ──────────────
+    // ─── Phase 2 : Syndic crée la spec via API ───────────────────────────
     const spec = await createSpec(
       request,
-      adminToken,
+      syndic.token,
       acp.id,
       building.id,
       "B7",
     );
 
     // Submit la spec → PendingSignatures
-    await submitSpec(request, adminToken, spec.id);
+    await submitSpec(request, syndic.token, spec.id);
 
-    // ─── Phase 3 : login admin → page détail → vérifie status badge ───────
-    await uiLogin(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    // ─── Phase 3 : login syndic → page détail → vérifie status badge ─────
+    await uiLogin(page, syndic.email, TEST_PASSWORD);
     await page.goto(`/syndic/technical-spec?id=${spec.id}`, {
       waitUntil: "networkidle",
     });
@@ -263,9 +275,12 @@ test.describe("Story B7 — TechnicalSpec full flow (multi-rôle 3 acteurs)", ()
     await expect(titleEl).toContainText("Travaux toiture");
 
     const statusBadge = page.getByTestId("tech-spec-detail-status-badge");
+    // `data-status` reflète le statut backend en snake_case (cf. badge
+    // rendu réel), pas le nom d'enum Rust PascalCase — trouvé en
+    // investiguant #617 C7.
     await expect(statusBadge).toHaveAttribute(
       "data-status",
-      "PendingSignatures",
+      "pending_signatures",
     );
 
     // Le bouton "Soumettre pour signatures" est ABSENT (déjà soumis).

--- a/frontend/tests/e2e/refonte-ux/phase-b-fe/ticket-complaint.spec.ts
+++ b/frontend/tests/e2e/refonte-ux/phase-b-fe/ticket-complaint.spec.ts
@@ -248,20 +248,27 @@ test.describe("Story B5 — Ticket Complaint (multi-rôle)", () => {
     // On attend la redirection vers le détail (peut tarder si l'API est lente).
     await page.waitForURL(/\/ticket-detail/, { timeout: 15_000 });
 
+    // Capturer l'URL (donc l'id du ticket) AVANT le logout — une fois
+    // reconnecté en syndic, `page.url()` pointe vers son dashboard
+    // (/syndic), pas vers le ticket-detail de l'owner (bug trouvé en
+    // investiguant #617 C5 : l'URL était lue APRÈS le re-login syndic,
+    // donc le regex `id=` ne matchait jamais et le test restait
+    // silencieusement sur /syndic).
+    const ticketUrl = page.url();
+    const ticketIdMatch = ticketUrl.match(/[?&]id=([^&]+)/);
+    expect(
+      ticketIdMatch,
+      `ticket id introuvable dans l'URL ${ticketUrl}`,
+    ).not.toBeNull();
+
     // ─── Phase 3 : Owner-plaignant logout → Syndic login ─────────────────
     await logoutUi(page);
     await uiLogin(page, syndic.email, TEST_PASSWORD);
 
-    // Le syndic ouvre la même URL ticket-detail (on récupère l'ID depuis URL).
-    const ticketUrl = page.url();
-    // Anti-flake : si l'URL syndic ne contient pas l'id (dashboards diffèrent),
-    // on construit l'URL manuellement via le param.
-    const ticketIdMatch = ticketUrl.match(/[?&]id=([^&]+)/);
-    if (ticketIdMatch) {
-      await page.goto(`/ticket-detail?id=${ticketIdMatch[1]}`, {
-        waitUntil: "networkidle",
-      });
-    }
+    // Le syndic ouvre la même URL ticket-detail (id capturé avant logout).
+    await page.goto(`/ticket-detail?id=${ticketIdMatch![1]}`, {
+      waitUntil: "networkidle",
+    });
 
     // Le syndic voit le titre (intégration FE-BE OK).
     await expect(page.getByTestId("ticket-detail-title")).toContainText(


### PR DESCRIPTION
## ⚠️ Empilée sur #692 — merger #692 en premier

Cette PR est basée sur `fix/auth-email-case-insensitive-login` (#692), pas sur `feature/dev` — C6 a besoin du fix email de #692 pour passer seul en CI. La diff ne montrera que les commits propres à cette PR une fois #692 mergée (ou après rebase).

## Summary

Suite de [#690](https://github.com/gilmry/koprogo/pull/690) (C1) et [#691](https://github.com/gilmry/koprogo/pull/691) (C2, brief) — stabilise 4 des 8 sous-tâches de #617 Phase C.

- **C5** `ticket-complaint.spec.ts` — bug de test : l'id du ticket était lu après la reconnexion syndic (donc `/syndic`, sans id) au lieu de juste après sa création par l'owner.
- **C6** `syndic-response-sla.spec.ts` — aucun fix nécessaire, débloqué par le fix casse email de #692.
- **C7** `technical-spec-flow.spec.ts` — **bug produit réel** : `TechnicalSpecDetail.svelte` comparait `spec.status` contre du PascalCase (`"PendingSignatures"`) alors que le backend sérialise en snake_case (`"pending_signatures"`, via `impl Display`). Conséquence en production, pour **toute** fiche technique : les boutons Soumettre/Signer/Bump ne s'affichaient **jamais**. Même bug dans `TechnicalSpecVersionTimeline.svelte`. Trouvé aussi un `listSpecs()` sans `acp_id` (obligatoire côté backend) causant un toast d'erreur parasite à chaque ouverture d'une fiche — fixé pour le cas direct (`TechnicalSpecPage.svelte`), laissé pour les listings cross-ACP (`TechnicalSpecsPage.svelte`, `ContractorEvaluationsPage.svelte`, hors scope).
- **C8** `contractor-eval.spec.ts` — mêmes bugs de test que C3/C7 (acteur + casse status). La branche de création d'évaluation reste *vacuously skip* (confirmé `GET /users → 403` pour un syndic dans les logs backend) — toujours bloquée par le brief #691, pas par cette PR.

`playwright.config.ts` : C5/C6/C7/C8 retirés du `testIgnore` du projet `chromium`. C2/C3/C4/role-assignment restent exclus.

## Test plan

- [x] Les 4 specs : **3 runs consécutifs chacune, zéro flake**.
- [x] Vitest `TechnicalSpecDetail.test.ts` (8) + `TechnicalSpecVersionTimeline.test.ts` (6) + `TechnicalSpecCreate.test.ts` (7, non touché) : 21/21 verts, fixtures alignées en snake_case.
- [x] `npx astro check` : 0 erreur, 0 warning.
- [x] `npx playwright test --project=chromium --list` : confirme exactement les 4 tests attendus dans `phase-b-fe/`.
- [x] Logs Tier-2 : `docs/agent-activity/2026-08-06-issue617-c{3,5,6,7,8}-*.md`.

Refs: #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)