### PR TITLE
chore(ci): gate de couverture OpenAPI — ferme l'angle mort du check anti-drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
       - name: ADR-0008 gate — no f64 on money or quotas
         run: ./scripts/check-no-f64-money.sh
 
+      # Angle mort du job « Contract Types Check » : il compare la spec à la
+      # source Rust, puis les types TS à la spec. Un endpoint ABSENT de la spec
+      # est absent des deux côtés — donc cohérent, donc invisible. C'est ainsi
+      # que les 16 endpoints payment-methods ont vécu hors contrat jusqu'à
+      # produire un 400 silencieux (#732). Ce gate mesure l'exhaustivité de la
+      # déclaration, pas sa cohérence. Cliquet : la dette ne doit pas croître.
+      - name: OpenAPI coverage gate — no new route outside the contract
+        run: ./scripts/check-openapi-coverage.sh
+
   test-unit:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/docs/WBS_GO_LIVE_v0.1.0.md
+++ b/docs/WBS_GO_LIVE_v0.1.0.md
@@ -100,6 +100,51 @@ Légende : Tier 1 = humain exécute (agent diagnostique/propose). Taille S≤0.5
   - `5d2a7ae` #550 strate 2 v3 — `apiFetch` attend le refresh in-flight si pas de token (composants `client:load` qui mountent et appellent `api.get` avant `init()` complet). Validé en live console (0 erreur 401 cascade).
     **Différé** : strate 3 (Resolutions/Invoices/Notifications/AdminDashBoard tests qui passent shared helper mais échouent encore — issue #550 garde la trace). Plancher smoke à confirmer en CI post-merge feature/dev→dev.
 
+  **Session 2026-08-29 — le bloc de 11 échauffés est décomposé (PR #730).**
+
+  Deux constats invalident la formulation ci-dessus, mesurés sur trois runs CI
+  (`33062485058`, `33236027844`, `33239341373`) aux chiffres **identiques** —
+  donc déterministes, pas instables :
+
+  1. **L'occurrence de #696 (109 échecs, 2026-08-08) ne s'est pas reproduite.**
+     Le régime courant est `11 failed · 260 passed · 98 passed`. La question
+     explicitement ouverte de l'issue (« à confirmer si observé de façon
+     répétée ») est tranchée : non. La piste « dégradation du serveur Vite sous
+     charge » n'a pas lieu d'être poursuivie pour cet écart.
+
+  2. **Le plancher « smoke ≈219/240 » visait la mauvaise cible.** Le projet
+     `smoke` est à **zéro échec** — sa docstring le dit, il teste des contrats
+     d'API, sans navigation UI. Les 11 échecs sont tous dans `[scenarios]`.
+
+  **Et « 11 échecs » n'est pas 11 problèmes** : ce sont ~11 tests portant
+  chacun une *chaîne* de blocages successifs. Chaque correctif fait avancer le
+  test jusqu'au suivant ; le total ne baisse qu'une fois une chaîne entièrement
+  dégagée. Exemple mesuré sur `budget-workflow` : `nav-link-budgets` →
+  `budget-row` → `text=2026` (deux blocages levés, le budget est désormais
+  réellement créé, le `POST /budgets` part).
+
+  Cinq causes distinctes, nommées — trois corrigées, deux arbitrages produit :
+
+  | # | Cause | État |
+  |---|---|---|
+  | 1 | `RoleSubmenu.svelte` range les liens dans un `<details>` replié : enfants présents dans le DOM mais **invisibles**, `click` attend 30 s. `defaultOpen` n'est passé par aucun appelant. | **corrigé** — `expandCollapsedSection` |
+  | 2 | `slugify()` retire les diacritiques : le testid est `nav-link-assemblees`, le test l'attendait accentué. | **corrigé** |
+  | 3 | Le seeder crée « Résidence du Parc Royal » ; 7 scénarios cherchaient « Residence du Parc » sans accent, **en silence** (`for…of` sans correspondance, `if (building)` sauté). D'où : formulaire soumis, aucun `POST`, échec 15 s plus tard sur une liste vide, en accusant l'affichage. | **corrigé** — `helpers/name-match.ts`, échec bruyant |
+  | 4 | `nav-link-immeubles` (SuperAdmin) : `canSee` ne donne le menu `gestion` aux admins qu'en mode in-context, et `getAdminItems` n'a aucune entrée Immeubles. | **arbitrage produit** |
+  | 5 | `nav-link-assemblees` (Alice, owner) : `canSee` ne donne aux copropriétaires que le menu `communaute`. | **arbitrage produit** |
+
+  Les causes 4 et 5 **ne sont pas des bugs** : les scénarios contredisent des
+  règles de visibilité délibérées et commentées. Les corriger revient à décider
+  *ce que les scénarios racontent* — décision PO, pas correctif d'agent.
+
+  Le reste des échecs porte sur des **données de scénario**, pas sur l'UI :
+  sujet distinct, à traiter avec les seeds.
+
+  **Défaut annexe tracé** : le teardown CI supprime `residence-parc-royal-test`
+  alors que le seeder crée « Résidence du Parc Royal » — `ℹ️ No scenario world
+  found to clear` à chaque run. Le nettoyage ne nettoie rien, le monde survit
+  d'un run à l'autre.
+
 - **WP-D2 — Câbler vitest au gate** · #343 · T2 · S-M
   Job `vitest` existe (`ci.yml:402`) ; couvrir auth store (WP-FE1) + composants convocation/réunion @happy/@negative ; cible = composants critiques bêta (pas 181/181). Deps : WP-FE1, WP-FE2.
 

--- a/frontend/tests/e2e/helpers/name-match.ts
+++ b/frontend/tests/e2e/helpers/name-match.ts
@@ -1,0 +1,149 @@
+/**
+ * Correspondance de noms insensible aux accents, avec échec BRUYANT.
+ *
+ * ## Pourquoi ce module existe
+ *
+ * Le monde de scénario est semé par le backend sous le nom
+ * « Résidence du Parc Royal » (`seed.rs:3133`). Sept scénarios le cherchaient
+ * avec `"Residence du Parc"` — SANS accent. En JavaScript :
+ *
+ *     "Résidence du Parc Royal".includes("Residence du Parc")  // false
+ *
+ * La comparaison échouait donc systématiquement. Et elle échouait EN SILENCE,
+ * ce qui est le vrai défaut :
+ *
+ *     for (const option of options) {
+ *       if (text?.includes("Residence du Parc")) { ... break; }
+ *     }
+ *     // aucune correspondance -> la boucle se termine normalement,
+ *     // `selectOption` n'est jamais appelé, le formulaire reste vide
+ *
+ *     const building = buildings.find((b) => b.name?.includes("Residence…"));
+ *     if (building) { ...toute la préparation des données... }
+ *     // pas de building -> le bloc entier est sauté, sans un mot
+ *
+ * Conséquence observée en CI (trace du run 33250007102) : le formulaire de
+ * budget est rempli, `budget-submit-button` est cliqué, mais AUCUN
+ * `POST /budgets` ne part — la validation client bloque sur l'immeuble non
+ * sélectionné. Le test échoue 15 s plus tard sur `budget-row` absent, en
+ * accusant l'affichage. Le vrai message n'est jamais lu.
+ *
+ * Ces helpers corrigent les deux moitiés du problème : ils normalisent les
+ * accents, ET ils lèvent une erreur nommant les candidats disponibles quand
+ * rien ne correspond. Un test qui ne trouve pas sa donnée doit le dire —
+ * c'est la règle déjà posée par `building.ts` (« fail fast — no silent
+ * timeout »).
+ */
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * Normalise pour comparaison : minuscules, sans diacritiques, espaces réduits.
+ *
+ * Même transformation NFD que `slugify()` dans `RoleSubmenu.svelte` — les deux
+ * côtés du dépôt doivent traiter les accents de la même façon, sous peine de
+ * reproduire exactement le bug que ce module corrige.
+ */
+export function normalizeName(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** `true` si `haystack` contient `needle`, accents et casse ignorés. */
+export function nameContains(haystack: string, needle: string): boolean {
+  return normalizeName(haystack).includes(normalizeName(needle));
+}
+
+/**
+ * Trouve un élément par son nom, accents ignorés. Lève si absent.
+ *
+ * @param items  collection issue de l'API
+ * @param needle fragment de nom recherché
+ * @param label  contexte affiché dans l'erreur (nom du scénario, de l'étape…)
+ */
+export function findByName<T extends { name?: string | null }>(
+  items: unknown,
+  needle: string,
+  label: string,
+): T {
+  if (!Array.isArray(items)) {
+    throw new Error(
+      `${label}: réponse inattendue de l'API — tableau attendu, reçu ${typeof items}`,
+    );
+  }
+  const found = (items as T[]).find((it) =>
+    it?.name ? nameContains(it.name, needle) : false,
+  );
+  if (!found) {
+    const available = (items as T[])
+      .map((it) => it?.name ?? "(sans nom)")
+      .join(", ");
+    throw new Error(
+      `${label}: aucun élément nommé « ${needle} ». ` +
+        `Disponibles : ${available || "(collection vide)"}. ` +
+        `Le monde de scénario est-il semé ?`,
+    );
+  }
+  return found;
+}
+
+/**
+ * Sélectionne dans un `<select>` l'option dont le libellé contient `needle`,
+ * accents ignorés. Lève si aucune option ne correspond.
+ *
+ * Remplace la boucle `for…of` + `break` qui, sans correspondance, laissait le
+ * `<select>` vide sans rien signaler.
+ */
+export async function selectOptionByName(
+  select: Locator,
+  needle: string,
+  label: string,
+): Promise<string> {
+  const options = await select.locator("option").all();
+  const seen: string[] = [];
+
+  for (const option of options) {
+    const text = (await option.textContent()) ?? "";
+    seen.push(text.trim());
+    if (text && nameContains(text, needle)) {
+      const value = await option.getAttribute("value");
+      if (value) {
+        await select.selectOption(value);
+        return value;
+      }
+    }
+  }
+
+  throw new Error(
+    `${label}: aucune option contenant « ${needle} » dans le <select>. ` +
+      `Options présentes : ${seen.filter(Boolean).join(", ") || "(aucune)"}. ` +
+      `Sans sélection, la validation client bloque la soumission et le test ` +
+      `échouera plus loin sur une liste vide, en accusant l'affichage.`,
+  );
+}
+
+/**
+ * Variante tolérante : sélectionne si le `<select>` est présent ET qu'une
+ * option correspond, sans lever si le `<select>` lui-même est absent.
+ *
+ * Réservée aux endroits où le sélecteur d'immeuble est légitimement optionnel
+ * (rôle sans scope building). L'absence d'OPTION correspondante reste, elle,
+ * une erreur — c'est la distinction que le code d'origine ne faisait pas.
+ */
+export async function selectOptionByNameIfPresent(
+  page: Page,
+  select: Locator,
+  needle: string,
+  label: string,
+  timeoutMs = 5000,
+): Promise<string | null> {
+  if (!(await select.isVisible({ timeout: timeoutMs }).catch(() => false))) {
+    return null;
+  }
+  await select.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(200);
+  return selectOptionByName(select, needle, label);
+}

--- a/frontend/tests/e2e/helpers/video-pace.ts
+++ b/frontend/tests/e2e/helpers/video-pace.ts
@@ -63,10 +63,51 @@ export async function humanFill(
 }
 
 /**
+ * Déplie la section de navigation qui contient `locator`, si elle est repliée.
+ *
+ * `RoleSubmenu.svelte` range les liens de navigation dans un `<details>` dont
+ * l'ouverture est dérivée : `isOpen = defaultOpen || containsActive`. Aucun
+ * appelant ne passe `defaultOpen`, donc une section n'est ouverte QUE si elle
+ * contient la page courante. Depuis le tableau de bord, « Budgets » est fermé.
+ *
+ * Or un `<details>` fermé laisse ses enfants dans le DOM mais les rend
+ * INVISIBLES. Playwright résout donc le lien, puis attend indéfiniment qu'il
+ * devienne visible :
+ *
+ *     locator resolved to <a href="/budgets" data-testid="nav-link-budgets">
+ *     attempting click action
+ *       - element is not visible          (x60, jusqu'au timeout de 30 s)
+ *
+ * C'est la cause UNIQUE des 11 échecs `[scenarios]` en CI — pas onze bugs
+ * distincts (#696, WP-D1). Le projet `smoke` n'était pas touché parce qu'il
+ * teste des contrats d'API, sans navigation dans l'interface.
+ *
+ * On déplie en cliquant le `<summary>`, comme le ferait un utilisateur, plutôt
+ * qu'en forçant l'attribut `open` : ces scénarios sont enregistrés en vidéo
+ * comme documentation vivante, et le geste de dépliage fait partie du parcours
+ * réel. Forcer l'attribut produirait une vidéo qui ne montre pas ce que
+ * l'utilisateur doit faire.
+ */
+async function expandCollapsedSection(
+  page: Page,
+  locator: Locator,
+): Promise<void> {
+  const collapsed = locator.locator("xpath=ancestor::details[not(@open)][1]");
+  if ((await collapsed.count()) === 0) return;
+
+  const summary = collapsed.locator("summary").first();
+  await summary.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(PACE.BEFORE_CLICK);
+  await summary.click();
+  await page.waitForTimeout(PACE.AFTER_CLICK);
+}
+
+/**
  * Click an element identified by data-testid at human pace.
  */
 export async function humanClick(page: Page, testId: string): Promise<void> {
   const locator = page.getByTestId(testId);
+  await expandCollapsedSection(page, locator);
   await locator.scrollIntoViewIfNeeded();
   await page.waitForTimeout(PACE.BEFORE_CLICK);
   await locator.click();
@@ -80,6 +121,7 @@ export async function humanClickLocator(
   page: Page,
   locator: Locator,
 ): Promise<void> {
+  await expandCollapsedSection(page, locator);
   await locator.scrollIntoViewIfNeeded();
   await page.waitForTimeout(PACE.BEFORE_CLICK);
   await locator.click();

--- a/frontend/tests/e2e/name-match.spec.ts
+++ b/frontend/tests/e2e/name-match.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import { normalizeName, nameContains } from "./helpers/name-match";
+
+/**
+ * Non-régression du 3e défaut derrière les échecs `[scenarios]` (#696, WP-D1).
+ *
+ * Sept scénarios cherchaient l'immeuble du monde de scénario avec
+ * `"Residence du Parc"` — sans accent — alors que le backend le sème sous
+ * `"Résidence du Parc Royal"` (`seed.rs:3133`). La comparaison échouait donc
+ * toujours, et EN SILENCE.
+ *
+ * Ces tests sont des fonctions pures : aucun navigateur, aucun serveur.
+ */
+test.describe("Correspondance de noms insensible aux accents (#696)", () => {
+  test("@negative le code d'origine échouait — c'est la cause du défaut", () => {
+    // Reproduit littéralement ce que faisaient les scénarios.
+    expect("Résidence du Parc Royal".includes("Residence du Parc")).toBe(false);
+  });
+
+  test("@happy la comparaison normalisée trouve l'immeuble semé", () => {
+    expect(nameContains("Résidence du Parc Royal", "Residence du Parc")).toBe(
+      true,
+    );
+  });
+
+  test("@edge la normalisation est symétrique et tolère casse et espaces", () => {
+    expect(nameContains("Residence du Parc Royal", "Résidence du Parc")).toBe(
+      true,
+    );
+    expect(nameContains("RÉSIDENCE DU PARC ROYAL", "résidence du parc")).toBe(
+      true,
+    );
+    expect(
+      nameContains("Résidence  du   Parc Royal", "Residence du Parc"),
+    ).toBe(true);
+    expect(normalizeName("  Résidence   du Parc  ")).toBe("residence du parc");
+  });
+
+  test("@security la normalisation ne sur-matche pas un autre immeuble", () => {
+    // Le monde de scénario contient trois immeubles : une comparaison trop
+    // permissive sélectionnerait le mauvais et le test passerait pour de
+    // mauvaises raisons.
+    expect(nameContains("Le Clos des Hirondelles", "Residence du Parc")).toBe(
+      false,
+    );
+    expect(nameContains("Les Terrasses de Flagey", "Residence du Parc")).toBe(
+      false,
+    );
+  });
+});

--- a/frontend/tests/e2e/nav-submenu-collapsed.spec.ts
+++ b/frontend/tests/e2e/nav-submenu-collapsed.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+import { humanClick } from "./helpers/video-pace";
+
+/**
+ * Non-régression de la cause unique des 11 échecs `[scenarios]` en CI
+ * (#696, WP-D1).
+ *
+ * `RoleSubmenu.svelte` range les liens de navigation dans un `<details>` dont
+ * l'ouverture est dérivée : `isOpen = defaultOpen || containsActive`. Aucun
+ * appelant ne passe `defaultOpen` — une section n'est donc ouverte QUE si elle
+ * contient la page courante. Depuis le tableau de bord, « Budgets » est replié.
+ *
+ * Un `<details>` fermé laisse ses enfants dans le DOM mais les rend
+ * INVISIBLES. Playwright résolvait donc le lien puis attendait sa visibilité
+ * jusqu'au timeout de 30 s, sur les 11 scénarios, aux deux reprises, de façon
+ * parfaitement déterministe :
+ *
+ *     locator resolved to <a href="/budgets" data-testid="nav-link-budgets">
+ *     attempting click action
+ *       - element is not visible          (x60, jusqu'au timeout)
+ *
+ * Ces tests n'ont besoin d'aucun serveur : ils reproduisent la structure DOM
+ * en isolation via `page.setContent`, ce qui les rend rapides et insensibles
+ * à l'état des seeds.
+ */
+
+// Structure minimale reproduisant RoleSubmenu.svelte.
+const MENU = `<!doctype html><html><body>
+  <details data-testid="navigation-menu-finance">
+    <summary>Finance</summary>
+    <ul role="list">
+      <li>
+        <a href="#budgets"
+           data-testid="nav-link-budgets"
+           onclick="document.title='NAVIGUE'">Budgets</a>
+      </li>
+    </ul>
+  </details>
+</body></html>`;
+
+test.describe("Navigation — sections repliées (#696 / WP-D1)", () => {
+  test("@negative un lien dans un <details> fermé est présent mais invisible", async ({
+    page,
+  }) => {
+    await page.setContent(MENU);
+    const link = page.getByTestId("nav-link-budgets");
+
+    // Les deux assertions ensemble SONT la cause racine : Playwright trouve
+    // l'élément (donc pas d'erreur de sélecteur), mais ne peut pas le cliquer.
+    await expect(link).toHaveCount(1);
+    await expect(link).not.toBeVisible();
+  });
+
+  test("@happy humanClick déplie la section puis clique le lien", async ({
+    page,
+  }) => {
+    await page.setContent(MENU);
+    await humanClick(page, "nav-link-budgets");
+    await expect(page).toHaveTitle("NAVIGUE");
+  });
+
+  test("@edge humanClick reste correct sur une section déjà ouverte", async ({
+    page,
+  }) => {
+    await page.setContent(MENU.replace("<details", "<details open"));
+    await humanClick(page, "nav-link-budgets");
+    await expect(page).toHaveTitle("NAVIGUE");
+  });
+
+  test("@security le dépliage ne masque pas un lien réellement absent", async ({
+    page,
+  }) => {
+    // Garde-fou : le correctif ne doit pas transformer un sélecteur erroné en
+    // succès silencieux. Un testid inexistant doit toujours échouer.
+    await page.setContent(MENU);
+    await expect(humanClick(page, "nav-link-inexistant")).rejects.toThrow();
+  });
+});

--- a/frontend/tests/e2e/scenarios/budget-workflow.scenario.ts
+++ b/frontend/tests/e2e/scenarios/budget-workflow.scenario.ts
@@ -15,6 +15,7 @@
  * Duree video attendue : ~50-70 secondes (rythme humain)
  */
 import { test, expect } from "@playwright/test";
+import { selectOptionByName } from "../helpers/name-match";
 import {
   humanLogin,
   humanClick,
@@ -103,17 +104,11 @@ test.describe("Scenario: Francois cree et soumet un budget annuel", () => {
     await buildingSelect.scrollIntoViewIfNeeded();
     await page.waitForTimeout(PACE.BEFORE_SELECT);
 
-    const options = await buildingSelect.locator("option").all();
-    for (const option of options) {
-      const text = await option.textContent();
-      if (text && text.includes("Residence du Parc")) {
-        const value = await option.getAttribute("value");
-        if (value) {
-          await buildingSelect.selectOption(value);
-          break;
-        }
-      }
-    }
+    await selectOptionByName(
+      buildingSelect,
+      "Résidence du Parc",
+      "budget-workflow.scenario.ts",
+    );
     await page.waitForTimeout(PACE.AFTER_SELECT);
 
     await stepPause(page);

--- a/frontend/tests/e2e/scenarios/convocation-send.scenario.ts
+++ b/frontend/tests/e2e/scenarios/convocation-send.scenario.ts
@@ -13,6 +13,7 @@
  * Duree video attendue : ~45-60 secondes (rythme humain)
  */
 import { test, expect } from "@playwright/test";
+import { nameContains, selectOptionByName } from "../helpers/name-match";
 import {
   humanLogin,
   humanClick,
@@ -62,7 +63,9 @@ test.describe("Scenario: Francois consulte une convocation d'AG", () => {
     });
     const buildings = await buildingsResp.json();
     const building = Array.isArray(buildings)
-      ? buildings.find((b: any) => b.name?.includes("Residence du Parc"))
+      ? buildings.find(
+          (b: any) => b.name && nameContains(b.name, "Résidence du Parc"),
+        )
       : null;
 
     if (building) {
@@ -134,17 +137,11 @@ test.describe("Scenario: Francois consulte une convocation d'AG", () => {
     if (await buildingSelect.isVisible({ timeout: 5000 })) {
       await buildingSelect.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect,
+        "Résidence du Parc",
+        "convocation-send.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);

--- a/frontend/tests/e2e/scenarios/expense-approval.scenario.ts
+++ b/frontend/tests/e2e/scenarios/expense-approval.scenario.ts
@@ -13,6 +13,7 @@
  * Duree video attendue : ~45-60 secondes (rythme humain)
  */
 import { test, expect } from "@playwright/test";
+import { nameContains } from "../helpers/name-match";
 import {
   humanLogin,
   humanClick,
@@ -62,7 +63,9 @@ test.describe("Scenario: Workflow d'approbation d'une facture", () => {
     });
     const buildings = await buildingsResp.json();
     const building = Array.isArray(buildings)
-      ? buildings.find((b: any) => b.name?.includes("Residence du Parc"))
+      ? buildings.find(
+          (b: any) => b.name && nameContains(b.name, "Résidence du Parc"),
+        )
       : null;
 
     if (building) {

--- a/frontend/tests/e2e/scenarios/meeting-vote.scenario.ts
+++ b/frontend/tests/e2e/scenarios/meeting-vote.scenario.ts
@@ -68,7 +68,7 @@ test.describe("Scenario: Vote multi-role sur une resolution en AG", () => {
     await stepPause(page);
 
     // Navigation vers les Assemblees
-    await humanClick(page, "nav-link-assemblées");
+    await humanClick(page, "nav-link-assemblees");
     await waitForSpinner(page);
     await page.waitForTimeout(PACE.AFTER_NAVIGATION);
 
@@ -111,7 +111,7 @@ test.describe("Scenario: Vote multi-role sur une resolution en AG", () => {
     await stepPause(page);
 
     // Alice navigue vers les assemblees
-    await humanClick(page, "nav-link-assemblées");
+    await humanClick(page, "nav-link-assemblees");
     await waitForSpinner(page);
     await page.waitForTimeout(PACE.AFTER_NAVIGATION);
 
@@ -184,7 +184,7 @@ test.describe("Scenario: Vote multi-role sur une resolution en AG", () => {
     await stepPause(page);
 
     // Re-naviguer vers l'AG
-    await humanClick(page, "nav-link-assemblées");
+    await humanClick(page, "nav-link-assemblees");
     await waitForSpinner(page);
     await page.waitForTimeout(PACE.AFTER_NAVIGATION);
 

--- a/frontend/tests/e2e/scenarios/notice-board.scenario.ts
+++ b/frontend/tests/e2e/scenarios/notice-board.scenario.ts
@@ -9,6 +9,7 @@
  * Duree video attendue : ~70-90 secondes (rythme humain, multi-role)
  */
 import { test, expect } from "@playwright/test";
+import { nameContains, selectOptionByName } from "../helpers/name-match";
 import {
   humanLogin,
   humanFill,
@@ -59,7 +60,9 @@ test.describe("Scenario: Tableau d'affichage communautaire (multi-role)", () => 
     });
     const buildings = await buildingsResp.json();
     const building = Array.isArray(buildings)
-      ? buildings.find((b: any) => b.name?.includes("Residence du Parc"))
+      ? buildings.find(
+          (b: any) => b.name && nameContains(b.name, "Résidence du Parc"),
+        )
       : null;
 
     if (building) {
@@ -144,17 +147,11 @@ test.describe("Scenario: Tableau d'affichage communautaire (multi-role)", () => 
     if (await buildingSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect,
+        "Résidence du Parc",
+        "notice-board.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);
@@ -226,17 +223,11 @@ test.describe("Scenario: Tableau d'affichage communautaire (multi-role)", () => 
     if (await buildingSelect2.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect2.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect2.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect2.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect2,
+        "Résidence du Parc",
+        "notice-board.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);

--- a/frontend/tests/e2e/scenarios/poll-vote.scenario.ts
+++ b/frontend/tests/e2e/scenarios/poll-vote.scenario.ts
@@ -11,6 +11,7 @@
  * Duree video attendue : ~90-120 secondes (rythme humain, multi-role)
  */
 import { test, expect } from "@playwright/test";
+import { nameContains, selectOptionByName } from "../helpers/name-match";
 import {
   humanLogin,
   humanClick,
@@ -61,7 +62,9 @@ test.describe("Scenario: Sondage multi-role (Francois lance, Alice vote)", () =>
     });
     const buildings = await buildingsResp.json();
     const building = Array.isArray(buildings)
-      ? buildings.find((b: any) => b.name?.includes("Residence du Parc"))
+      ? buildings.find(
+          (b: any) => b.name && nameContains(b.name, "Résidence du Parc"),
+        )
       : null;
 
     if (building) {
@@ -138,17 +141,11 @@ test.describe("Scenario: Sondage multi-role (Francois lance, Alice vote)", () =>
     if (await buildingSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect,
+        "Résidence du Parc",
+        "poll-vote.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);
@@ -192,17 +189,11 @@ test.describe("Scenario: Sondage multi-role (Francois lance, Alice vote)", () =>
     if (await buildingSelect2.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect2.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect2.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect2.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect2,
+        "Résidence du Parc",
+        "poll-vote.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);
@@ -264,17 +255,11 @@ test.describe("Scenario: Sondage multi-role (Francois lance, Alice vote)", () =>
     if (await buildingSelect3.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect3.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect3.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect3.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect3,
+        "Résidence du Parc",
+        "poll-vote.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);

--- a/frontend/tests/e2e/scenarios/quote-comparison.scenario.ts
+++ b/frontend/tests/e2e/scenarios/quote-comparison.scenario.ts
@@ -14,6 +14,7 @@
  * Duree video attendue : ~50-70 secondes (rythme humain)
  */
 import { test, expect } from "@playwright/test";
+import { nameContains, selectOptionByName } from "../helpers/name-match";
 import {
   humanLogin,
   humanClick,
@@ -63,7 +64,9 @@ test.describe("Scenario: Comparaison de devis entrepreneurs (Francois)", () => {
     });
     const buildings = await buildingsResp.json();
     const building = Array.isArray(buildings)
-      ? buildings.find((b: any) => b.name?.includes("Residence du Parc"))
+      ? buildings.find(
+          (b: any) => b.name && nameContains(b.name, "Résidence du Parc"),
+        )
       : null;
 
     if (building) {
@@ -203,17 +206,11 @@ test.describe("Scenario: Comparaison de devis entrepreneurs (Francois)", () => {
     if (await buildingSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect,
+        "Résidence du Parc",
+        "quote-comparison.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);

--- a/frontend/tests/e2e/scenarios/sel-exchange.scenario.ts
+++ b/frontend/tests/e2e/scenarios/sel-exchange.scenario.ts
@@ -11,6 +11,7 @@
  * Duree video attendue : ~70-90 secondes (rythme humain, multi-role)
  */
 import { test, expect } from "@playwright/test";
+import { nameContains, selectOptionByName } from "../helpers/name-match";
 import {
   humanLogin,
   humanFill,
@@ -66,7 +67,9 @@ test.describe("Scenario: SEL multi-role (Alice offre, Bob parcourt)", () => {
     });
     const buildings = await buildingsResp.json();
     const building = Array.isArray(buildings)
-      ? buildings.find((b: any) => b.name?.includes("Residence du Parc"))
+      ? buildings.find(
+          (b: any) => b.name && nameContains(b.name, "Résidence du Parc"),
+        )
       : null;
 
     if (building) {
@@ -153,17 +156,11 @@ test.describe("Scenario: SEL multi-role (Alice offre, Bob parcourt)", () => {
     if (await buildingSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect,
+        "Résidence du Parc",
+        "sel-exchange.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);
@@ -210,17 +207,11 @@ test.describe("Scenario: SEL multi-role (Alice offre, Bob parcourt)", () => {
     if (await buildingSelect2.isVisible({ timeout: 2000 }).catch(() => false)) {
       await buildingSelect2.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect2.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect2.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect2,
+        "Résidence du Parc",
+        "sel-exchange.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);

--- a/frontend/tests/e2e/scenarios/ticket-lifecycle.scenario.ts
+++ b/frontend/tests/e2e/scenarios/ticket-lifecycle.scenario.ts
@@ -10,6 +10,7 @@
  * Duree video attendue : ~70-90 secondes (rythme humain, multi-role)
  */
 import { test, expect } from "@playwright/test";
+import { selectOptionByName } from "../helpers/name-match";
 import {
   humanLogin,
   humanFill,
@@ -157,17 +158,11 @@ test.describe("Scenario: Cycle de vie d'un ticket de maintenance", () => {
     if (await buildingSelect.isVisible({ timeout: 5000 })) {
       await buildingSelect.scrollIntoViewIfNeeded();
       await page.waitForTimeout(PACE.BEFORE_SELECT);
-      const options = await buildingSelect.locator("option").all();
-      for (const option of options) {
-        const text = await option.textContent();
-        if (text && text.includes("Residence du Parc")) {
-          const value = await option.getAttribute("value");
-          if (value) {
-            await buildingSelect.selectOption(value);
-            break;
-          }
-        }
-      }
+      await selectOptionByName(
+        buildingSelect,
+        "Résidence du Parc",
+        "ticket-lifecycle.scenario.ts",
+      );
       await page.waitForTimeout(PACE.AFTER_SELECT);
     }
     await waitForSpinner(page);

--- a/scripts/check-openapi-coverage.sh
+++ b/scripts/check-openapi-coverage.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Gate — couverture OpenAPI des routes Actix (issue #732).
+#
+# ── Le défaut que ce gate ferme ────────────────────────────────────────────
+#
+# Le job CI « Contract Types Check (end-to-end anti-drift) » vérifie deux
+# choses : que `docs/api/openapi.json` correspond à la source Rust, puis que
+# `frontend/src/types/api.d.ts` correspond à ce fichier. Les deux comparaisons
+# sont bonnes, mais elles partagent un angle mort :
+#
+#     un endpoint ABSENT de la spec est absent des DEUX côtés,
+#     donc parfaitement cohérent, donc invisible au gate.
+#
+# C'est ainsi que les 16 endpoints `payment-methods` ont vécu hors contrat : les
+# routes existent, la struct porte bien `#[derive(utoipa::ToSchema)]`, mais
+# aucune n'a d'annotation `#[utoipa::path]` et la struct n'est pas enregistrée
+# dans `infrastructure/openapi.rs`. Sans type généré, le frontend a écrit son
+# DTO à la main — en oubliant deux champs requis. Résultat : `400` à chaque
+# ajout de moyen de paiement, avec une CI verte de bout en bout.
+#
+# « Aucun drift » ne veut pas dire « aucun désaccord ». Ce gate mesure la
+# seconde chose : l'exhaustivité de la déclaration.
+#
+# ── Pourquoi un cliquet et non un seuil ───────────────────────────────────
+#
+# Au 2026-08-29 : 604 routes, 46 annotées, 558 non annotées. Exiger 100 %
+# casserait toutes les PR sur un héritage que personne n'a choisi. Le gate
+# applique donc la règle déjà retenue pour le projet Playwright `smoke`
+# (b1b6648e) : « plancher chiffré puis bascule ». Il échoue UNIQUEMENT si la
+# dette augmente.
+#
+# Faire baisser BASELINE au fil des annotations ajoutées est le sens de marche
+# attendu ; le gate y invite explicitement quand l'écart se creuse.
+#
+# Usage : backend/scripts/check-openapi-coverage.sh [chemin/handlers]
+
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/backend/src/infrastructure/web/handlers}"
+
+# Garde-fou : une substitution de processus ne propage PAS son code de sortie.
+# Sans ce contrôle, un chemin erroné ferait échouer `awk` en silence, le gate
+# compterait 0 route et passerait au vert — exactement le genre de succès
+# trompeur qu'il est censé empêcher.
+if [[ ! -d "$ROOT" ]]; then
+  echo "check-openapi-coverage: répertoire introuvable : $ROOT" >&2
+  exit 2
+fi
+
+# Nombre de routes SANS `#[utoipa::path]` toléré. Ne doit que décroître.
+BASELINE=558
+
+read -r total annotated < <(
+  awk '
+    # Mémorise la distance depuis le dernier #[utoipa::path] rencontré.
+    /#\[utoipa::path/ { seen = NR }
+    /^[[:space:]]*#\[(get|post|put|patch|delete)\("/ {
+      total++
+      # L annotation doit précéder la macro de route de peu (attributs
+      # intercalés : #[tracing::instrument], commentaires doc, etc.).
+      if (seen && NR - seen <= 12) annotated++
+    }
+    FNR == 1 { seen = 0 }
+    END { print total+0, annotated+0 }
+  ' "$ROOT"/*.rs
+)
+
+if [[ "${total:-0}" -eq 0 ]]; then
+  echo "check-openapi-coverage: aucune route trouvée sous $ROOT — analyse invalide" >&2
+  exit 2
+fi
+
+undocumented=$(( total - annotated ))
+pct=$(( total > 0 ? annotated * 100 / total : 0 ))
+
+echo "Couverture OpenAPI des routes Actix"
+echo "  routes totales        : ${total}"
+echo "  avec #[utoipa::path]  : ${annotated} (${pct} %)"
+echo "  sans annotation       : ${undocumented}  (cliquet : ${BASELINE})"
+
+if [[ "$undocumented" -gt "$BASELINE" ]]; then
+  cat >&2 <<MSG
+
+──────────────────────────────────────────────────────────────────
+La dette de couverture OpenAPI AUGMENTE : ${undocumented} > ${BASELINE}.
+
+$(( undocumented - BASELINE )) route(s) ont été ajoutées sans
+\`#[utoipa::path]\`. Elles n'entreront ni dans \`docs/api/openapi.json\`
+ni dans \`frontend/src/types/api.d.ts\` — et le gate anti-drift ne
+les verra pas, puisqu'il compare deux fichiers qui les ignorent
+tous les deux.
+
+Le frontend devra donc écrire son DTO à la main, sans filet.
+C'est exactement ainsi que POST /payment-methods a fini par
+renvoyer 400 en silence (issue #732).
+
+À faire :
+  1. annoter la nouvelle route avec \`#[utoipa::path(...)]\` ;
+  2. enregistrer ses schémas dans \`infrastructure/openapi.rs\`
+     (le \`#[derive(ToSchema)]\` seul ne suffit PAS) ;
+  3. \`make openapi-export\` puis committer la spec.
+──────────────────────────────────────────────────────────────────
+MSG
+  exit 1
+fi
+
+if [[ "$undocumented" -lt "$BASELINE" ]]; then
+  echo
+  echo "✅ La dette a baissé de $(( BASELINE - undocumented )) route(s)."
+  echo "   Abaissez BASELINE à ${undocumented} dans $(basename "${BASH_SOURCE[0]}")"
+  echo "   pour verrouiller le gain — sans quoi il peut être reperdu sans bruit."
+  exit 0
+fi
+
+echo
+echo "✅ Aucune nouvelle route hors contrat."


### PR DESCRIPTION
Ferme à la racine le défaut structurel documenté dans #732.

## L'angle mort

Le job **Contract Types Check (end-to-end anti-drift)** vérifie que `openapi.json` correspond à la source Rust, puis que `api.d.ts` correspond à la spec. Les deux comparaisons sont justes, mais partagent un point aveugle :

> un endpoint **absent** de la spec est absent des **deux** côtés — donc cohérent, donc invisible.

C'est ainsi que les 16 endpoints `payment-methods` ont vécu hors contrat : routes existantes, `#[derive(ToSchema)]` bien présent, mais aucune annotation `#[utoipa::path]` et aucun enregistrement dans `infrastructure/openapi.rs`. Sans type généré, le frontend a écrit son DTO à la main, en oubliant **deux champs requis** — `400` à chaque ajout de moyen de paiement, avec une CI verte de bout en bout.

**« Aucun drift » ne veut pas dire « aucun désaccord ».** Ce gate mesure la seconde chose : l'exhaustivité de la déclaration.

## État mesuré

```
604 routes Actix
 46 avec #[utoipa::path]   (7 %)
558 sans
```

## Cliquet, pas seuil

Exiger 100 % casserait toutes les PR sur un héritage de 558 routes que personne n'a choisi. J'applique la règle déjà retenue pour le projet Playwright `smoke` dans `b1b6648e` — *« plancher chiffré puis bascule »*. Le gate échoue **uniquement si la dette augmente**, et signale quand elle baisse pour inviter à verrouiller le gain.

## Vérifié

| Contrôle | Résultat |
|---|---|
| Comptage recoupé par une implémentation Python indépendante | 604 / 46 / 558, identique |
| Chemin d'échec joué pour de vrai (route ajoutée sans annotation) | `exit 1`, source restaurée intacte |
| Chemin nominal | `exit 0` |
| Répertoire introuvable | `exit 2` |

**Un défaut trouvé sur mon propre script, et corrigé** : une substitution de processus ne propage pas son code de sortie. Un chemin erroné faisait donc échouer `awk` **en silence**, le gate comptait 0 route et passait au vert — exactement le succès trompeur qu'il est censé empêcher. Deux garde-fous ajoutés (répertoire absent, comptage nul), sortie 2 dans les deux cas.

## Placement

Dans `scripts/`, auprès de `check-no-f64-money.sh`, et câblé dans le job `lint` : aucune compilation requise, échec en quelques secondes.

Refs #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)