### PR TITLE
fix(frontend): corrige la boucle de redirection HTTP/HTTPS sur nginx

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -33,6 +33,16 @@ http {
         root /usr/share/nginx/html;
         index index.html;
 
+        # nginx sits behind Traefik, which terminates TLS and forwards over
+        # plain HTTP. Without this, nginx's automatic trailing-slash redirect
+        # (triggered by `try_files ... $uri/` below, e.g. /login -> /login/)
+        # builds an absolute URL from its own $scheme, which is always
+        # "http" here — sending HTTPS visitors on an unnecessary http://
+        # round-trip back through Traefik's redirect, which some browsers'
+        # loop detection flags as ERR_TOO_MANY_REDIRECTS. A relative
+        # Location header lets the browser keep the original scheme.
+        absolute_redirect off;
+
         # Security headers (complementing Traefik headers)
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "DENY" always;


### PR DESCRIPTION
## 📝 Description

Corrige `ERR_TOO_MANY_REDIRECTS` observé sur `https://koprogo.com/login` (signalé après la promotion de #715 vers `main`, mais **bug pré-existant sans rapport avec le rate limiting** — aucun fichier frontend/nginx n'était touché par #714/#715, confirmé par `git diff` sur le merge).

**Cause racine** (reproduite en curl) :

```
https://koprogo.com/login
  → nginx 301 → http://koprogo.com/login/     ← bug : nginx émet une URL absolue en http
  → Traefik (redirect entrypoint web→websecure) 301 → https://koprogo.com/login/
  → 200 OK
```

`frontend/nginx.conf` utilise `try_files $uri $uri/ /index.html;`. Quand nginx ajoute automatiquement le slash final (`/login` → `/login/`), il construit l'URL de redirection avec `$scheme`, qui vaut toujours `http` côté nginx puisque Traefik termine le TLS en amont et lui transmet en clair. Ce va-et-vient HTTP↔HTTPS (amplifié par le HSTS `preload` déjà actif sur le domaine) déclenche la détection de boucle de certains navigateurs.

**Correctif** : `absolute_redirect off;` dans le bloc `server` — nginx émet alors des `Location` relatives (`/login/`), qui préservent le schéma d'origine côté client. Directive nginx core standard, un seul ajout, aucun changement de comportement applicatif.

## 🔗 Issue(s) Liée(s)

Refs: #78

## 🎯 Type de Changement

- [x] 🐛 Bug fix

## 🏗️ Architecture Hexagonale

### Infrastructure

- [x] `frontend/nginx.conf` — ajout d'une directive nginx core

## ✅ Checklist Qualité

### Tests

- [ ] Vérification manuelle en environnement de prod/staging après déploiement : `curl -D - https://koprogo.com/login` doit rediriger directement en `https://` (plus de saut par `http://`)
- Pas de test automatisé possible en sandbox (pas de nginx/docker local disponible dans cette session)

## 🧪 Comment Tester

1. Déployer cette branche (build de l'image frontend)
2. `curl -sS -D - -o /dev/null https://koprogo.com/login` → la `Location` du 301 doit être `/login/` (relative) et non `http://koprogo.com/login/`
3. Vérifier en navigateur que `/login` charge sans `ERR_TOO_MANY_REDIRECTS`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NVS5mRW6j9kHaXMaGyx4vG)_